### PR TITLE
SignHash deprecation

### DIFF
--- a/ocean_lib/data_provider/data_service_provider.py
+++ b/ocean_lib/data_provider/data_service_provider.py
@@ -93,7 +93,7 @@ class DataServiceProvider:
         if nonce is None:
             nonce = DataServiceProvider.get_nonce(wallet.address, provider_uri)
         print(f"signing message with nonce {nonce}: {msg}, account={wallet.address}")
-        return sign_hash(encode_defunct(f"{msg}{nonce}"), wallet)
+        return sign_hash(encode_defunct(text=f"{msg}{nonce}"), wallet)
 
     @staticmethod
     def get_nonce(user_address, provider_uri):

--- a/ocean_lib/data_provider/data_service_provider.py
+++ b/ocean_lib/data_provider/data_service_provider.py
@@ -13,13 +13,13 @@ from json import JSONDecodeError
 
 import requests
 from enforce_typing import enforce_types
+from eth_account.messages import encode_defunct
 from ocean_lib.common.agreements.service_types import ServiceTypes
 from ocean_lib.common.http_requests.requests_session import get_requests_session
 from ocean_lib.exceptions import OceanEncryptAssetUrlsError
 from ocean_lib.models.algorithm_metadata import AlgorithmMetadata
 from ocean_lib.ocean.env_constants import ENV_PROVIDER_API_VERSION
 from ocean_lib.web3_internal.transactions import sign_hash
-from ocean_lib.web3_internal.utils import add_ethereum_prefix_and_hash_msg
 from requests.exceptions import InvalidURL
 
 logger = logging.getLogger(__name__)
@@ -93,7 +93,7 @@ class DataServiceProvider:
         if nonce is None:
             nonce = DataServiceProvider.get_nonce(wallet.address, provider_uri)
         print(f"signing message with nonce {nonce}: {msg}, account={wallet.address}")
-        return sign_hash(add_ethereum_prefix_and_hash_msg(f"{msg}{nonce}"), wallet)
+        return sign_hash(encode_defunct(f"{msg}{nonce}"), wallet)
 
     @staticmethod
     def get_nonce(user_address, provider_uri):

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -11,6 +11,7 @@ import os
 from typing import Optional
 
 from enforce_typing import enforce_types
+from eth_account.messages import encode_defunct
 from eth_utils import add_0x_prefix, remove_0x_prefix
 from ocean_lib.assets.asset import Asset
 from ocean_lib.assets.asset_downloader import download_asset_files
@@ -43,10 +44,7 @@ from ocean_lib.models.metadata import MetadataContract
 from ocean_lib.ocean.util import to_base_18
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.transactions import sign_hash
-from ocean_lib.web3_internal.utils import (
-    add_ethereum_prefix_and_hash_msg,
-    get_network_name,
-)
+from ocean_lib.web3_internal.utils import get_network_name
 from ocean_lib.web3_internal.wallet import Wallet
 from ocean_lib.web3_internal.web3_provider import Web3Provider
 
@@ -279,7 +277,7 @@ class OceanAssets:
             asset.add_service(compute_service)
 
         asset.proof["signatureValue"] = sign_hash(
-            add_ethereum_prefix_and_hash_msg(asset.asset_id), publisher_wallet
+            encode_defunct(asset.asset_id), publisher_wallet
         )
 
         # Add public key and authentication

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -277,7 +277,7 @@ class OceanAssets:
             asset.add_service(compute_service)
 
         asset.proof["signatureValue"] = sign_hash(
-            encode_defunct(asset.asset_id), publisher_wallet
+            encode_defunct(text=asset.asset_id), publisher_wallet
         )
 
         # Add public key and authentication

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -6,6 +6,7 @@ import logging
 from typing import Optional
 
 from enforce_typing import enforce_types
+from eth_account.messages import encode_defunct
 from ocean_lib.assets.asset_resolver import resolve_asset
 from ocean_lib.assets.utils import create_publisher_trusted_algorithms
 from ocean_lib.common.agreements.consumable import AssetNotConsumable, ConsumableCodes
@@ -16,7 +17,6 @@ from ocean_lib.config import Config
 from ocean_lib.models.algorithm_metadata import AlgorithmMetadata
 from ocean_lib.models.compute_input import ComputeInput
 from ocean_lib.web3_internal.transactions import sign_hash
-from ocean_lib.web3_internal.utils import add_ethereum_prefix_and_hash_msg
 from ocean_lib.web3_internal.wallet import Wallet
 
 logger = logging.getLogger("ocean")
@@ -232,7 +232,7 @@ class OceanCompute:
         if nonce is None:
             uri = self._data_provider.get_root_uri(service_endpoint)
             nonce = self._data_provider.get_nonce(wallet.address, uri)
