### PR TITLE
Renamed metadataStoreUri to metadataCacheUri.

### DIFF
--- a/READMEs/compute-flow.md
+++ b/READMEs/compute-flow.md
@@ -108,6 +108,7 @@ assert token_address == asset.data_token_address
 
 did = asset.did  # did contains the datatoken address
 ```
+For legacy support, you can also use `metadataStoreUri` instead of `metadataCacheUri`.
 
 ## 3. Alice mints 100 tokens
 

--- a/READMEs/compute-flow.md
+++ b/READMEs/compute-flow.md
@@ -66,7 +66,7 @@ from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 #Alice's config
 config = {
    'network' : 'rinkeby',
-   'metadataStoreUri' : 'http://127.0.0.1:5000',
+   'metadataCacheUri' : 'http://127.0.0.1:5000',
    'providerUri' : 'http://127.0.0.1:8030'
 }
 ocean = Ocean(config)

--- a/READMEs/marketplace_flow.md
+++ b/READMEs/marketplace_flow.md
@@ -48,7 +48,7 @@ from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_utils.agreements.service_factory import ServiceDescriptor
 config = {
    'network' : os.getenv('NETWORK_URL'),
-   'metadataStoreUri' : os.getenv('AQUARIUS_URL'),
+   'metadataCacheUri' : os.getenv('AQUARIUS_URL'),
    'providerUri' : os.getenv('PROVIDER_URL'),
 }
 ocean = Ocean(config)
@@ -148,7 +148,7 @@ import os
 from ocean_lib.ocean.ocean import Ocean
 config = {
    'network' : os.getenv('NETWORK_URL'),
-   'metadataStoreUri' : os.getenv('AQUARIUS_URL'),
+   'metadataCacheUri' : os.getenv('AQUARIUS_URL'),
    'providerUri' : os.getenv('PROVIDER_URL'),
 }
 market_ocean = Ocean(config)
@@ -197,7 +197,7 @@ import os
 from ocean_lib.ocean.ocean import Ocean
 config = {
    'network' : os.getenv('NETWORK_URL'),
-   'metadataStoreUri' : os.getenv('AQUARIUS_URL'),
+   'metadataCacheUri' : os.getenv('AQUARIUS_URL'),
    'providerUri' : os.getenv('PROVIDER_URL'),
 }
 bob_ocean = Ocean(config)

--- a/READMEs/marketplace_flow.md
+++ b/READMEs/marketplace_flow.md
@@ -207,6 +207,7 @@ from ocean_lib.web3_internal.wallet import Wallet
 bob_wallet = Wallet(bob_ocean.web3, private_key=os.getenv('BOB_KEY'))
 print(f"bob_wallet.address = '{bob_wallet.address}'")
 ```
+For legacy support, you can also use `metadataStoreUri` instead of `metadataCacheUri`.
 
 Verify that Bob has Rinkeby ETH. If it fails, the [datatokens tutorial](datatokens_tutorial.md) can help.
 ```python

--- a/READMEs/parameters.md
+++ b/READMEs/parameters.md
@@ -30,6 +30,7 @@ d = {
 }
 ocean = Ocean(d)
 ```
+For legacy support, you can also use `metadataStoreUri` instead of `metadataCacheUri`.
 
 ## 1a. Unsetting envvars
 

