### PR TITLE
Fix bug where Ocean instance always uses development contract addresses (#376)

### DIFF
--- a/ocean_lib/models/test/test_bfactory.py
+++ b/ocean_lib/models/test/test_bfactory.py
@@ -9,7 +9,7 @@ from ocean_lib.ocean.util import get_bfactory_address
 
 def test_bpool_creation(web3, config, alice_wallet):
     """Test the creation of a Balancer Pool from BFactory (happy flow)."""
-    bfactory_address = get_bfactory_address(config.address_file)
+    bfactory_address = get_bfactory_address(config.address_file, web3=web3)
     bfactory = BFactory(web3, bfactory_address)
 
     pool_address = bfactory.newBPool(from_wallet=alice_wallet)

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -93,7 +93,7 @@ class Ocean:
         if not data_provider:
             data_provider = DataServiceProvider
 
-        network = get_network_name()
+        network = get_network_name(web3=self._web3)
         addresses = get_contracts_addresses(self._config.address_file, network)
         self.assets = OceanAssets(
             self._config,
@@ -113,9 +113,7 @@ class Ocean:
         self.exchange = OceanExchange(
             self._web3,
             ocean_address,
-            FixedRateExchange.configured_address(
-                network or get_network_name(), self._config.address_file
-            ),
+            FixedRateExchange.configured_address(network, self._config.address_file),
             self._config,
         )
 
@@ -134,7 +132,7 @@ class Ocean:
 
     @property
     def OCEAN_address(self):
-        return get_ocean_token_address(self.config.address_file, get_network_name())
+        return get_ocean_token_address(self.config.address_file, web3=self.web3)
 
     def create_data_token(
         self,
@@ -187,7 +185,7 @@ class Ocean:
         :return: `DTFactory` instance
         """
         dtf_address = dtfactory_address or DTFactory.configured_address(
-            get_network_name(), self._config.address_file
+            get_network_name(web3=self._web3), self._config.address_file
         )
         return DTFactory(self.web3, dtf_address)
 

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -203,7 +203,7 @@ class OceanAssets:
         #################
         # DataToken
         address = DTFactory.configured_address(
-            get_network_name(), self._config.address_file
+            get_network_name(web3=self._web3), self._config.address_file
         )
         dtfactory = DTFactory(self._web3, address)
         if not data_token_address:

--- a/ocean_lib/ocean/ocean_pool.py
+++ b/ocean_lib/ocean/ocean_pool.py
@@ -638,7 +638,7 @@ class OceanPool:
         current_block = to_block if to_block is not None else self.web3.eth.block_number
         pool = BPool(self.web3, pool_address)
         dt_address = token_address or self.get_token_address(pool_address, pool)
-        factory = DTFactory(self.web3, get_dtfactory_address())
+        factory = DTFactory(self.web3, get_dtfactory_address(web3=self.web3))
         if block_number is None:
             block_number = factory.get_token_registered_event(
                 0, current_block, token_address=dt_address

--- a/ocean_lib/ocean/test/test_ocean_pool.py
+++ b/ocean_lib/ocean/test/test_ocean_pool.py
@@ -9,7 +9,7 @@ from tests.resources.helper_functions import get_publisher_wallet
 
 def test_get_OCEAN_address(publisher_ocean_instance):
     """Tests OCEAN address retrieval."""
-    network = get_network_name()
+    network = get_network_name(web3=publisher_ocean_instance.web3)
     assert publisher_ocean_instance.pool.get_OCEAN_address() == get_ocean_token_address(
         publisher_ocean_instance.config.address_file, network
     )

--- a/ocean_lib/ocean/test/test_util.py
+++ b/ocean_lib/ocean/test/test_util.py
@@ -162,7 +162,7 @@ def test_get_dtfactory_address(config):
     assert isinstance(addresses, dict)
     assert "DTFactory" in addresses
 
-    address = get_dtfactory_address(config.address_file)
+    address = get_dtfactory_address(config.address_file, "ganache")
     assert address[:2] == "0x", "It is not a token address."
     assert address == addresses["DTFactory"]
 
@@ -173,7 +173,7 @@ def test_get_bfactory_address(config):
     assert isinstance(addresses, dict)
     assert "BFactory" in addresses
 
-    address = get_bfactory_address(config.address_file)
+    address = get_bfactory_address(config.address_file, "ganache")
     assert address[:2] == "0x", "It is not a token address."
     assert address == addresses["BFactory"]
 
@@ -184,6 +184,6 @@ def test_get_ocean_token_address(config):
     assert isinstance(addresses, dict)
     assert "Ocean" in addresses
 
-    address = get_ocean_token_address(config.address_file)
+    address = get_ocean_token_address(config.address_file, "ganache")
     assert address[:2] == "0x", "It is not a token address."
     assert address == addresses["Ocean"]

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -126,14 +126,29 @@ def from_base(num_base: int, dec: int) -> float:
     return float(num_base / (10 ** dec))
 
 
-def get_dtfactory_address(address_file, network=None):
-    return DTFactory.configured_address(network or get_network_name(), address_file)
+def get_dtfactory_address(address_file, network=None, web3=None):
+    """Returns the DTFactory address for given network or web3 instance
+    Requires either network name or web3 instance.
+    """
+    return DTFactory.configured_address(
+        network or get_network_name(web3=web3), address_file
+    )
 
 
-def get_bfactory_address(address_file, network=None):
-    return BFactory.configured_address(network or get_network_name(), address_file)
+def get_bfactory_address(address_file, network=None, web3=None):
+    """Returns the BFactory address for given network or web3 instance
+    Requires either network name or web3 instance.
+    """
+    return BFactory.configured_address(
+        network or get_network_name(web3=web3), address_file
+    )
 
 
-def get_ocean_token_address(address_file, network=None):
-    addresses = get_contracts_addresses(address_file, network or get_network_name())
+def get_ocean_token_address(address_file, network=None, web3=None):
+    """Returns the Ocean token address for given network or web3 instance
+    Requires either network name or web3 instance.
+    """
+    addresses = get_contracts_addresses(
+        address_file, network or get_network_name(web3=web3)
+    )
     return addresses.get("Ocean") if addresses else None

--- a/ocean_lib/web3_internal/test/test_utils.py
+++ b/ocean_lib/web3_internal/test/test_utils.py
@@ -5,7 +5,6 @@
 import os
 
 import pytest
-
 from ocean_lib.web3_internal.utils import (
     generate_multi_value_hash,
     get_network_id,
@@ -22,6 +21,7 @@ def test_get_network_name(web3):
     assert get_network_name(8996) == "ganache"
     assert get_network_name(web3=web3) == "ganache"
     assert get_network_name(-1) == "ganache"
+    assert get_network_name() == "ganache"
 
 
 def test_get_network_id(web3):


### PR DESCRIPTION
Fixes #376 

Changes proposed in this PR:

- Fix bug where Ocean instance always uses development contract addresses
- Several utility functions now require a web3 instance if a network name is not provided: get_dtfactory_address, get_bfactory_address, and get_ocean_token_address