### PR TITLE
Non-blocking nature of calls hurts DX/maintenance. Use blocking.

### DIFF
--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -224,6 +224,11 @@ class ContractBase(object):
         if transact:
             _transact.update(transact)
 
+        is_successful = self.is_tx_successful(
+            contract_function.transact(_transact).hex()
+        )
+        if not is_successful:
+            return "Tx was not successful."
         return contract_function.transact(_transact).hex()
 
     def get_event_argument_names(self, event_name: str):

--- a/ocean_lib/web3_internal/test/test_contract_base.py
+++ b/ocean_lib/web3_internal/test/test_contract_base.py
@@ -26,6 +26,34 @@ class MyFactory(ContractBase):
         )
 
 
+def test_send_transaction_with_a_wrong_password(dtfactory_address, alice_wallet):
+    factory = MyFactory(dtfactory_address)
+    old_hash = factory.createToken(
+        "foo_blob", "DT1", "DT1", to_base_18(1000.0), alice_wallet
+    )
+    _transact = {
+        "from": alice_wallet.address,
+        "passphrase": "my_secret_passphrase",
+        "account_key": alice_wallet.key,
+    }
+    wrong_tx_hash = factory.send_transaction(
+        "createToken",
+        ("foo_blob", "DT1", "DT1", to_base_18(1000.0)),
+        alice_wallet,
+        _transact,
+    )
+    assert old_hash != wrong_tx_hash
+    assert not factory.is_tx_successful(
+        factory.send_transaction(
+            "createToken",
+            ("foo_blob", "DT1", "DT1", to_base_18(1000.0)),
+            alice_wallet,
+            _transact,
+        )
+    )
+    assert wrong_tx_hash == "Tx was not successful."
+
+
 def test_name_is_None():
     with pytest.raises(AssertionError):
         # self.name will become None, triggering the error
@@ -46,7 +74,6 @@ def test_nochild():
 
 
 def test_main(network, alice_wallet, alice_address, dtfactory_address, alice_ocean):
-
     # test super-simple functionality of child
     factory = MyFactory(dtfactory_address)
     factory.createToken("foo_blob", "DT1", "DT1", to_base_18(1000.0), alice_wallet)


### PR DESCRIPTION

Fixes #227 .

Changes proposed in this PR:

- add blocking to verify if the tx was successful or not;
- add unit test for that;
- test on multiple networks to see if it works.