### PR TITLE
Fixes ignore files in .coveragerc.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *test*


### PR DESCRIPTION
Changes proposed in this PR:

- after moving tests in different folders, the omission rule was broken and a new one must be added.