### PR TITLE
Adds setRate processing to OceanExchange.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.14
+current_version = 0.5.15
 commit = True
 tag = True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ copyright = "ocean.py contributors"
 author = "ocean.py contributors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.5.14"
+release = "0.5.15"
 # The short X.Y version
 release_parts = release.split(".")  # a list
 version = release_parts[0] + "." + release_parts[1]

--- a/ocean_lib/__init__.py
+++ b/ocean_lib/__init__.py
@@ -7,5 +7,5 @@
 
 __author__ = """OceanProtocol"""
 # fmt: off
-__version__ = '0.5.14'
+__version__ = '0.5.15'
 # fmt: on

--- a/ocean_lib/ocean/test/test_ocean_exchange.py
+++ b/ocean_lib/ocean/test/test_ocean_exchange.py
@@ -76,4 +76,10 @@ def test_ocean_exchange(publisher_ocean_instance):
         is True
     ), "buy datatokens failed"
 
-    print("-------- all good --------")
+    assert ox.setRate(1.0, bob_wallet, exchange_id=x_id)
+    rate = 1.0
+    # re-evaluate with new rate
+    base_token_amount = ox.get_quote(2.0, exchange_id=x_id)
+    assert (
+        base_token_amount == 2.0 * rate
+    ), f"unexpected quote of base token {base_token_amount}, should be {2.0*rate}."

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     url="https://github.com/oceanprotocol/ocean.py",
     # fmt: off
     # bumpversion.sh needs single-quotes
-    version='0.5.14',
+    version='0.5.15',
     # fmt: on
     zip_safe=False,
 )


### PR DESCRIPTION
Changes proposed in this PR:

- add setRate utilitary in OceanExchange, in order to trigger event when changing the fixed rate.