### PR TITLE
Added sleep before creating a pool

### DIFF
--- a/READMEs/marketplace_flow.md
+++ b/READMEs/marketplace_flow.md
@@ -121,6 +121,9 @@ assert OCEAN_token.balanceOf(alice_wallet.address) > 0, "need Rinkeby OCEAN"
 
 Let's do the actual work to create the pool. It will do several blockchain transactions: create the base pool, bind OCEAN and datatoken, add OCEAN and datatoken liquidity, and finalize the pool. 
 ```python
+import time
+
+time.sleep(30) #if you are using a .py file to run as etherium contracts take time to be created. So, include this only if you are using a .py file
 pool = ocean.pool.create(
    token_address,
    data_token_amount=100.0,

--- a/READMEs/marketplace_flow.md
+++ b/READMEs/marketplace_flow.md
@@ -123,7 +123,7 @@ Let's do the actual work to create the pool. It will do several blockchain trans
 ```python
 import time
 
-time.sleep(30) #if you are using a .py file to run as etherium contracts take time to be created. So, include this only if you are using a .py file
+time.sleep(30) #if you are using a .py file, running etherium contracts take time to be created. So, include this only if you are using a .py file
 pool = ocean.pool.create(
    token_address,
    data_token_amount=100.0,


### PR DESCRIPTION
Etherium contracts take time to be created. So, if the program is run by copying the code to a .py file, it will throw an error. Therefore, the program must be paused for 30 seconds before creating the pool if it is executed through a .py file. This is linked to the issue #106 