### PR TITLE
Removes restart function from OceanCompute.

### DIFF
--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -388,26 +388,6 @@ class OceanCompute:
             )
         )
 
-    def restart(self, did, job_id, wallet):
-        """
-        Attempt to restart the compute job by stopping it first, then starting a new job.
-
-        :param did: str id of the asset offering the compute service of this job
-        :param job_id: str id of the compute job
-        :param wallet: Wallet instance
-        :return: str -- id of the new compute job
-        """
-        _, service_endpoint = self._get_service_endpoint(did)
-        msg = f'{wallet.address}{job_id or ""}{did}'
-        job_info = self._data_provider.restart_compute_job(
-            did,
-            job_id,
-            service_endpoint,
-            wallet.address,
-            self._sign_message(wallet, msg, service_endpoint=service_endpoint),
-        )
-        return job_info["jobId"]
-
     def _get_service_endpoint(self, did, asset=None):
         if not asset:
             asset = resolve_asset(did, self._config.aquarius_url)

--- a/tests/integration/test_compute_flow.py
+++ b/tests/integration/test_compute_flow.py
@@ -79,7 +79,7 @@ def run_compute_test(
     algo_meta=None,
     expect_failure=False,
     expect_failure_message=None,
-    restart_and_result=False,
+    with_result=False,
 ):
     """Helper function to bootstrap compute job creation and status checking."""
     compute_ddo = input_ddos[0]
@@ -150,10 +150,7 @@ def run_compute_test(
     print(f"got job status after requesting stop: {status}")
     assert status, f"something not right about the compute job, got status: {status}"
 
-    if restart_and_result:
-        # TODO: test restart function after pending rework
-        # OR delete this TODO if restart is removed from the interface
-
+    if with_result:
         result = ocean_instance.compute.result(did, job_id, consumer_wallet)
         print(f"got job status after requesting result: {result}")
         assert "did" in result, "something not right about the compute job, no did."
@@ -178,7 +175,7 @@ def test_compute_raw_algo():
         setup.consumer_wallet,
         [compute_ddo],
         algo_meta=algorithm_meta,
-        restart_and_result=True,
+        with_result=True,
     )
 
 


### PR DESCRIPTION
Closes #232.

Changes proposed in this PR:

- remove the obsolete restart function in OceanCompute