### PR TITLE
Fix code and logic duplication in event retrieval

### DIFF
--- a/ocean_lib/models/bpool.py
+++ b/ocean_lib/models/bpool.py
@@ -12,7 +12,8 @@ from ocean_lib.ocean import util
 from ocean_lib.web3_internal.wallet import Wallet
 from web3.main import Web3
 
-from .btoken import BToken
+from ocean_lib.models.btoken import BToken
+from ocean_lib.web3_internal.contract_base import ContractBase
 
 logger = logging.getLogger(__name__)
 
@@ -596,7 +597,6 @@ class BPool(BToken):
         topic0 = self.get_event_signature(event_name)
         to_block = to_block or "latest"
         topics = [topic0]
-        address = self.address if this_pool_only else None
 
         if user_address:
             assert Web3.isChecksumAddress(user_address)
@@ -605,8 +605,12 @@ class BPool(BToken):
             )
         event = getattr(self.events, event_name)
         argument_filters = {"topics": topics}
-        logs = event.getLogs(
-            argument_filters=argument_filters, fromBlock=from_block, toBlock=to_block
+        logs = ContractBase.getLogs(
+            event(),
+            argument_filters=argument_filters,
+            fromBlock=from_block,
+            toBlock=to_block,
+            from_all_addresses=this_pool_only,
         )
         return logs
 

--- a/ocean_lib/models/bpool.py
+++ b/ocean_lib/models/bpool.py
@@ -10,11 +10,9 @@ from eth_utils import remove_0x_prefix
 from ocean_lib.models import balancer_constants
 from ocean_lib.ocean import util
 from ocean_lib.web3_internal.wallet import Wallet
-from web3._utils.events import get_event_data
 from web3.main import Web3
 
 from .btoken import BToken
-from ..web3_internal.event_filter import EventFilter
 
 logger = logging.getLogger(__name__)
 
@@ -590,7 +588,7 @@ class BPool(BToken):
         from_block,
         to_block=None,
         user_address=None,
-        this_pool_only=True,
+        this_pool_only=False,
     ):
         """
         :param event_name: str, one of LOG_JOIN, LOG_EXIT, LOG_SWAP
@@ -606,32 +604,23 @@ class BPool(BToken):
                 f"0x000000000000000000000000{remove_0x_prefix(user_address).lower()}"
             )
         event = getattr(self.events, event_name)
-        event_filter = EventFilter(
-            event=event,
-            from_block=from_block,
-            to_block=to_block,
-            topics=topics,
-            address=address,
+        argument_filters = {"topics": topics}
+        logs = event.getLogs(
+            argument_filters=argument_filters, fromBlock=from_block, toBlock=to_block
         )
-        return event_filter.get_all_entries()
+        return logs
 
-    def get_join_logs(
-        self, from_block, to_block=None, user_address=None, this_pool_only=True
-    ):
+    def get_join_logs(self, from_block, to_block=None, user_address=None):
         return self.get_liquidity_logs(
-            "LOG_JOIN", from_block, to_block, user_address, this_pool_only
+            "LOG_JOIN", from_block, to_block, user_address, False
         )
 
-    def get_exit_logs(
-        self, from_block, to_block=None, user_address=None, this_pool_only=True
-    ):
+    def get_exit_logs(self, from_block, to_block=None, user_address=None):
         return self.get_liquidity_logs(
-            "LOG_EXIT", from_block, to_block, user_address, this_pool_only
+            "LOG_EXIT", from_block, to_block, user_address, False
         )
 
-    def get_swap_logs(
-        self, from_block, to_block=None, user_address=None, this_pool_only=True
-    ):
+    def get_swap_logs(self, from_block, to_block=None, user_address=None):
         return self.get_liquidity_logs(
-            "LOG_SWAP", from_block, to_block, user_address, this_pool_only
+            "LOG_SWAP", from_block, to_block, user_address, False
         )

--- a/ocean_lib/models/bpool.py
+++ b/ocean_lib/models/bpool.py
@@ -589,7 +589,7 @@ class BPool(BToken):
         from_block,
         to_block=None,
         user_address=None,
-        this_pool_only=False,
+        this_pool_only=True,
     ):
         """
         :param event_name: str, one of LOG_JOIN, LOG_EXIT, LOG_SWAP
@@ -610,21 +610,27 @@ class BPool(BToken):
             argument_filters=argument_filters,
             fromBlock=from_block,
             toBlock=to_block,
-            from_all_addresses=this_pool_only,
+            from_all_addresses=not this_pool_only,
         )
         return logs
 
