### PR TITLE
Issue 234 - docker instrs

### DIFF
--- a/READMEs/datatokens-flow.md
+++ b/READMEs/datatokens-flow.md
@@ -5,7 +5,15 @@ SPDX-License-Identifier: Apache-2.0
 
 # Quickstart: Publish datatoken
 
-## Run the services
+## Prerequisites
+
+-   Linux/MacOS
+-   Docker, [allowing non-root users](https://www.thegeekdiary.com/run-docker-as-a-non-root-user/)
+-   Python 3.8.5+
+
+## Run barge services
+
+Ocean `barge` runs ganache (local blockchain), Provider (data service), and Aquarius (metadata cache).
 
 In a new console:
 
@@ -17,7 +25,7 @@ cd barge
 #clean up old containers (to be sure)
 docker system prune -a --volumes
 
-#run barge (runs ganache, Provider, Aquarius)
+#run barge: start ganache, Provider, Aquarius; deploy contracts; update ~/.ocean
 ./start_ocean.sh  --with-provider2
 ```
 

--- a/READMEs/developers.md
+++ b/READMEs/developers.md
@@ -20,8 +20,8 @@ Steps:
 ### 1.1 Prerequisites
 
 -   Linux/MacOS
--   Docker
--   Python 3.8.5
+-   Docker, [allowing non-root users](https://www.thegeekdiary.com/run-docker-as-a-non-root-user/)
+-   Python 3.8.5+
 
 ### 1.2 Do Install
 
@@ -43,9 +43,7 @@ source venv/bin/activate
 pip install -r requirements_dev.txt
 ```
 
-## 2. Run the services
-
-Use Ocean Barge to run local Ethereum node with Ocean contracts, Aquarius, and Provider.
+## 2. Run barge services
 
 In a new console:
 
@@ -57,7 +55,7 @@ cd barge
 #clean up old containers (to be sure)
 docker system prune -a --volumes
 
-#run barge with provider on
+#run barge: start ganache, Provider, Aquarius; deploy contracts; update ~/.ocean
 ./start_ocean.sh  --with-provider2
 ```
 

--- a/READMEs/marketplace-flow.md
+++ b/READMEs/marketplace-flow.md
@@ -20,7 +20,15 @@ Let's go through each step.
 
 ## 1. Setup
 
+### Prerequisites
+
+-   Linux/MacOS
+-   Docker, [allowing non-root users](https://www.thegeekdiary.com/run-docker-as-a-non-root-user/)
+-   Python 3.8.5+
+
 ### Run barge services
+
+In a new console:
 
 ```console
 #grab repo
@@ -30,7 +38,7 @@ cd barge
 #clean up old containers (to be sure)
 docker system prune -a --volumes
 
-#run barge (runs ganache, Provider, Aquarius)
+#run barge: start ganache, Provider, Aquarius; deploy contracts; update ~/.ocean
 ./start_ocean.sh  --with-provider2
 ```
 


### PR DESCRIPTION
Fixes #234.

Changes proposed in this PR:

- Ensure there's a "prerequisites" section in each of: simple quickstart, marketplace quickstart, and developers.md
- In this section, explain that docker needs to allow non-root users, and link to more info
- In the call to barge itself, explain that the `~/.ocean` directory is added. (This would have helped to identify the correct issue faster in #234)
- Harmonize the barge section for all three files. And add a tiny bit more in the simple quickstart, to help onboarding.