### PR TITLE
fix issue 270 set_config first AssertionError in simple import 

### DIFF
--- a/ocean_lib/enforce_typing_shim.py
+++ b/ocean_lib/enforce_typing_shim.py
@@ -18,11 +18,11 @@ def setup_enforce_typing_shim():
 def enforce_types_shim(func):
     try:
         c = ConfigProvider.get_config()
-        typecheck = c["util"].getboolean("typecheck")
-
     except AssertionError:  # handle if ConfigProvider.set_config() not done yet
-        val = config_defaults["util"][NAME_TYPECHECK]
-        typecheck = distutils.util.strtobool(val)
+        c = config_defaults
+
+    val = c["util"][NAME_TYPECHECK]
+    typecheck = distutils.util.strtobool(val)
 
     if typecheck:
         return enforce_types(func)

--- a/ocean_lib/enforce_typing_shim.py
+++ b/ocean_lib/enforce_typing_shim.py
@@ -18,12 +18,11 @@ def enforce_types_shim(func):
     try:
         c = ConfigProvider.get_config()
         typecheck = c["util"].getboolean("typecheck")
-        
-    except AssertionError: #handle if ConfigProvider.set_config() not done yet
+
+    except AssertionError:  # handle if ConfigProvider.set_config() not done yet
         typecheck = config_defaults["util"][NAME_TYPECHECK]
 
     if typecheck:
         return enforce_types(func)
     else:
         return func
-

--- a/ocean_lib/enforce_typing_shim.py
+++ b/ocean_lib/enforce_typing_shim.py
@@ -26,5 +26,4 @@ def enforce_types_shim(func):
 
     if typecheck:
         return enforce_types(func)
-    else:
-        return func
+    return func

--- a/ocean_lib/enforce_typing_shim.py
+++ b/ocean_lib/enforce_typing_shim.py
@@ -5,7 +5,7 @@
 import os
 
 from enforce_typing import enforce_types
-from ocean_lib.config import Config
+from ocean_lib.config import Config, config_defaults, NAME_TYPECHECK
 from ocean_lib.config_provider import ConfigProvider
 from ocean_lib.ocean.env_constants import ENV_CONFIG_FILE
 
@@ -15,6 +15,15 @@ def setup_enforce_typing_shim():
 
 
 def enforce_types_shim(func):
-    if not ConfigProvider.get_config()["util"].getboolean("typecheck"):
+    try:
+        c = ConfigProvider.get_config()
+        typecheck = c["util"].getboolean("typecheck")
+        
+    except AssertionError: #handle if ConfigProvider.set_config() not done yet
+        typecheck = config_defaults["util"][NAME_TYPECHECK]
+
+    if typecheck:
+        return enforce_types(func)
+    else:
         return func
-    return enforce_types(func)
+

--- a/ocean_lib/enforce_typing_shim.py
+++ b/ocean_lib/enforce_typing_shim.py
@@ -2,6 +2,7 @@
 # Copyright 2021 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
+import distutils.util
 import os
 
 from enforce_typing import enforce_types
@@ -20,7 +21,8 @@ def enforce_types_shim(func):
         typecheck = c["util"].getboolean("typecheck")
 
     except AssertionError:  # handle if ConfigProvider.set_config() not done yet
-        typecheck = config_defaults["util"][NAME_TYPECHECK]
+        val = config_defaults["util"][NAME_TYPECHECK]
+        typecheck = distutils.util.strtobool(val)
 
     if typecheck:
         return enforce_types(func)


### PR DESCRIPTION
Fixes #270.

Changes proposed in this PR:
- made `enforce_types_shim()` robust to being called even before `ConfigProvider.set_config()` is called, which can easily happen in practice 