### PR TITLE
Bump version: 0.7.0 → 0.8.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0
 commit = True
 tag = True
 

--- a/ocean_lib/__init__.py
+++ b/ocean_lib/__init__.py
@@ -7,5 +7,5 @@
 
 __author__ = """OceanProtocol"""
 # fmt: off
-__version__ = '0.7.0'
+__version__ = '0.8.0'
 # fmt: on

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     url="https://github.com/oceanprotocol/ocean.py",
     # fmt: off
     # bumpversion.sh needs single-quotes
-    version='0.7.0',
+    version='0.8.0',
     # fmt: on
     zip_safe=False,
 )


### PR DESCRIPTION
Towards #497 

Proposed changelog entry:

# Breaking Changes

- The following methods no longer return the compute job results URL. 
  - `OceanCompute.result()`
  - `DataServiceProvider.get_compute_status()`
  - `DataServiceProvider.get_compute_result()`

# Non-breaking changes

- Added support for the `computeResult` endpoint for getting the compute job results URL: 
  - `OceanCompute.result_file()`
  - `DataServiceProvider.compute_job_result_file()`
- Replace Travis with GitHub Actions