### PR TITLE
Issue238 polygon

### DIFF
--- a/ocean_lib/ocean/test/test_util.py
+++ b/ocean_lib/ocean/test/test_util.py
@@ -15,61 +15,64 @@ from ocean_lib.ocean.env_constants import (
 
 
 def test_get_infura_connection_type(monkeypatch):
-    #no envvar
+    # no envvar
     if ENV_INFURA_CONNECTION_TYPE in os.environ:
         monkeypatch.delenv(ENV_INFURA_CONNECTION_TYPE)
     assert util.get_infura_connection_type() == "http"
-    
-    #envvar is "http"
+
+    # envvar is "http"
     monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "http")
     assert util.get_infura_connection_type() == "http"
-    
-    #envvar is "websocket"
+
+    # envvar is "websocket"
     monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "websocket")
     assert util.get_infura_connection_type() == "websocket"
-    
-    #envvar is other val
+
+    # envvar is other val
     monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "foo_type")
     assert util.get_infura_connection_type() == "http"
 
+
 def test_get_infura_id(monkeypatch):
-    #no envvar
+    # no envvar
     if ENV_INFURA_PROJECT_ID in os.environ:
         monkeypatch.delenv(ENV_INFURA_PROJECT_ID)
     assert util.get_infura_id() == util.WEB3_INFURA_PROJECT_ID
 
-    #envvar is other val
+    # envvar is other val
     monkeypatch.setenv(ENV_INFURA_PROJECT_ID, "foo_id")
     assert util.get_infura_id() == "foo_id"
 
+
 def test_get_infura_url(monkeypatch):
-    #envvar is "http"
+    # envvar is "http"
     monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "http")
-    assert util.get_infura_url("id1","net1") == "https://net1.infura.io/v3/id1"
-    
-    #envvar is "websocket"
+    assert util.get_infura_url("id1", "net1") == "https://net1.infura.io/v3/id1"
+
+    # envvar is "websocket"
     monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "websocket")
-    assert util.get_infura_url("id2","net2") == "wss://net2.infura.io/ws/v3/id2"
-    
-    #envvar is other val - it will resort to "http"
+    assert util.get_infura_url("id2", "net2") == "wss://net2.infura.io/ws/v3/id2"
+
+    # envvar is other val - it will resort to "http"
     monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "foo_type")
-    assert util.get_infura_url("id3","net3") == "https://net3.infura.io/v3/id3"
+    assert util.get_infura_url("id3", "net3") == "https://net3.infura.io/v3/id3"
+
 
 def test_get_web3_connection_provider(monkeypatch):
     # "ganache"
     provider = util.get_web3_connection_provider("ganache")
-    assert provider.endpoint_uri == util.GANACHE_URL #e.g. http://127.0.0.1:8545
+    assert provider.endpoint_uri == util.GANACHE_URL  # e.g. http://127.0.0.1:8545
 
     # GANACHE_URL
     provider = util.get_web3_connection_provider(util.GANACHE_URL)
     assert provider.endpoint_uri == util.GANACHE_URL
 
     # typical http uri "http://foo.com"
-    provider = util.get_web3_connection_provider("http://foo.com")    
+    provider = util.get_web3_connection_provider("http://foo.com")
     assert provider.endpoint_uri == "http://foo.com"
 
     # typical https uri "https://bar.com"
-    provider = util.get_web3_connection_provider("https://bar.com")    
+    provider = util.get_web3_connection_provider("https://bar.com")
     assert provider.endpoint_uri == "https://bar.com"
 
     # "rinkeby"
@@ -80,7 +83,8 @@ def test_get_web3_connection_provider(monkeypatch):
 
     # all infura-supported network names
     for network in util.SUPPORTED_NETWORK_NAMES:
-        if network == "ganache": continue #tested above
+        if network == "ganache":
+            continue  # tested above
         monkeypatch.setenv(ENV_INFURA_PROJECT_ID, f"id_{network}")
         provider = util.get_web3_connection_provider(network)
         assert provider.endpoint_uri == f"https://{network}.infura.io/v3/id_{network}"
@@ -91,7 +95,7 @@ def test_get_web3_connection_provider(monkeypatch):
         util.get_web3_connection_provider("not_network_name")
 
     # typical websockets uri "wss://foo.com"
-    provider = util.get_web3_connection_provider("wss://bah.com")    
+    provider = util.get_web3_connection_provider("wss://bah.com")
     assert provider.endpoint_uri == "wss://bah.com"
 
 
@@ -105,4 +109,3 @@ def test_get_web3_connection_provider(monkeypatch):
 # get_bfactory_address
 # get_ocean_token_address
 # init_components
-

