### PR TITLE
Issue258 licenseheaders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/johann-petrak/licenseheaders.git
-    rev: version-0.8.x
+    rev: v0.8.8
     hooks:
     - id: licenseheaders
       args: ["-t", ".copyright.tmpl", "-f"]


### PR DESCRIPTION
Closes #258.

# Changes proposed:

- Freeze licenseheaders version at latest available
  - v0.8.8 includes the fix to issue #258 where licenseheaders pre-commit
    check always failed. 

# Test

The following console output shows that I cleaned my pre-commit environment and re-installed all pre-commit hooks. Then I ran pre-commit on all files and all checks passed.

```console
(venv) david@david-Inspiron-5502:~/projects/ocean.py$ pre-commit clean
Cleaned /home/david/.cache/pre-commit.
(venv) david@david-Inspiron-5502:~/projects/ocean.py$ pre-commit gc
0 repo(s) removed.
(venv) david@david-Inspiron-5502:~/projects/ocean.py$ pre-commit install --install-hooks
pre-commit installed at .git/hooks/pre-commit
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-isort.
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
[INFO] Initializing environment for https://github.com/johann-petrak/licenseheaders.git.
[INFO] Installing environment for https://github.com/pre-commit/mirrors-isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/johann-petrak/licenseheaders.git.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
(venv) david@david-Inspiron-5502:~/projects/ocean.py$ pre-commit run --all-files
isort....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
licenseheaders...........................................................Passed
```