### PR TITLE
Fix `OceanPool._get_all_liquidity_records method()`

### DIFF
--- a/ocean_lib/models/test/test_balancer_simple_for_users_flow.py
+++ b/ocean_lib/models/test/test_balancer_simple_for_users_flow.py
@@ -109,6 +109,14 @@ def test_quickstart(alice_ocean, alice_wallet, alice_address, bob_ocean, bob_wal
         pool_address, amount=to_wei("0.1"), from_wallet=bob_wallet
     )
 
+    # ===============================================================
+    # 13. Get liquidity history
+    ocean_liquidity_history, dt_liquidity_history = bob_ocean.pool.get_liquidity_history(
+        pool_address
+    )
+    assert len(ocean_liquidity_history) == 7
+    assert len(dt_liquidity_history) == 7
+
 
 # ===============================================================
 # Test helper functions for the quickstart stuff above

--- a/ocean_lib/models/test/test_balancer_simple_for_users_flow.py
+++ b/ocean_lib/models/test/test_balancer_simple_for_users_flow.py
@@ -111,9 +111,10 @@ def test_quickstart(alice_ocean, alice_wallet, alice_address, bob_ocean, bob_wal
 
     # ===============================================================
     # 13. Get liquidity history
-    ocean_liquidity_history, dt_liquidity_history = bob_ocean.pool.get_liquidity_history(
-        pool_address
-    )
+    (
+        ocean_liquidity_history,
+        dt_liquidity_history,
+    ) = bob_ocean.pool.get_liquidity_history(pool_address)
     assert len(ocean_liquidity_history) == 7
     assert len(dt_liquidity_history) == 7
 

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -24,6 +24,7 @@ from ocean_lib.ocean.ocean_services import OceanServices
 from ocean_lib.ocean.util import (
     get_bfactory_address,
     get_contracts_addresses,
+    get_dtfactory_address,
     get_ocean_token_address,
     get_web3_connection_provider,
 )
@@ -108,6 +109,7 @@ class Ocean:
             self.web3,
             ocean_address,
             get_bfactory_address(self.config.address_file, network),
+            get_dtfactory_address(self.config.address_file, network),
         )
         self.exchange = OceanExchange(
             self.web3,


### PR DESCRIPTION
Closes #495

Breaking changes proposed in this PR:

- Add `OceanPool.dtfactory_address` attribute

Changes proposed in this PR:

- Fix `OceanPool._get_all_liquidity_records method()`
- Add `OceanPool.get_liquidity_history()` to integration test. This will hopefully catch argument list errors in the future.