### PR TITLE
Moved the NETWORK_NAME from example_config to config.py

### DIFF
--- a/ocean_lib/config.py
+++ b/ocean_lib/config.py
@@ -17,12 +17,14 @@ from ocean_lib.web3_internal.constants import GAS_LIMIT_DEFAULT
 DEFAULT_NETWORK_HOST = "localhost"
 DEFAULT_NETWORK_PORT = 8545
 DEFAULT_NETWORK_URL = "http://localhost:8545"
+DEFAULT_NETWORK_NAME = "ganache"
 DEFAULT_ADDRESS_FILE = ""
 DEFAULT_METADATA_CACHE_URI = "http://localhost:5000"
 DEFAULT_PROVIDER_URL = "http://localhost:8030"
 DEFAULT_DOWNLOADS_PATH = "consume-downloads"
 
 NAME_NETWORK_URL = "network"
+NETWORK_NAME = "network_name"
 NAME_CHAIN_ID = "chain_id"
 NAME_ADDRESS_FILE = "address.file"
 NAME_GAS_LIMIT = "gas_limit"
@@ -84,6 +86,7 @@ deprecated_environ_names = {
 config_defaults = {
     "eth-network": {
         NAME_NETWORK_URL: DEFAULT_NETWORK_URL,
+        NETWORK_NAME: DEFAULT_NETWORK_NAME,
         NAME_ADDRESS_FILE: DEFAULT_ADDRESS_FILE,
         NAME_GAS_LIMIT: GAS_LIMIT_DEFAULT,
     },
@@ -231,6 +234,12 @@ class Config(configparser.ConfigParser):
     def network_url(self) -> str:
         """URL of the ethereum network. (e.g.): http://mynetwork:8545."""
         return self.get(SECTION_ETH_NETWORK, NAME_NETWORK_URL)
+
+    @property
+    @enforce_types
+    def network_name(self) -> str:
+        """Name of the ethereum network. (e.g.): ganache."""
+        return self.get(SECTION_ETH_NETWORK, NETWORK_NAME)
 
     @property
     @enforce_types

--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -15,6 +15,7 @@ from ocean_lib.config import (
     NAME_METADATA_CACHE_URI,
     NAME_NETWORK_URL,
     NAME_PROVIDER_URL,
+    NETWORK_NAME,
     SECTION_ETH_NETWORK,
     SECTION_RESOURCES,
     Config,
@@ -25,7 +26,6 @@ from web3 import Web3
 
 logging.basicConfig(level=logging.INFO)
 
-NETWORK_NAME = "network_name"
 """The interval in seconds between calls for the latest block number."""
 NAME_BLOCK_CONFIRMATION_POLL_INTERVAL = "block_confirmation_poll_interval"
 


### PR DESCRIPTION
Fixes #477 .

Changes proposed in this PR:
- move the `NETWOK_NAME` from `example_config` to `config.py`;
- create a new property for network name.

**Pupose of this change**

To be able to retrieve the network name from the config object for accessing the specific contracts addresses from #474 .