### PR TITLE
Fixing #157 - pytest warnings friction

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+# pytest.ini
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning


### PR DESCRIPTION
Fixes #157.

Changes proposed in this PR:

- add new file to configure pytest: `pytest.ini`
- in file, ignore all deprecation warnings
