### PR TITLE
Added utf-8 spec in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from os.path import join
 
 from setuptools import setup
 
-with open("README.md") as readme_file:
+with open("README.md", encoding="utf8") as readme_file:
     readme = readme_file.read()
 
 # Installed by pip install ocean-lib


### PR DESCRIPTION
- On [development docs](https://github.com/oceanprotocol/ocean.py/blob/master/READMEs/developers.md) when 
```pip install -r requirements_dev.txt```
is entered, I got a codec error:
``` UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1159: character maps to <undefined>```
this is simply caused by multiple emojis, since my setup is not using utf-8 as default. 

Changes proposed in this PR:
- Add default encoding param: encoding="utf8"