-        return sign_hash(add_ethereum_prefix_and_hash_msg(f"{msg}{nonce}"), wallet)
+        return sign_hash(encode_defunct(f"{msg}{nonce}"), wallet)
 
     def start(
         self,

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -232,7 +232,7 @@ class OceanCompute:
         if nonce is None:
             uri = self._data_provider.get_root_uri(service_endpoint)
             nonce = self._data_provider.get_nonce(wallet.address, uri)
-        return sign_hash(encode_defunct(f"{msg}{nonce}"), wallet)
+        return sign_hash(encode_defunct(text=f"{msg}{nonce}"), wallet)
 
     def start(
         self,

--- a/ocean_lib/web3_internal/test/test_wallet.py
+++ b/ocean_lib/web3_internal/test/test_wallet.py
@@ -21,7 +21,7 @@ def test_wallet_arguments():
     wallet = Wallet(web3, private_key=private_key)
     assert wallet.private_key == private_key, "Private keys are different."
     assert wallet.address, "The wallet does not have a wallet address."
-    signed_message = wallet.sign(encode_defunct("msg-to-sign"))
+    signed_message = wallet.sign(encode_defunct(text="msg-to-sign"))
     assert signed_message, "Signed message is None."
 
     # Create wallet with encrypted key and password
@@ -30,7 +30,7 @@ def test_wallet_arguments():
     w2 = Wallet(web3, encrypted_key=encrypted_key, password=password)
     assert w2.address == wallet.address
     assert w2.private_key == wallet.private_key
-    assert w2.sign(encode_defunct("msg-to-sign")) == signed_message
+    assert w2.sign(encode_defunct(text="msg-to-sign")) == signed_message
 
     # create wallet with missing arguments
     with pytest.raises(AssertionError):

--- a/ocean_lib/web3_internal/test/test_wallet.py
+++ b/ocean_lib/web3_internal/test/test_wallet.py
@@ -5,7 +5,7 @@
 import os
 
 import pytest
-from ocean_lib.web3_internal.utils import add_ethereum_prefix_and_hash_msg
+from eth_account.messages import encode_defunct
 from ocean_lib.web3_internal.wallet import Wallet
 from ocean_lib.web3_internal.web3_provider import Web3Provider
 
@@ -21,7 +21,7 @@ def test_wallet_arguments():
     wallet = Wallet(web3, private_key=private_key)
     assert wallet.private_key == private_key, "Private keys are different."
     assert wallet.address, "The wallet does not have a wallet address."
-    signed_message = wallet.sign(add_ethereum_prefix_and_hash_msg("msg-to-sign"))
+    signed_message = wallet.sign(encode_defunct("msg-to-sign"))
     assert signed_message, "Signed message is None."
 
     # Create wallet with encrypted key and password
@@ -30,7 +30,7 @@ def test_wallet_arguments():
     w2 = Wallet(web3, encrypted_key=encrypted_key, password=password)
     assert w2.address == wallet.address
     assert w2.private_key == wallet.private_key
-    assert w2.sign(add_ethereum_prefix_and_hash_msg("msg-to-sign")) == signed_message
+    assert w2.sign(encode_defunct("msg-to-sign")) == signed_message
 
     # create wallet with missing arguments
     with pytest.raises(AssertionError):

--- a/ocean_lib/web3_internal/utils.py
+++ b/ocean_lib/web3_internal/utils.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 from decimal import Decimal
 
 from enforce_typing import enforce_types
+from eth_account.messages import encode_defunct
 from eth_keys import keys
 from eth_utils import big_endian_to_int, decode_hex
 from ocean_lib.web3_internal.constants import DEFAULT_NETWORK_NAME, NETWORK_NAME_MAP
@@ -41,17 +42,6 @@ def prepare_prefixed_hash(msg_hash):
     return generate_multi_value_hash(
         ["string", "bytes32"], ["\x19Ethereum Signed Message:\n32", msg_hash]
     )
-
-
-def add_ethereum_prefix_and_hash_msg(text):
-    """
-    This method of adding the ethereum prefix seems to be used in web3.personal.sign/ecRecover.
-
-    :param text: str any str to be signed / used in recovering address from a signature
-    :return: hash of prefixed text according to the recommended ethereum prefix
-    """
-    prefixed_msg = f"\x19Ethereum Signed Message:\n{len(text)}{text}"
-    return Web3Provider.get_web3().keccak(text=prefixed_msg)
 
 
 def to_32byte_hex(web3, val):
@@ -141,7 +131,7 @@ def ec_recover(message, signed_message):
 
 @enforce_types
 def personal_ec_recover(message, signed_message):
-    prefixed_hash = add_ethereum_prefix_and_hash_msg(message)
+    prefixed_hash = encode_defunct(message)
     return ec_recover(prefixed_hash, signed_message)
 
 

--- a/ocean_lib/web3_internal/utils.py
+++ b/ocean_lib/web3_internal/utils.py
@@ -131,7 +131,7 @@ def ec_recover(message, signed_message):
 
 @enforce_types
 def personal_ec_recover(message, signed_message):
-    prefixed_hash = encode_defunct(message)
+    prefixed_hash = encode_defunct(text=message)
     return ec_recover(prefixed_hash, signed_message)
 
 

--- a/ocean_lib/web3_internal/wallet.py
+++ b/ocean_lib/web3_internal/wallet.py
@@ -151,7 +151,7 @@ class Wallet:
     def sign(self, msg_hash):
         """Sign a transaction."""
         account = self._web3.eth.account.from_key(self.private_key)
-        return account.signHash(msg_hash)
+        return account.sign_message(msg_hash)
 
     def keys_str(self):
         s = []


### PR DESCRIPTION
Closes #351.

See reasons for deprecation here: https://github.com/ethereum/eth-account/issues/85
I agree that we should offer a safe environment, without hash signing. I also took this issue because I was able to work on it independently and it does not affect others.