--- a/READMEs/parameters.md
+++ b/READMEs/parameters.md
@@ -25,7 +25,7 @@ import os
 from ocean_lib.ocean.ocean import Ocean
 d = {
    'network' : os.getenv('NETWORK_URL'),
-   'metadataStoreUri' : os.getenv('AQUARIUS_URL'),
+   'metadataCacheUri' : os.getenv('AQUARIUS_URL'),
    'providerUri' : os.getenv('PROVIDER_URL'),
 }
 ocean = Ocean(d)

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -75,7 +75,7 @@ class Ocean:
 
         if isinstance(config, dict):
             aqua_url = config.get(
-                "metadataStoreUri", config.get("aquarius.url", "http://localhost:5000")
+                "metadataCacheUri", config.get("aquarius.url", "http://localhost:5000")
             )
             config_dict = {
                 "eth-network": {"network": config.get("network", "")},

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -6,6 +6,8 @@ import logging
 import os
 
 from eth_utils import remove_0x_prefix
+from web3.datastructures import AttributeDict
+
 from ocean_lib.config import Config
 from ocean_lib.config_provider import ConfigProvider
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
@@ -33,7 +35,6 @@ from ocean_lib.web3_internal.contract_handler import ContractHandler
 from ocean_lib.web3_internal.wallet import Wallet
 from ocean_lib.web3_internal.web3_provider import Web3Provider
 from ocean_lib.web3_internal.web3helper import Web3Helper
-from web3.datastructures import AttributeDict
 
 logger = logging.getLogger("ocean")
 
@@ -75,9 +76,9 @@ class Ocean:
         if isinstance(config, dict):
             # fallback to metadataStoreUri
             cache_key = (
-                "metadataStoreUri"
-                if "metadataStoreUri" in config and "metadataCacheUri" not in config
-                else "metadataCacheUri"
+                "metadataCacheUri"
+                if ("metadataCacheUri" in config)
+                else "metadataStoreUri"
             )
             aqua_url = config.get(
                 cache_key, config.get("aquarius.url", "http://localhost:5000")

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -72,10 +72,15 @@ class Ocean:
             except AssertionError:
                 config = Config(os.getenv(ENV_CONFIG_FILE))
                 ConfigProvider.set_config(config)
-
         if isinstance(config, dict):
+            # fallback to metadataStoreUri
+            cache_key = (
+                "metadataStoreUri"
+                if "metadataStoreUri" in config and "metadataCacheUri" not in config
+                else "metadataCacheUri"
+            )
             aqua_url = config.get(
-                "metadataCacheUri", config.get("aquarius.url", "http://localhost:5000")
+                cache_key, config.get("aquarius.url", "http://localhost:5000")
             )
             config_dict = {
                 "eth-network": {"network": config.get("network", "")},
@@ -85,7 +90,6 @@ class Ocean:
                 },
             }
             config = Config(options_dict=config_dict)
-
         ConfigProvider.set_config(config)
         self._config = config
         ContractHandler.set_artifacts_path(self._config.artifacts_path)

--- a/tests/ocean/test_compute_flow.py
+++ b/tests/ocean/test_compute_flow.py
@@ -3,11 +3,13 @@
 
 import uuid
 
+from ocean_utils.agreements.service_factory import ServiceDescriptor
+from ocean_utils.agreements.service_types import ServiceTypes
+
 from ocean_lib.assets.asset import Asset
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.algorithm_metadata import AlgorithmMetadata
-from ocean_utils.agreements.service_factory import ServiceDescriptor
-from ocean_utils.agreements.service_types import ServiceTypes
+from ocean_lib.ocean.ocean import Ocean
 from tests.resources.helper_functions import (
     get_consumer_ocean_instance,
     get_consumer_wallet,
@@ -17,6 +19,24 @@ from tests.resources.helper_functions import (
     mint_tokens_and_wait,
     wait_for_ddo,
 )
+
+
+def test_metadaCacheUri_version():
+    config_dict = {
+        "metadataCacheUri": "http://ItWorked.com",
+        "network": "rinkeby",
+    }
+    ocean_instance = Ocean(config=config_dict)
+    assert "http://ItWorked.com" == ocean_instance.config.aquarius_url
+
+
+def test_metadataStoreUri_version():
+    config_dict = {
+        "metadataStoreUri": "http://ItWorked.com",
+        "network": "rinkeby",
+    }
+    ocean_instance = Ocean(config=config_dict)
+    assert "http://ItWorked.com" == ocean_instance.config.aquarius_url
 
 
 def test_expose_endpoints():


### PR DESCRIPTION
Fixes #126 .

Changes proposed in this PR:

- to rename the config dictionary key called metadataStoreUri to metadataCacheUri.