### PR TITLE
fix starting compute using algorithm did.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.3
+current_version = 0.5.4
 commit = True
 tag = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ copyright = 'ocean.py contributors'
 author = 'ocean.py contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '0.5.3'
+release = '0.5.4'
 # The short X.Y version
 release_parts = release.split('.')  # a list
 version = release_parts[0] + '.' + release_parts[1]

--- a/ocean_lib/__init__.py
+++ b/ocean_lib/__init__.py
@@ -1,5 +1,5 @@
 __author__ = """OceanProtocol"""
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 
 #  Copyright 2018 Ocean Protocol Foundation
 #  SPDX-License-Identifier: Apache-2.0

--- a/ocean_lib/data_provider/data_service_provider.py
+++ b/ocean_lib/data_provider/data_service_provider.py
@@ -170,9 +170,10 @@ class DataServiceProvider:
             DataServiceProvider.write_file(response, destination_folder, file_name or f'file-{i}')
 
     @staticmethod
-    def start_compute_job(did, service_endpoint, consumer_address, signature,
-                          service_id, token_address, order_tx_id, algorithm_did=None,
-                          algorithm_meta=None, output=None, job_id=None):
+    def start_compute_job(did: str, service_endpoint: str, consumer_address: str, signature: str,
+                          service_id: int, token_address: str, order_tx_id: str, algorithm_did: str=None,
+                          algorithm_meta: AlgorithmMetadata=None, algorithm_tx_id: str='',
+                          algorithm_data_token: str='', output: dict=None, job_id: str=None):
         """
 
         :param did: id of asset starting with `did:op:` and a hex str without 0x prefix
@@ -185,6 +186,8 @@ class DataServiceProvider:
         :param algorithm_did: str -- the asset did (of `algorithm` type) which consist of `did:op:` and
             the assetId hex str (without `0x` prefix)
         :param algorithm_meta: see `OceanCompute.execute`
+        :param algorithm_tx_id: transaction hash of algorithm StartOrder tx (Required when using `algorithm_did`)
+        :param algorithm_data_token: datatoken address of this algorithm (Required when using `algorithm_did`)
         :param output: see `OceanCompute.execute`
         :param job_id: str id of compute job that was started and stopped (optional, use it
             here to start a job after it was stopped)
@@ -203,6 +206,8 @@ class DataServiceProvider:
             signature=signature,
             algorithm_did=algorithm_did,
             algorithm_meta=algorithm_meta,
+            algorithm_tx_id=algorithm_tx_id,
+            algorithm_data_token=algorithm_data_token,
             output=output,
             job_id=job_id
         )
@@ -468,9 +473,10 @@ class DataServiceProvider:
 
     @staticmethod
     def _prepare_compute_payload(
-            did, consumer_address, service_id, service_type, token_address, order_tx_id,
-            signature=None, algorithm_did=None, algorithm_meta=None,
-            output=None, job_id=None):
+            did: str, consumer_address: str, service_id: int, service_type: str,
+            token_address: str, order_tx_id: str, signature: str=None,
+            algorithm_did: str=None, algorithm_meta=None, algorithm_tx_id: str='',
+            algorithm_data_token: str='', output: dict=None, job_id: str=None):
         assert algorithm_did or algorithm_meta, 'either an algorithm did or an algorithm meta must be provided.'
 
         if algorithm_meta:
@@ -482,8 +488,10 @@ class DataServiceProvider:
             'signature': signature,
             'documentId': did,
             'consumerAddress': consumer_address,
-            'algorithmDID': algorithm_did,
+            'algorithmDid': algorithm_did,
             'algorithmMeta': algorithm_meta,
+            'algorithmDataToken': algorithm_data_token,
+            'algorithmTransferTxId': algorithm_tx_id,
             'output': output or dict(),
             'jobId': job_id or "",
             'serviceId': service_id,

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -7,7 +7,6 @@ from ocean_utils.agreements.service_agreement import ServiceAgreement
 from ocean_lib.assets.asset_resolver import resolve_asset
 from ocean_lib.config_provider import ConfigProvider
 from ocean_lib.models.algorithm_metadata import AlgorithmMetadata
-from ocean_lib.ocean.util import to_base_18
 from ocean_lib.web3_internal.utils import add_ethereum_prefix_and_hash_msg
 from ocean_lib.web3_internal.wallet import Wallet
 from ocean_lib.web3_internal.web3helper import Web3Helper
@@ -189,6 +188,7 @@ class OceanCompute:
     def start(self, did: str, consumer_wallet: Wallet, order_tx_id: str,
               nonce: [int, None]=None, algorithm_did: [str, None]=None,
               algorithm_meta: [AlgorithmMetadata, None]=None,
+              algorithm_tx_id: str='', algorithm_data_token: str='',
               output: dict=None, job_id: str=None):
         """Start a remote compute job on the asset files identified by `did` after
         verifying that the provider service is active and transferring the
@@ -202,6 +202,8 @@ class OceanCompute:
             the assetId hex str (without `0x` prefix)
         :param algorithm_meta: `AlgorithmMetadata` instance -- metadata about the algorithm being run if
             `algorithm` is being used. This is ignored when `algorithm_did` is specified.
+        :param algorithm_tx_id: transaction hash of algorithm StartOrder tx (Required when using `algorithm_did`)
+        :param algorithm_data_token: datatoken address of this algorithm (Required when using `algorithm_did`)
         :param output: dict object to be used in publishing mechanism, must define
         :param job_id: str identifier of a compute job that was previously started and
             stopped (if supported by the provider's  backend)
@@ -227,6 +229,8 @@ class OceanCompute:
             order_tx_id,
             algorithm_did,
             algorithm_meta,
+            algorithm_tx_id,
+            algorithm_data_token,
             output,
             job_id
         )

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/oceanprotocol/ocean.py',
-    version='0.5.3',
+    version='0.5.4',
     zip_safe=False,
 )


### PR DESCRIPTION
The provider requires the algorithm transferTxId and the algorithm datatoken address when using a published algorithm. Those attributes were missing from the call to start compute in ocean.compute.