### PR TITLE
Bump version: 0.6.1 → 0.7.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.1
+current_version = 0.7.0
 commit = True
 tag = True
 

--- a/ocean_lib/__init__.py
+++ b/ocean_lib/__init__.py
@@ -7,5 +7,5 @@
 
 __author__ = """OceanProtocol"""
 # fmt: off
-__version__ = '0.6.1'
+__version__ = '0.7.0'
 # fmt: on

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     url="https://github.com/oceanprotocol/ocean.py",
     # fmt: off
     # bumpversion.sh needs single-quotes
-    version='0.6.1',
+    version='0.7.0',
     # fmt: on
     zip_safe=False,
 )


### PR DESCRIPTION
Towards #497

Proposed changelog entry:

# Breaking Changes

- Add `block_confirmations` attribute to `Wallet`

# Non-breaking changes

- Add `wait_for_transaction_receipt_and_block_confirmations` function. Called any time a transaction is sent, thus making all transactions "blocking".
- Add `block_confirmations` attribute to `Config`
- Add `BLOCK_CONFIRMATIONS` envvar
- Add `eth-network.block_confirmations` config.ini option
- Add `send_dummy_transactions` and `StoppableThread` for use in unit tests. Needed for testing `wait_for_transaction_receipt_and_block_confirmations` because Ganache doesn't mine new blocks unless new transactions are sent.
- Add `Integer` wrapper class to allow passing `int` by reference. Use case: The user creates a `Wallet` using `config.block_confirmations` but then changes the `config.block_confirmations` attribute value, The `Wallet` will use the new value.
- Add hard-coded `BLOCK_NUMBER_POLL_INTERVAL` which maps chain_id to poll interval.
- Use c2d address in pay for service.
- Fix OceanPool._get_all_liquidity_records method()
- Fix typo in marketplace-flow.md
- Add get_web3() utility that injects geth-poa-middleware when on Rinkeby