-    def get_join_logs(self, from_block, to_block=None, user_address=None):
+    def get_join_logs(
+        self, from_block, to_block=None, user_address=None, this_pool_only=True
+    ):
         return self.get_liquidity_logs(
-            "LOG_JOIN", from_block, to_block, user_address, False
+            "LOG_JOIN", from_block, to_block, user_address, this_pool_only
         )
 
-    def get_exit_logs(self, from_block, to_block=None, user_address=None):
+    def get_exit_logs(
+        self, from_block, to_block=None, user_address=None, this_pool_only=True
+    ):
         return self.get_liquidity_logs(
-            "LOG_EXIT", from_block, to_block, user_address, False
+            "LOG_EXIT", from_block, to_block, user_address, this_pool_only
         )
 
-    def get_swap_logs(self, from_block, to_block=None, user_address=None):
+    def get_swap_logs(
+        self, from_block, to_block=None, user_address=None, this_pool_only=True
+    ):
         return self.get_liquidity_logs(
-            "LOG_SWAP", from_block, to_block, user_address, False
+            "LOG_SWAP", from_block, to_block, user_address, this_pool_only
         )

--- a/ocean_lib/models/data_token.py
+++ b/ocean_lib/models/data_token.py
@@ -20,7 +20,6 @@ from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.event_filter import EventFilter
 from ocean_lib.web3_internal.wallet import Wallet
 from web3 import Web3
-from web3._utils.events import get_event_data
 from web3.exceptions import MismatchedABI
 from websockets import ConnectionClosed
 
@@ -250,14 +249,12 @@ class DataToken(ContractBase):
 
     def get_transfer_event(self, block_number, sender, receiver):
         filter_params = {"from": sender, "to": receiver}
-        event_filter = EventFilter(
-            self.events.Transfer,
-            argument_filters=filter_params,
+        logs = self.get_event_logs(
+            "Transfer",
+            filter_args=filter_params,
             from_block=block_number - 1,
             to_block=block_number + 10,
         )
-
-        logs = event_filter.get_all_entries(max_tries=10)
         if not logs:
             return None
 
@@ -318,14 +315,9 @@ class DataToken(ContractBase):
     ):
         event = getattr(self.events, event_name)
         filter_params = filter_args or {}
