### PR TITLE
Minor fix in getting compute job results

### DIFF
--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -269,7 +269,7 @@ class OceanCompute:
         )
         return {
             'did': info_dict.get('resultsDid', ''),
-            'urls': info_dict.get('resultsUrls', []),
+            'urls': info_dict.get('resultsUrl', []),
             'logs': info_dict.get('algorithmLogUrl', [])
         }
 


### PR DESCRIPTION
Ocean operator returns `resultsUrl` instead of `resultsUrls`

https://github.com/oceanprotocol/operator-service/blob/061e6b07f928f1ed6d1401e3cfef8a089c9f4dad/operator_service/data_store.py#L53