### PR TITLE
Remove abi_path parameter from ContractBase class.

### DIFF
--- a/ocean_lib/models/test/conftest.py
+++ b/ocean_lib/models/test/conftest.py
@@ -167,7 +167,6 @@ def _deployAndMintToken(web3: Web3, symbol: str, to_address: str) -> btoken.BTok
     dt_address = DataToken.deploy(
         web3,
         wallet,
-        None,
         "Template Contract",
         "TEMPLATE",
         wallet.address,
@@ -175,9 +174,7 @@ def _deployAndMintToken(web3: Web3, symbol: str, to_address: str) -> btoken.BTok
         DTFactory.FIRST_BLOB,
         to_address,
     )
-    dt_factory = DTFactory(
-        web3, DTFactory.deploy(web3, wallet, None, dt_address, to_address)
-    )
+    dt_factory = DTFactory(web3, DTFactory.deploy(web3, wallet, dt_address, to_address))
     token_address = dt_factory.get_token_address(
         dt_factory.createToken(
             symbol, symbol, symbol, DataToken.DEFAULT_CAP_BASE, wallet

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -245,7 +245,7 @@ class ContractBase(object):
             return event().argument_names
 
     @classmethod
-    def deploy(cls, web3: Web3, deployer_wallet: Wallet, *args):
+    def deploy(cls, web3: Web3, deployer_wallet: Wallet, abi_path: str = "", *args):
         """
         Deploy the DataTokenTemplate and DTFactory contracts to the current network.
 
@@ -254,8 +254,8 @@ class ContractBase(object):
 
         :return: smartcontract address of this contract
         """
-
-        abi_path = get_artifacts_path()
+        if not abi_path:
+            abi_path = get_artifacts_path()
 
         assert abi_path, f"abi_path is required, got {abi_path}"
 

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -39,18 +39,11 @@ class ContractBase(object):
     CONTRACT_NAME = None
 
     def __init__(self, web3: Web3, address: Optional[str]):
-        """Initialises Contract Base object.
-
-        The contract name attribute and `abi_path` are required.
-        """
+        """Initialises Contract Base object."""
         self.name = self.contract_name
         assert (
             self.name
         ), "contract_name property needs to be implemented in subclasses."
-
-        abi_path = get_artifacts_path()
-
-        assert abi_path, f"abi_path is required, got {abi_path}"
 
         self.web3 = web3
         self.contract = load_contract(self.web3, self.name, address)
@@ -245,7 +238,7 @@ class ContractBase(object):
             return event().argument_names
 
     @classmethod
-    def deploy(cls, web3: Web3, deployer_wallet: Wallet, abi_path: str = "", *args):
+    def deploy(cls, web3: Web3, deployer_wallet: Wallet, *args):
         """
         Deploy the DataTokenTemplate and DTFactory contracts to the current network.
 
@@ -254,10 +247,6 @@ class ContractBase(object):
 
         :return: smartcontract address of this contract
         """
-        if not abi_path:
-            abi_path = get_artifacts_path()
-
-        assert abi_path, f"abi_path is required, got {abi_path}"
 
         _json = get_contract_definition(cls.CONTRACT_NAME)
 

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -38,7 +38,7 @@ class ContractBase(object):
 
     CONTRACT_NAME = None
 
-    def __init__(self, web3: Web3, address: Optional[str], abi_path=None):
+    def __init__(self, web3: Web3, address: Optional[str]):
         """Initialises Contract Base object.
 
         The contract name attribute and `abi_path` are required.
@@ -47,8 +47,8 @@ class ContractBase(object):
         assert (
             self.name
         ), "contract_name property needs to be implemented in subclasses."
-        if not abi_path:
-            abi_path = get_artifacts_path()
+
+        abi_path = get_artifacts_path()
 
         assert abi_path, f"abi_path is required, got {abi_path}"
 
@@ -245,18 +245,17 @@ class ContractBase(object):
             return event().argument_names
 
     @classmethod
-    def deploy(cls, web3: Web3, deployer_wallet: Wallet, abi_path: str = "", *args):
+    def deploy(cls, web3: Web3, deployer_wallet: Wallet, *args):
         """
         Deploy the DataTokenTemplate and DTFactory contracts to the current network.
 
         :param web3:
-        :param abi_path:
         :param deployer_wallet: Wallet instance
 
         :return: smartcontract address of this contract
         """
-        if not abi_path:
-            abi_path = get_artifacts_path()
+
+        abi_path = get_artifacts_path()
 
         assert abi_path, f"abi_path is required, got {abi_path}"
 


### PR DESCRIPTION
Fixes #360  .

Changes proposed in this PR:

- remove `abi_path` parameter from `contract_base`.