### PR TITLE
Refactored logic for creating an asset with both dt address and owner address

### DIFF
--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -262,8 +262,8 @@ def test_create_asset_with_address(publisher_ocean_instance):
     ), "Asset creation failed with the specified datatoken address."
 
 
-def test_create_asset_with_owner_address(publisher_ocean_instance):
-    """Tests that the created assets have the same owner address."""
+def test_create_asset_with_dt_address_and_owner_address(publisher_ocean_instance):
+    """Tests that an asset can be created with both a datatoken address and owner address."""
     ocn = publisher_ocean_instance
     alice = get_publisher_wallet()
 
@@ -278,24 +278,12 @@ def test_create_asset_with_owner_address(publisher_ocean_instance):
     )
 
     assert ocn.assets.create(
-        asset.metadata, alice, [auth_service], owner_address=alice.address
-    ), "Asset creation failed with the specified owner address."
-
-    asset_1 = ocn.assets.create(
         asset.metadata,
         alice,
         [auth_service],
         owner_address=alice.address,
         data_token_address=token.address,
-    )
-    assert asset_1, "Asset creation failed. The asset is None."
-    asset_2 = ocn.assets.create(
-        asset.metadata, alice, [auth_service], data_token_address=token.address
-    )
-    assert asset_2, "Asset creation failed. The asset is None."
-    assert (
-        asset_1.proof["creator"] == asset_2.proof["creator"]
-    ), "Different owners of the assets."
+    ), "Asset creation failed when given both a datatoken address and owner address."
 
 
 def test_create_asset_without_dt_address(publisher_ocean_instance):

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -262,6 +262,25 @@ def test_create_asset_with_address(publisher_ocean_instance):
     ), "Asset creation failed with the specified datatoken address."
 
 
+def test_create_asset_with_owner_address(publisher_ocean_instance):
+    """Tests that an asset can be created with owner address."""
+    ocn = publisher_ocean_instance
+    alice = get_publisher_wallet()
+
+    sample_ddo_path = get_resource_path("ddo", "ddo_sa_sample.json")
+    asset = DDO(json_filename=sample_ddo_path)
+    asset.metadata["main"]["files"][0]["checksum"] = str(uuid.uuid4())
+    my_secret_store = "http://myownsecretstore.com"
+    auth_service = ServiceDescriptor.authorization_service_descriptor(my_secret_store)
+
+    assert ocn.assets.create(
+        asset.metadata,
+        alice,
+        [auth_service],
+        owner_address=alice.address,
+    ), "Asset creation failed with the specified owner address."
+
+
 def test_create_asset_with_dt_address_and_owner_address(publisher_ocean_instance):
     """Tests that an asset can be created with both a datatoken address and owner address."""
     ocn = publisher_ocean_instance


### PR DESCRIPTION

Fixes #439  .

Changes proposed in this PR:

- updated docstrings;
- refactored the logic of the unit test to match the intention of it.