--- a/ocean_lib/ocean/test/test_util.py
+++ b/ocean_lib/ocean/test/test_util.py
@@ -1,0 +1,108 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import os
+import pytest
+
+from ocean_lib.ocean import util
+from ocean_lib.ocean.env_constants import (
+    ENV_CONFIG_FILE,
+    ENV_INFURA_CONNECTION_TYPE,
+    ENV_INFURA_PROJECT_ID,
+)
+
+
+def test_get_infura_connection_type(monkeypatch):
+    #no envvar
+    if ENV_INFURA_CONNECTION_TYPE in os.environ:
+        monkeypatch.delenv(ENV_INFURA_CONNECTION_TYPE)
+    assert util.get_infura_connection_type() == "http"
+    
+    #envvar is "http"
+    monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "http")
+    assert util.get_infura_connection_type() == "http"
+    
+    #envvar is "websocket"
+    monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "websocket")
+    assert util.get_infura_connection_type() == "websocket"
+    
+    #envvar is other val
+    monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "foo_type")
+    assert util.get_infura_connection_type() == "http"
+
+def test_get_infura_id(monkeypatch):
+    #no envvar
+    if ENV_INFURA_PROJECT_ID in os.environ:
+        monkeypatch.delenv(ENV_INFURA_PROJECT_ID)
+    assert util.get_infura_id() == util.WEB3_INFURA_PROJECT_ID
+
+    #envvar is other val
+    monkeypatch.setenv(ENV_INFURA_PROJECT_ID, "foo_id")
+    assert util.get_infura_id() == "foo_id"
+
+def test_get_infura_url(monkeypatch):
+    #envvar is "http"
+    monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "http")
+    assert util.get_infura_url("id1","net1") == "https://net1.infura.io/v3/id1"
+    
+    #envvar is "websocket"
+    monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "websocket")
+    assert util.get_infura_url("id2","net2") == "wss://net2.infura.io/ws/v3/id2"
+    
+    #envvar is other val - it will resort to "http"
+    monkeypatch.setenv(ENV_INFURA_CONNECTION_TYPE, "foo_type")
+    assert util.get_infura_url("id3","net3") == "https://net3.infura.io/v3/id3"
+
+def test_get_web3_connection_provider(monkeypatch):
+    # "ganache"
+    provider = util.get_web3_connection_provider("ganache")
+    assert provider.endpoint_uri == util.GANACHE_URL #e.g. http://127.0.0.1:8545
+
+    # GANACHE_URL
+    provider = util.get_web3_connection_provider(util.GANACHE_URL)
+    assert provider.endpoint_uri == util.GANACHE_URL
+
+    # typical http uri "http://foo.com"
+    provider = util.get_web3_connection_provider("http://foo.com")    
+    assert provider.endpoint_uri == "http://foo.com"
+
+    # typical https uri "https://bar.com"
+    provider = util.get_web3_connection_provider("https://bar.com")    
+    assert provider.endpoint_uri == "https://bar.com"
+
+    # "rinkeby"
+    assert "rinkeby" in util.SUPPORTED_NETWORK_NAMES
+    monkeypatch.setenv(ENV_INFURA_PROJECT_ID, "id1")
+    provider = util.get_web3_connection_provider("rinkeby")
+    assert provider.endpoint_uri == "https://rinkeby.infura.io/v3/id1"
+
+    # all infura-supported network names
+    for network in util.SUPPORTED_NETWORK_NAMES:
+        if network == "ganache": continue #tested above
+        monkeypatch.setenv(ENV_INFURA_PROJECT_ID, f"id_{network}")
+        provider = util.get_web3_connection_provider(network)
+        assert provider.endpoint_uri == f"https://{network}.infura.io/v3/id_{network}"
+
+    # non-supported name
+    monkeypatch.setenv(ENV_INFURA_PROJECT_ID, "idx")
+    with pytest.raises(Exception):
+        util.get_web3_connection_provider("not_network_name")
+
+    # typical websockets uri "wss://foo.com"
+    provider = util.get_web3_connection_provider("wss://bah.com")    
+    assert provider.endpoint_uri == "wss://bah.com"
+
+
+# FIXME: add tests for:
+# get_contracts_addresses
+# to_base_18
+# to_base
+# from_base_18
+# from_base
+# get_dtfactory_address
+# get_bfactory_address
+# get_ocean_token_address
+# init_components
+

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -22,7 +22,7 @@ from web3 import WebsocketProvider
 WEB3_INFURA_PROJECT_ID = "357f2fe737db4304bd2f7285c5602d0d"
 GANACHE_URL = "http://127.0.0.1:8545"
 
-#shortcut names for networks that *Infura* supports, plus ganache
+# shortcut names for networks that *Infura* supports, plus ganache
 SUPPORTED_NETWORK_NAMES = {"rinkeby", "kovan", "ganache", "mainnet", "ropsten"}
 
 

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -21,6 +21,8 @@ from web3 import WebsocketProvider
 
 WEB3_INFURA_PROJECT_ID = "357f2fe737db4304bd2f7285c5602d0d"
 GANACHE_URL = "http://127.0.0.1:8545"
+
+#shortcut names for networks that *Infura* supports, plus ganache
 SUPPORTED_NETWORK_NAMES = {"rinkeby", "kovan", "ganache", "mainnet", "ropsten"}
 
 

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -65,8 +65,8 @@ def get_web3_connection_provider(network_url):
         - the issue is described here: https://github.com/ethereum/web3.py/issues/549
         - and the fix is here: https://web3py.readthedocs.io/en/latest/middleware.html#geth-style-proof-of-authority
 
-    :param network_url:
-    :return:
+    :param network_url: str
+    :return: provider : HTTPProvider
     """
     if network_url == "ganache":
         network_url = GANACHE_URL


### PR DESCRIPTION
Fixes #238.

Changes proposed in this PR:
- Introduce unit test module for `ocean_lib/ocean/util.py`, and write tests for the first half: url generation, Infura, etc. Document the tests that still need writing.
- Document that `util.SUPPORTED_NETWORK_NAMES` is for _Infura_-supported networks, not general. 
- Polygon is _not_ supported by infura, therefore it's not put into the list