### PR TITLE
Upgrade to ocean-contracts 0.6.3

### DIFF
--- a/ocean_lib/config.py
+++ b/ocean_lib/config.py
@@ -8,7 +8,7 @@ import logging
 import os
 from pathlib import Path
 
-import ocean_abis
+import artifacts
 from ocean_lib.ocean.env_constants import ENV_CONFIG_FILE
 from ocean_lib.web3_internal.constants import GAS_LIMIT_DEFAULT
 
@@ -222,7 +222,7 @@ class Config(configparser.ConfigParser):
         if path and path.exists():
             return path
 
-        return Path(ocean_abis.__file__).parent.expanduser().resolve()
+        return Path(artifacts.__file__).parent.expanduser().resolve()
 
     @property
     def address_file(self):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", encoding="utf8") as readme_file:
 # Installed by pip install ocean-lib
 # or pip install -e .
 install_requirements = [
-    "ocean-contracts==0.6.2",
+    "ocean-contracts==0.6.3",
     "coloredlogs",
     "pyopenssl",
     "PyJWT",  # not jwt

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
     ARTIFACTS_PATH=~/.ocean/ocean-contracts/artifacts
 
 deps =
-    -r{toxinidir}/requirements_dev.txt
+    -rrequirements_dev.txt
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:
 ;     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Towards https://github.com/oceanprotocol/multi-repo-issue/issues/83.

Changes proposed in this PR:

- Upgrade to ocean-contracts 0.6.3
- Fix bug in tox.ini that prevented dependencies from being updated

# tox.ini bug that prevented dependencies from being updated
Quoted from: https://tox.readthedocs.io/en/latest/example/basic.html#depending-on-requirements-txt-or-defining-constraints

>All installation commands are executed using {toxinidir} (the directory where tox.ini resides) as the current working directory. Therefore, the underlying pip installation will assume requirements.txt or constraints.txt to exist at {toxinidir}/requirements.txt or {toxinidir}/constraints.txt.

But we were using `deps = -r{toxinidir}/requirements.txt` which resolved to `{toxinidir}/{toxinidir}/requirements.txt` which doesn't exist so none of the dependencies were updated. The fix was to remove `{toxinidir}`.

This issue only appeared when running `tox` on one's local machine and not in the travis checks because travis creates a brand new environment each time it is run so the dependencies would never be stale.