### PR TITLE
Install wheel first to eliminate benign errors while installing ocean-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ This is in beta state and you can expect running into problems. If you run into 
 ## 🏗 Installation
 
 ```console
+#Install the ocean.py library. Install wheel first to avoid errors.
 pip install wheel ocean-lib
 ```
-
-NOTE: `wheel` is not strictly necessary, but installing it first eliminates
-benign error messages that occur while installing `ocean-lib`.
 
 ## 🏄 Quickstart
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ This is in beta state and you can expect running into problems. If you run into 
 
 ```console
 #Install the ocean.py library. Install wheel first to avoid errors.
-pip install wheel ocean-lib
+pip install wheel
+pip install ocean-lib
 ```
 
 ## 🏄 Quickstart

--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ This is in beta state and you can expect running into problems. If you run into 
 
 ## 🏗 Installation
 
-`pip install ocean-lib`
+```console
+pip install wheel ocean-lib
+```
+
+NOTE: `wheel` is not strictly necessary, but installing it first eliminates
+benign error messages that occur while installing `ocean-lib`.
 
 ## 🏄 Quickstart
 

--- a/READMEs/compute-flow.md
+++ b/READMEs/compute-flow.md
@@ -33,11 +33,9 @@ this [faucet](https://www.rinkeby.io/#faucet). Otherwise, run `ganache-cli` and 
 If you haven't installed yet:
 
 ```console
+#Install the ocean.py library. Install wheel first to avoid errors.
 pip install wheel ocean-lib
 ```
-
-NOTE: `wheel` is not strictly necessary, but installing it first eliminates
-benign error messages that occur while installing `ocean-lib`.
 
 ## 1. Initialize services
 

--- a/READMEs/compute-flow.md
+++ b/READMEs/compute-flow.md
@@ -33,8 +33,11 @@ this [faucet](https://www.rinkeby.io/#faucet). Otherwise, run `ganache-cli` and 
 If you haven't installed yet:
 
 ```console
-pip install ocean-lib
+pip install wheel ocean-lib
 ```
+
+NOTE: `wheel` is not strictly necessary, but installing it first eliminates
+benign error messages that occur while installing `ocean-lib`.
 
 ## 1. Initialize services
 

--- a/READMEs/compute-flow.md
+++ b/READMEs/compute-flow.md
@@ -34,7 +34,8 @@ If you haven't installed yet:
 
 ```console
 #Install the ocean.py library. Install wheel first to avoid errors.
-pip install wheel ocean-lib
+pip install wheel
+pip install ocean-lib
 ```
 
 ## 1. Initialize services

--- a/READMEs/datatokens-flow.md
+++ b/READMEs/datatokens-flow.md
@@ -49,7 +49,7 @@ In a new console:
 python -m venv venv
 source venv/bin/activate
 
-#Install the ocean.py library
+#Install the ocean.py library. Install wheel first to avoid errors.
 pip install wheel ocean-lib
 
 #set envvars
@@ -58,9 +58,6 @@ export TEST_PRIVATE_KEY1=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f43
 #go into python
 python
 ```
-
-NOTE: `wheel` is not strictly necessary, but installing it first eliminates
-benign error messages that occur while installing `ocean-lib`.
 
 ## Publish datatokens
 

--- a/READMEs/datatokens-flow.md
+++ b/READMEs/datatokens-flow.md
@@ -50,7 +50,7 @@ python -m venv venv
 source venv/bin/activate
 
 #Install the ocean.py library
-pip install ocean-lib
+pip install wheel ocean-lib
 
 #set envvars
 export TEST_PRIVATE_KEY1=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58
@@ -58,6 +58,9 @@ export TEST_PRIVATE_KEY1=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f43
 #go into python
 python
 ```
+
+NOTE: `wheel` is not strictly necessary, but installing it first eliminates
+benign error messages that occur while installing `ocean-lib`.
 
 ## Publish datatokens
 

--- a/READMEs/datatokens-flow.md
+++ b/READMEs/datatokens-flow.md
@@ -50,7 +50,8 @@ python -m venv venv
 source venv/bin/activate
 
 #Install the ocean.py library. Install wheel first to avoid errors.
-pip install wheel ocean-lib
+pip install wheel
+pip install ocean-lib
 
 #set envvars
 export TEST_PRIVATE_KEY1=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58

--- a/READMEs/marketplace-flow.md
+++ b/READMEs/marketplace-flow.md
@@ -72,8 +72,11 @@ python -m venv venv
 source venv/bin/activate
 
 #Install the ocean.py library
-pip install ocean-lib
+pip install wheel ocean-lib
 ```
+
+NOTE: `wheel` is not strictly necessary, but installing it first eliminates
+benign error messages that occur while installing `ocean-lib`.
 
 ### Set up contracts
 

--- a/READMEs/marketplace-flow.md
+++ b/READMEs/marketplace-flow.md
@@ -72,7 +72,8 @@ python -m venv venv
 source venv/bin/activate
 
 #Install the ocean.py library. Install wheel first to avoid errors.
-pip install wheel ocean-lib
+pip install wheel
+pip install ocean-lib
 ```
 
 ### Set up contracts

--- a/READMEs/marketplace-flow.md
+++ b/READMEs/marketplace-flow.md
@@ -71,12 +71,9 @@ cd test3
 python -m venv venv
 source venv/bin/activate
 
-#Install the ocean.py library
+#Install the ocean.py library. Install wheel first to avoid errors.
 pip install wheel ocean-lib
 ```
-
-NOTE: `wheel` is not strictly necessary, but installing it first eliminates
-benign error messages that occur while installing `ocean-lib`.
 
 ### Set up contracts
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ install_requirements = [
     "tqdm",
     "pytz",
     "web3==5.19.0",
-    "wheel",
     "cryptography==3.3.2",
     "scipy",
     "enforce-typing==1.0.0.post1"


### PR DESCRIPTION
Towards https://github.com/oceanprotocol/ocean.py/issues/345#issuecomment-863375587

Changes proposed in this PR:

- Install wheel before ocean-lib in all the READMEs
- Remove wheel from install_requirements because (1) it's not strictly required and (2) installing it like this doesn't fix the errors.