### PR TITLE
Add get_web3() utility that injects geth-poa-middleware when on Rinkeby

### DIFF
--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -22,7 +22,7 @@ from ocean_lib.config import (
     Config,
     config_defaults,
 )
-from ocean_lib.ocean.util import get_web3, get_web3_connection_provider
+from ocean_lib.ocean.util import get_web3
 
 logging.basicConfig(level=logging.INFO)
 
@@ -111,7 +111,7 @@ class ExampleConfig:
             network_url is not None
         ), "Cannot use ocean-lib without a specified network URL."
 
-        w3 = get_web3(get_web3_connection_provider(network_url))
+        w3 = get_web3(network_url)
         chain_id = w3.eth.chain_id
 
         config = get_config_dict(chain_id)

--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -22,8 +22,7 @@ from ocean_lib.config import (
     Config,
     config_defaults,
 )
-from ocean_lib.ocean.util import get_web3_connection_provider
-from web3 import Web3
+from ocean_lib.ocean.util import get_web3, get_web3_connection_provider
 
 logging.basicConfig(level=logging.INFO)
 
@@ -112,7 +111,7 @@ class ExampleConfig:
             network_url is not None
         ), "Cannot use ocean-lib without a specified network URL."
 
-        w3 = Web3(get_web3_connection_provider(network_url))
+        w3 = get_web3(get_web3_connection_provider(network_url))
         chain_id = w3.eth.chain_id
 
         config = get_config_dict(chain_id)

--- a/ocean_lib/ocean/mint_fake_ocean.py
+++ b/ocean_lib/ocean/mint_fake_ocean.py
@@ -7,7 +7,7 @@ import os
 
 from ocean_lib.config import Config
 from ocean_lib.models.data_token import DataToken
-from ocean_lib.ocean.util import get_web3, get_web3_connection_provider
+from ocean_lib.ocean.util import get_web3
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.transactions import send_ether
 from ocean_lib.web3_internal.utils import get_ether_balance
@@ -25,7 +25,7 @@ def mint_fake_OCEAN(config: Config) -> None:
     with open(addresses_file) as f:
         network_addresses = json.load(f)
 
-    web3 = get_web3(get_web3_connection_provider(config.network_url))
+    web3 = get_web3(config.network_url)
     deployer_wallet = Wallet(
         web3,
         private_key=os.environ.get("FACTORY_DEPLOYER_PRIVATE_KEY"),

--- a/ocean_lib/ocean/mint_fake_ocean.py
+++ b/ocean_lib/ocean/mint_fake_ocean.py
@@ -7,12 +7,11 @@ import os
 
 from ocean_lib.config import Config
 from ocean_lib.models.data_token import DataToken
-from ocean_lib.ocean.util import get_web3_connection_provider
+from ocean_lib.ocean.util import get_web3, get_web3_connection_provider
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.transactions import send_ether
 from ocean_lib.web3_internal.utils import get_ether_balance
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.main import Web3
 
 
 def mint_fake_OCEAN(config: Config) -> None:
@@ -26,7 +25,7 @@ def mint_fake_OCEAN(config: Config) -> None:
     with open(addresses_file) as f:
         network_addresses = json.load(f)
 
-    web3 = Web3(provider=get_web3_connection_provider(config.network_url))
+    web3 = get_web3(get_web3_connection_provider(config.network_url))
     deployer_wallet = Wallet(
         web3,
         private_key=os.environ.get("FACTORY_DEPLOYER_PRIVATE_KEY"),

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -26,7 +26,6 @@ from ocean_lib.ocean.util import (
     get_contracts_addresses,
     get_ocean_token_address,
     get_web3,
-    get_web3_connection_provider,
 )
 from ocean_lib.web3_internal.utils import get_network_name
 from ocean_lib.web3_internal.wallet import Wallet
@@ -87,7 +86,7 @@ class Ocean:
             }
             config = Config(options_dict=config_dict)
         self.config = config
-        self.web3 = get_web3(get_web3_connection_provider(self.config.network_url))
+        self.web3 = get_web3(self.config.network_url)
 
         if not data_provider:
             data_provider = DataServiceProvider

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -25,12 +25,12 @@ from ocean_lib.ocean.util import (
     get_bfactory_address,
     get_contracts_addresses,
     get_ocean_token_address,
+    get_web3,
     get_web3_connection_provider,
 )
 from ocean_lib.web3_internal.utils import get_network_name
 from ocean_lib.web3_internal.wallet import Wallet
 from web3.datastructures import AttributeDict
-from web3.main import Web3
 
 logger = logging.getLogger("ocean")
 
@@ -87,7 +87,7 @@ class Ocean:
             }
             config = Config(options_dict=config_dict)
         self.config = config
-        self.web3 = Web3(provider=get_web3_connection_provider(self.config.network_url))
+        self.web3 = get_web3(get_web3_connection_provider(self.config.network_url))
 
         if not data_provider:
             data_provider = DataServiceProvider

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -15,15 +15,14 @@ from ocean_lib.web3_internal.web3_overrides.http_provider import CustomHTTPProvi
 from web3 import WebsocketProvider
 from web3.main import Web3
 from web3.middleware import geth_poa_middleware
-from web3.providers.base import BaseProvider
 
 GANACHE_URL = "http://127.0.0.1:8545"
 
 
 @enforce_types
-def get_web3(provider: BaseProvider) -> Web3:
+def get_web3(network_url: str) -> Web3:
     """
-    Return a web3 instance using the given Provider.
+    Return a web3 instance connected via the given network_url.
 
     Adds POA middleware when connecting to the Rinkeby Testnet.
 
@@ -32,6 +31,7 @@ def get_web3(provider: BaseProvider) -> Web3:
     - the issue is described here: https://github.com/ethereum/web3.py/issues/549
     - and the fix is here: https://web3py.readthedocs.io/en/latest/middleware.html#geth-style-proof-of-authority
     """
+    provider = get_web3_connection_provider(network_url)
     web3 = Web3(provider)
     if web3.eth.chain_id == 4:
         web3.middleware_onion.inject(geth_poa_middleware, layer=0)

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -14,15 +14,15 @@ from enforce_typing import enforce_types
 from ocean_lib.example_config import ExampleConfig
 from ocean_lib.models.data_token import DataToken
 from ocean_lib.ocean.ocean import Ocean
+from ocean_lib.ocean.util import get_web3 as util_get_web3
 from ocean_lib.ocean.util import get_web3_connection_provider
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.wallet import Wallet
 from tests.resources.mocks.data_provider_mock import DataProviderMock
-from web3.main import Web3
 
 
 def get_web3():
-    return Web3(provider=get_web3_connection_provider(get_example_config().network_url))
+    return util_get_web3(get_web3_connection_provider(get_example_config().network_url))
 
 
 def get_example_config():

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -15,14 +15,13 @@ from ocean_lib.example_config import ExampleConfig
 from ocean_lib.models.data_token import DataToken
 from ocean_lib.ocean.ocean import Ocean
 from ocean_lib.ocean.util import get_web3 as util_get_web3
-from ocean_lib.ocean.util import get_web3_connection_provider
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.wallet import Wallet
 from tests.resources.mocks.data_provider_mock import DataProviderMock
 
 
 def get_web3():
-    return util_get_web3(get_web3_connection_provider(get_example_config().network_url))
+    return util_get_web3(get_example_config().network_url)
 
 
 def get_example_config():


### PR DESCRIPTION
Closes #493 

Changes proposed in this PR:

- Add get_web3() utility that injects geth-poa-middleware when on Rinkeby
- Create all Web3 instances using get_web3() utility.