-        event_filter = EventFilter(
-            event,
-            argument_filters=filter_params,
-            from_block=from_block,
-            to_block=to_block,
+        logs = event.getLogs(
+            argument_filters=filter_params, fromBlock=from_block, toBlock=to_block
         )
-
-        logs = event_filter.get_all_entries(max_tries=10)
         return logs
 
     def verify_order_tx(self, tx_id, did, service_id, amount_base, sender):

--- a/ocean_lib/models/data_token.py
+++ b/ocean_lib/models/data_token.py
@@ -189,18 +189,17 @@ class DataToken(ContractBase):
         if consumer_address:
             topic1 = f"0x000000000000000000000000{consumer_address[2:].lower()}"
             topics = [topic0, None, topic1]
+        address = self.address if not from_all_tokens else None
 
-        filter_params = {"fromBlock": from_block, "toBlock": to_block, "topics": topics}
-        if not from_all_tokens:
-            # get logs only for this token address
-            filter_params["address"] = self.address
-
-        event_abi = self.events.OrderStarted().abi
-        logs = self.web3.eth.get_logs(filter_params)
-        parsed_logs = []
-        for lg in logs:
-            parsed_logs.append(get_event_data(self.web3.codec, event_abi, lg))
-        return parsed_logs
+        event_filter = EventFilter(
+            event=self.events.OrderStarted(),
+            from_block=from_block,
+            to_block=to_block,
+            topics=topics,
+            address=address,
+        )
+        logs = event_filter.get_all_entries()
+        return logs
 
     def get_transfer_events_in_range(self, from_block, to_block):
         return self.getLogs(
@@ -252,9 +251,8 @@ class DataToken(ContractBase):
     def get_transfer_event(self, block_number, sender, receiver):
         filter_params = {"from": sender, "to": receiver}
         event_filter = EventFilter(
-            "Transfer",
             self.events.Transfer,
-            filter_params,
+            argument_filters=filter_params,
             from_block=block_number - 1,
             to_block=block_number + 10,
         )
@@ -321,13 +319,13 @@ class DataToken(ContractBase):
         event = getattr(self.events, event_name)
         filter_params = filter_args or {}
         event_filter = EventFilter(
-            event_name, event, filter_params, from_block=from_block, to_block=to_block
+            event,
+            argument_filters=filter_params,
+            from_block=from_block,
+            to_block=to_block,
         )
 
         logs = event_filter.get_all_entries(max_tries=10)
-        if not logs:
-            return []
-
         return logs
 
     def verify_order_tx(self, tx_id, did, service_id, amount_base, sender):

--- a/ocean_lib/models/dtfactory.py
+++ b/ocean_lib/models/dtfactory.py
@@ -18,24 +18,19 @@ class DTFactory(ContractBase):
 
     def verify_data_token(self, dt_address):
         """Checks that a token was registered."""
-        filter_params = {"tokenAddress": dt_address}
-        logs = ContractBase.getLogs(
-            self.events.TokenRegistered(),
-            argument_filters=filter_params,
-            fromBlock=0,
-            toBlock=999,
+        log = self.get_token_registered_event(
+            from_block=0, to_block=self.web3.eth.block_number, token_address=dt_address
         )
-
-        return logs and logs[0].args.tokenAddress == dt_address
+        return log and log.args.tokenAddress == dt_address
 
     def get_token_registered_event(self, from_block, to_block, token_address):
         """Retrieves event log of token registration."""
         filter_params = {"tokenAddress": token_address}
-        logs = ContractBase.getLogs(
-            self.events.TokenRegistered(),
-            argument_filters=filter_params,
-            fromBlock=from_block,
-            toBlock=to_block,
+        logs = self.get_event_log(
+            "TokenRegistered",
+            from_block=from_block,
+            to_block=to_block,
+            filters=filter_params,
         )
 
         return logs[0] if logs else None

--- a/ocean_lib/models/dtfactory.py
+++ b/ocean_lib/models/dtfactory.py
@@ -20,7 +20,10 @@ class DTFactory(ContractBase):
         """Checks that a token was registered."""
         filter_params = {"tokenAddress": dt_address}
         logs = ContractBase.getLogs(
-            self.events.TokenRegistered(), argument_filters=filter_params, fromBlock=0
+            self.events.TokenRegistered(),
+            argument_filters=filter_params,
+            fromBlock=0,
+            toBlock=999,
         )
 
         return logs and logs[0].args.tokenAddress == dt_address

--- a/ocean_lib/models/dtfactory.py
+++ b/ocean_lib/models/dtfactory.py
@@ -19,21 +19,21 @@ class DTFactory(ContractBase):
     def verify_data_token(self, dt_address):
         """Checks that a token was registered."""
         filter_params = {"tokenAddress": dt_address}
-        event_filter = self.events.TokenRegistered().createFilter(
-            fromBlock=0, argument_filters=filter_params
+        logs = ContractBase.getLogs(
+            self.events.TokenRegistered(), argument_filters=filter_params, fromBlock=0
         )
-        logs = event_filter.get_all_entries()
 
         return logs and logs[0].args.tokenAddress == dt_address
 
     def get_token_registered_event(self, from_block, to_block, token_address):
         """Retrieves event log of token registration."""
         filter_params = {"tokenAddress": token_address}
-
-        event_filter = self.events.TokenRegistered().createFilter(
-            fromBlock=from_block, toBlock=to_block, argument_filters=filter_params
+        logs = ContractBase.getLogs(
+            self.events.TokenRegistered(),
+            argument_filters=filter_params,
+            fromBlock=from_block,
+            toBlock=to_block,
         )
-        logs = event_filter.get_all_entries()
 
         return logs[0] if logs else None
 

--- a/ocean_lib/models/metadata.py
+++ b/ocean_lib/models/metadata.py
@@ -27,10 +27,10 @@ class MetadataContract(ContractBase):
     def get_event_log(self, event_name, block, did, timeout=45):
         did = remove_0x_prefix(did)
         start = time.time()
-        f = getattr(self.events, event_name)().createFilter(fromBlock=block)
+        event = getattr(self.events, event_name)
         logs = []
         while not logs:
-            logs = f.get_all_entries()
+            logs = ContractBase.getLogs(event(), fromBlock=block)
             if not logs:
                 time.sleep(0.2)
 

--- a/ocean_lib/models/test/test_datatoken.py
+++ b/ocean_lib/models/test/test_datatoken.py
@@ -178,14 +178,20 @@ def test_transfer_event(
     )
 
     block = alice_ocean.web3.eth.block_number
+    # different way of retrieving
     transfer_events = token.get_event_logs("Transfer", None, block, block)
-    assert transfer_events == []
+    assert transfer_events == ()
 
     token.mint(alice_address, to_base_18(100.0), from_wallet=alice_wallet)
     token.approve(bob_address, to_base_18(1.0), from_wallet=alice_wallet)
     token.transfer(bob_address, to_base_18(5.0), from_wallet=alice_wallet)
 
     block = alice_ocean.web3.eth.block_number
+    transfer_event = token.get_transfer_event(block, alice_address, bob_address)
+    assert transfer_event["args"]["from"] == alice_address
+    assert transfer_event["args"]["to"] == bob_address
+
+    # same transfer event, different way of retrieving
     transfer_event = token.get_event_logs("Transfer", None, block, block)[0]
     assert transfer_event["args"]["from"] == alice_address
     assert transfer_event["args"]["to"] == bob_address

--- a/ocean_lib/models/test/test_datatoken.py
+++ b/ocean_lib/models/test/test_datatoken.py
@@ -178,6 +178,7 @@ def test_transfer_event(
     )
 
     block = alice_ocean.web3.eth.block_number
+    transfer_event = token.get_transfer_event(block, alice_address, bob_address)
     # different way of retrieving
     transfer_events = token.get_event_logs("Transfer", None, block, block)
     assert transfer_events == ()

--- a/ocean_lib/models/test/test_datatoken.py
+++ b/ocean_lib/models/test/test_datatoken.py
@@ -178,8 +178,6 @@ def test_transfer_event(
     )
 
     block = alice_ocean.web3.eth.block_number
-    transfer_event = token.get_transfer_event(block, alice_address, bob_address)
-    # different way of retrieving
     transfer_events = token.get_event_logs("Transfer", None, block, block)
     assert transfer_events == []
 
@@ -188,11 +186,6 @@ def test_transfer_event(
     token.transfer(bob_address, to_base_18(5.0), from_wallet=alice_wallet)
 
     block = alice_ocean.web3.eth.block_number
-    transfer_event = token.get_transfer_event(block, alice_address, bob_address)
-    assert transfer_event["args"]["from"] == alice_address
-    assert transfer_event["args"]["to"] == bob_address
-
-    # same transfer event, different way of retrieving
     transfer_event = token.get_event_logs("Transfer", None, block, block)[0]
     assert transfer_event["args"]["from"] == alice_address
     assert transfer_event["args"]["to"] == bob_address

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -295,9 +295,6 @@ class ContractBase(object):
                 )
                 all_logs.extend(logs)
                 if len(all_logs) >= 1:
-                    import pdb
-
-                    pdb.set_trace()
                     break
                 _to = _from - 1
                 _from = max(_to - chunk + 1, from_block)

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -12,6 +12,8 @@ import requests
 from enforce_typing import enforce_types
 from eth_typing import BlockIdentifier
 from hexbytes import HexBytes
+from web3.contract import ContractEvent
+
 from ocean_lib.web3_internal.constants import ENV_GAS_PRICE
 from ocean_lib.web3_internal.contract_utils import (
     get_contract_definition,
@@ -329,7 +331,7 @@ class ContractBase(object):
 
     @staticmethod
     def getLogs(
-        event,
+        event: ContractEvent,
         argument_filters: Optional[Dict[str, Any]] = None,
         fromBlock: Optional[BlockIdentifier] = None,
         toBlock: Optional[BlockIdentifier] = None,
@@ -377,6 +379,7 @@ class ContractBase(object):
         ```
 
         See also: :func:`web3.middleware.filter.local_filter_middleware`.
+        :param event: the ContractEvent instance with a web3 instance
         :param argument_filters:
         :param fromBlock: block number or "latest", defaults to "latest"
         :param toBlock: block number or "latest". Defaults to "latest"
@@ -408,23 +411,14 @@ class ContractBase(object):
         # Construct JSON-RPC raw filter presentation based on human readable Python descriptions
         # Namely, convert event names to their keccak signatures
         address = event.address if not from_all_addresses else None
-        if address:
-            _, event_filter_params = construct_event_filter_params(
-                abi,
-                event.web3.codec,
-                contract_address=address,
-                argument_filters=_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-            )
-        else:
-            _, event_filter_params = construct_event_filter_params(
-                abi,
-                event.web3.codec,
-                argument_filters=_filters,
-                fromBlock=fromBlock,
-                toBlock=toBlock,
-            )
+        _, event_filter_params = construct_event_filter_params(
+            abi,
+            event.web3.codec,
+            contract_address=address,
+            argument_filters=_filters,
+            fromBlock=fromBlock,
+            toBlock=toBlock,
+        )
 
         if blockHash is not None:
             event_filter_params["blockHash"] = blockHash

--- a/ocean_lib/web3_internal/event_filter.py
+++ b/ocean_lib/web3_internal/event_filter.py
@@ -14,12 +14,11 @@ class EventFilter:
     def __init__(
         self,
         event: ContractEvent,
+        argument_filters=None,
         from_block=None,
         to_block=None,
-        argument_filters=None,
         address=None,
         topics=None,
-        poll_interval=None,
     ):
         """Initialises EventFilter."""
         self.event = event
@@ -28,7 +27,6 @@ class EventFilter:
         self._filter = None
         self.address = address
         self.topics = topics
-        self._poll_interval = poll_interval if poll_interval else 0.5
         self._create_filter()
 
     @property
@@ -37,11 +35,6 @@ class EventFilter:
 
     def uninstall(self):
         self.event.web3.eth.uninstall_filter(self._filter.filter_id)
-
-    def set_poll_interval(self, interval):
-        self._poll_interval = interval
-        if self._filter and self._poll_interval is not None:
-            self._filter.poll_interval = self._poll_interval
 
     def recreate_filter(self):
         self._create_filter()
@@ -54,8 +47,6 @@ class EventFilter:
             topics=self.topics,
             argument_filters=self.argument_filters,
         )
-        if self._poll_interval is not None:
-            self._filter.poll_interval = self._poll_interval
 
     def get_new_entries(self, max_tries=1):
         return self._get_entries(self._filter.get_new_entries, max_tries=max_tries)

--- a/ocean_lib/web3_internal/event_listener.py
+++ b/ocean_lib/web3_internal/event_listener.py
@@ -37,7 +37,6 @@ class EventListener(object):
         self.from_block = from_block if from_block is not None else "latest"
         self.to_block = to_block if to_block is not None else "latest"
         self.event_filter = self.make_event_filter()
-        self.event_filter.poll_interval = 0.5
         self.timeout = 600  # seconds
         self.args = args
 
@@ -49,7 +48,6 @@ class EventListener(object):
             from_block=self.from_block,
             to_block=self.to_block,
         )
-        event_filter.set_poll_interval(0.5)
         return event_filter
 
     def listen_once(

--- a/ocean_lib/web3_internal/event_listener.py
+++ b/ocean_lib/web3_internal/event_listener.py
@@ -44,9 +44,8 @@ class EventListener(object):
     def make_event_filter(self):
         """Create a new event filter."""
         event_filter = EventFilter(
-            self.event_name,
             self.event,
-            self.filters,
+            argument_filters=self.filters,
             from_block=self.from_block,
             to_block=self.to_block,
         )

--- a/ocean_lib/web3_internal/test/test_contract_base.py
+++ b/ocean_lib/web3_internal/test/test_contract_base.py
@@ -70,11 +70,8 @@ def test_main(network, alice_wallet, alice_address, dtfactory_address, web3):
         len(factory.get_event_logs("TokenCreated", block, block, None)) == 1
     ), "The token was not created."
 
-    copy = factory.contract.address
-    factory.contract.address = None
     with pytest.raises(TypeError):
-        factory.getLogs("")
-    factory.contract.address = copy
+        ContractBase.getLogs(None)
 
 
 def test_static_functions(web3):

--- a/ocean_lib/web3_internal/test/test_contract_base.py
+++ b/ocean_lib/web3_internal/test/test_contract_base.py
@@ -69,6 +69,10 @@ def test_main(network, alice_wallet, alice_address, dtfactory_address, web3):
     assert (
         len(factory.get_event_logs("TokenCreated", block, block, None)) == 1
     ), "The token was not created."
+    log = factory.get_event_log("TokenCreated", block, block, None)
+    assert len(log) == 1, "The token was not created."
+    assert log[0]["event"] == "TokenCreated"
+    assert log[0]["address"] == dtfactory_address
 
     with pytest.raises(TypeError):
         ContractBase.getLogs(None)

--- a/ocean_lib/web3_internal/test/test_event_filter.py
+++ b/ocean_lib/web3_internal/test/test_event_filter.py
@@ -17,8 +17,7 @@ def test_transfer_event_filter(alice_ocean, alice_wallet, alice_address, bob_add
     token.transfer(bob_address, to_base_18(5.0), from_wallet=alice_wallet)
 
     block = alice_ocean.web3.eth.block_number
-    event = getattr(token.events, "Transfer")
-    event_filter = EventFilter("Transfer", event, None, block, block)
+    event_filter = EventFilter(token.events.Transfer, from_block=block, to_block=block)
 
     assert event_filter.filter_id, "Event filter ID is None."
 


### PR DESCRIPTION
Fixes #252  .

Changes proposed in this PR:

- used `EventFilter` class to retrieve the event logs;
- refactored `EventFilter` class;
- removed `get_transfer_event` function.