### PR TITLE
Use chainId instead of networkId to lookup network name

### DIFF
--- a/ocean_lib/web3_internal/constants.py
+++ b/ocean_lib/web3_internal/constants.py
@@ -25,5 +25,5 @@ NETWORK_NAME_MAP = {
     42: "Kovan",
     100: "xDai",
     137: "Polygon",
-    8996: "Ganache",
+    1337: "Ganache",
 }

--- a/ocean_lib/web3_internal/test/test_utils.py
+++ b/ocean_lib/web3_internal/test/test_utils.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from ocean_lib.web3_internal.utils import (
     generate_multi_value_hash,
-    get_network_id,
+    get_chain_id,
     get_network_name,
     prepare_prefixed_hash,
 )
@@ -18,14 +18,14 @@ def test_get_network_name(web3):
     assert get_network_name(4) == "rinkeby"
     assert get_network_name(3) == "ropsten"
     assert get_network_name(137) == "polygon"
-    assert get_network_name(8996) == "ganache"
+    assert get_network_name(1337) == "ganache"
     assert get_network_name(web3=web3) == "ganache"
     assert get_network_name(-1) == "ganache"
     assert get_network_name() == "ganache"
 
 
-def test_get_network_id(web3):
-    assert get_network_id(web3) == 8996
+def test_get_chain_id(web3):
+    assert get_chain_id(web3) == 1337
 
 
 def test_generate_multi_value_hash(alice_address, alice_private_key):

--- a/ocean_lib/web3_internal/utils.py
+++ b/ocean_lib/web3_internal/utils.py
@@ -90,33 +90,33 @@ def private_key_to_public_key(private_key: str) -> str:
 
 @enforce_types
 def get_network_name(
-    network_id: Optional[int] = None, web3: Optional[Web3] = None
+    chain_id: Optional[int] = None, web3: Optional[Web3] = None
 ) -> str:
     """
-    Return the network name based on the current ethereum network id.
+    Return the network name based on the current ethereum chain id.
 
-    Return `ganache` for every network id that is not mapped.
+    Return `ganache` for every chain id that is not mapped.
 
-    :param network_id: Network id, int
+    :param chain_id: Chain id, int
     :param web3: Web3 instance
     """
-    if not network_id:
+    if not chain_id:
         if not web3:
             return DEFAULT_NETWORK_NAME.lower()
         else:
-            network_id = get_network_id(web3)
-    return NETWORK_NAME_MAP.get(network_id, DEFAULT_NETWORK_NAME).lower()
+            chain_id = get_chain_id(web3)
+    return NETWORK_NAME_MAP.get(chain_id, DEFAULT_NETWORK_NAME).lower()
 
 
 @enforce_types
-def get_network_id(web3: Web3) -> int:
+def get_chain_id(web3: Web3) -> int:
     """
-    Return the ethereum network id calling the `web3.net.network` method.
+    Return the ethereum chain id calling the `web3.eth.chain_id` method.
 
     :param web3: Web3 instance
-    :return: Network id, int
+    :return: Chain id, int
     """
-    return int(web3.net.version)
+    return int(web3.eth.chain_id)
 
 
 @enforce_types


### PR DESCRIPTION

Fixes #370  .

Changes proposed in this PR:

- replace the occurrences of `web3.net.version` with `web3.eth.chain_id`;
- update the doc strings related to network id;
- modify `NETWORK_NAME_MAP`.