### PR TITLE
Fix issue 'No address associated with hostname'

### DIFF
--- a/READMEs/marketplace_flow.md
+++ b/READMEs/marketplace_flow.md
@@ -30,8 +30,8 @@ First, please make sure you've got the following. The [datatokens tutorial](data
 Then, set Alice's config vals as envvars. In the console:
 ```
 export NETWORK_URL=https://rinkeby.infura.io/v3/<your Infura project id>
-export AQUARIUS_URL=https://aquarius.rinkeby.v3.oceanprotocol.com
-export PROVIDER_URL=https://provider.rinkeby.v3.oceanprotocol.com
+export AQUARIUS_URL=https://aquarius.rinkeby.oceanprotocol.com
+export PROVIDER_URL=https://provider.rinkeby.oceanprotocol.com
 ```
 
 Then, set Alice's private key. In the console:

--- a/READMEs/parameters.md
+++ b/READMEs/parameters.md
@@ -15,8 +15,8 @@ Here are examples.
 First, in console:
 ```console
 export NETWORK_URL=https://rinkeby.infura.io/v3/<your Infura project id>
-export AQUARIUS_URL=https://aquarius.rinkeby.v3.oceanprotocol.com
-export PROVIDER_URL=https://provider.rinkeby.v3.oceanprotocol.com
+export AQUARIUS_URL=https://aquarius.rinkeby.oceanprotocol.com
+export PROVIDER_URL=https://provider.rinkeby.oceanprotocol.com
 ```
 
 Then, do the following in Python. The `Ocean` constructor takes a `dict`, which in turn is set by envvars.
@@ -48,8 +48,8 @@ First, in your working directory, create `config.ini` file and fill as follows:
 network = https://rinkeby.infura.io/v3/<your infura project id>
 
 [resources]
-aquarius.url = https://provider.rinkeby.v3.oceanprotocol.com
-provider.url = https://aquarius.rinkeby.v3.oceanprotocol.com
+aquarius.url = https://provider.rinkeby.oceanprotocol.com
+provider.url = https://aquarius.rinkeby.oceanprotocol.com
 ```
 
 Then, in Python:

--- a/READMEs/services.md
+++ b/READMEs/services.md
@@ -18,8 +18,8 @@ In your working directory, create a file `config.ini` and fill it with the follo
 network = https://rinkeby.infura.io/v3/<your Infura project id>
 
 [resources]
-aquarius.url = AQUARIUS_URL=https://aquarius.rinkeby.v3.oceanprotocol.com
-provider.url = PROVIDER_URL=https://provider.rinkeby.v3.oceanprotocol.com
+aquarius.url = AQUARIUS_URL=https://aquarius.rinkeby.oceanprotocol.com
+provider.url = PROVIDER_URL=https://provider.rinkeby.oceanprotocol.com
 ```
 
 Ensure that envvars don't override the config file values:

--- a/examples/compute_service.py
+++ b/examples/compute_service.py
@@ -17,8 +17,8 @@ def get_config_dict():
             'network': 'rinkeby',
         },
         'resources': {
-            'aquarius.url': 'https://aquarius.rinkeby.v3.oceanprotocol.com',
-            'provider.url': 'https://provider.rinkeby.v3.oceanprotocol.com'
+            'aquarius.url': 'https://aquarius.rinkeby.oceanprotocol.com',
+            'provider.url': 'https://provider.rinkeby.oceanprotocol.com'
         }
     }
 


### PR DESCRIPTION
For #89, for the error reported in this comment: https://github.com/oceanprotocol/ocean.py/issues/89#issuecomment-756853909

I was able to replicate it locally.

Notes:
- originally the service had url `aquarius.rinkeby.v3.dev-ocean.com` (and similar for provider)
- then we created the service `aquarius.rinkeby.oceanprotocol.com`, quite a while ago now. That's the ones we've been maintaining. The READMEs etc were not updated at the time. The old services at dev-ocean were / are still running.
- #93 was to update the READMEs etc. Done. Except the wrong new url was provided: it had the `v3` in it, and it shouldn't have.
- This PR fixes that problem.