### PR TITLE
Added support for moonbeam alpha network.

### DIFF
--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -63,6 +63,12 @@ CONFIG_NETWORK_HELPER = {
         NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "polygon",
     },
+    1287: {
+        NAME_BLOCK_CONFIRMATION_POLL_INTERVAL: 6,
+        NAME_PROVIDER_URL: "https://provider.moonbeamalpha.oceanprotocol.com",
+        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
+        NETWORK_NAME: "moonbeamalpha",
+    },
     1337: {
         NAME_BLOCK_CONFIRMATION_POLL_INTERVAL: 2.5,
         NAME_PROVIDER_URL: DEFAULT_PROVIDER_URL,

--- a/ocean_lib/test/test_example_config.py
+++ b/ocean_lib/test/test_example_config.py
@@ -64,3 +64,23 @@ def test_bsc_example_config(monkeypatch):
     assert config.__dict__["_sections"][SECTION_ETH_NETWORK][
         NAME_BLOCK_CONFIRMATION_POLL_INTERVAL
     ] == str(1.5)
+
+
+def test_moonbeam_alpha_example_config(monkeypatch):
+    """Tests the config structure of Moonbeam Alpha network."""
+
+    monkeypatch.setenv("NETWORK_URL", "https://rpc.testnet.moonbeam.network")
+    config = ExampleConfig.get_config()
+
+    assert config.chain_id == 1287
+    assert config.network_url == "https://rpc.testnet.moonbeam.network"
+    assert config.metadata_cache_uri == "https://aquarius.oceanprotocol.com"
+    assert config.provider_url == "https://provider.moonbeamalpha.oceanprotocol.com"
+
+    assert (
+        config.__dict__["_sections"][SECTION_ETH_NETWORK][NETWORK_NAME]
+        == "moonbeamalpha"
+    )
+    assert config.__dict__["_sections"][SECTION_ETH_NETWORK][
+        NAME_BLOCK_CONFIRMATION_POLL_INTERVAL
+    ] == str(6)

--- a/ocean_lib/web3_internal/constants.py
+++ b/ocean_lib/web3_internal/constants.py
@@ -23,6 +23,7 @@ NETWORK_NAME_MAP = {
     4: "Rinkeby",
     56: "Binance Smart Chain",
     137: "Polygon",
+    1287: "Moonbeam Alpha",
     1337: "Ganache",
 }
 
@@ -32,5 +33,6 @@ NETWORK_TIMEOUT_MAP = {
     "rinkeby": 5 * 60,
     "bsc": 10 * 60,
     "polygon": 10 * 60,
+    "moonbeamalpha": 60,
     "ganache": 2,
 }


### PR DESCRIPTION
Fixes #404  .

Changes proposed in this PR:

- add `moonbeam alpha` network properties to `example_config`;
- implement an unit test for `moonbeam alpha` config helper;
- modify the `web3_internal` constants.