### PR TITLE
Update setup.md to fix typo 

### DIFF
--- a/READMEs/setup.md
+++ b/READMEs/setup.md
@@ -93,7 +93,7 @@ from ocean_lib.ocean.util import get_web3_connection_provider
 from ocean_lib.web3_internal.web3_provider import Web3Provider
 from ocean_lib.web3_internal.contract_handler import ContractHandler
 
-config = Config(os.getenv(ENV_CONFIG_FILE))
+config = Config(os.getenv('CONFIG_FILE'))
 ConfigProvider.set_config(config)
 Web3Provider.init_web3(provider=get_web3_connection_provider(config.network_url))
 ContractHandler.set_artifacts_path(config.artifacts_path)


### PR DESCRIPTION
In line 76 the env var `CONFIG_FILE` is set to the path of config.ini  , however in line 96 the wrong name and python syntax is used