### PR TITLE
Issue509 fix readmes to use ExampleConfig

### DIFF
--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -71,25 +71,6 @@ pip install numpy
 pip install matplotlib
 ```
 
-### Create config file
-
-In the work console:
-```console
-#Create config.ini file and fill it with configuration info
-echo """
-[eth-network]
-network = http://127.0.0.1:8545
-address.file = ~/.ocean/ocean-contracts/artifacts/address.json
-
-[resources]
-metadata_cache_uri = http://localhost:5000
-provider.url = http://localhost:8030
-provider.address = 0x00bd138abd70e2f00903268f3db08f2d25677c9e
-
-downloads.path = consume-downloads
-""" > config.ini
-```
-
 ### Set envvars
 
 In the work console:
@@ -97,9 +78,15 @@ In the work console:
 #set private keys of two accounts
 export TEST_PRIVATE_KEY1=0x5d75837394b078ce97bc289fa8d75e21000573520bfa7784a9d28ccaae602bf8
 export TEST_PRIVATE_KEY2=0xef4b441145c1d0f3b4bc6d61d29f5c6e502359481152f869247c7a4244d45209
+
+#set the address file only for ganache
+export ADDRESS_FILE=~/.ocean/ocean-contracts/artifacts/address.json
+
+#set network URL
+export OCEAN_NETWORK_URL=http://127.0.0.1:8545
 ```
 
-### Config in Python
+### Start Python
 
 In the work console:
 ```console
@@ -111,12 +98,13 @@ For the following steps, we use the Python console. Keep it open between steps.
 In the Python console:
 ```python
 #create ocean instance
-from ocean_lib.config import Config
+from ocean_lib.example_config import ExampleConfig
 from ocean_lib.ocean.ocean import Ocean
-config = Config('config.ini')
+config = ExampleConfig.get_config()
 ocean = Ocean(config)
 
 print(f"config.network_url = '{config.network_url}'")
+print(f"config.block_confirmations = {config.block_confirmations.value}")
 print(f"config.metadata_cache_uri = '{config.metadata_cache_uri}'")
 print(f"config.provider_url = '{config.provider_url}'")
 

--- a/READMEs/datatokens-flow.md
+++ b/READMEs/datatokens-flow.md
@@ -29,18 +29,6 @@ docker system prune -a --volumes
 ./start_ocean.sh  --with-provider2
 ```
 
-## Create config file
-
-In a console:
-```console
-#Create config.ini file and fill it with configuration info
-echo """
-[eth-network]
-network = http://127.0.0.1:8545
-address.file = ~/.ocean/ocean-contracts/artifacts/address.json
-""" > config.ini
-```
-
 ## Install the library, set envvars
 
 In a new console:
@@ -57,6 +45,12 @@ pip install ocean-lib
 #set envvars
 export TEST_PRIVATE_KEY1=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58
 
+#set the address file only for ganache
+export ADDRESS_FILE=~/.ocean/ocean-contracts/artifacts/address.json
+
+#set network URL
+export OCEAN_NETWORK_URL=http://127.0.0.1:8545
+
 #go into python
 python
 ```
@@ -67,12 +61,12 @@ In the Python console:
 
 ```python
 import os
-from ocean_lib.config import Config
+from ocean_lib.example_config import ExampleConfig
 from ocean_lib.ocean.ocean import Ocean
 from ocean_lib.web3_internal.wallet import Wallet
 
 private_key = os.getenv('TEST_PRIVATE_KEY1')
-config = Config('config.ini')
+config = ExampleConfig.get_config()
 ocean = Ocean(config)
 
 print("create wallet: begin")

--- a/READMEs/dispenser-flow.md
+++ b/READMEs/dispenser-flow.md
@@ -87,6 +87,7 @@ config = ExampleConfig.get_config()
 ocean = Ocean(config)
 
 print(f"config.network_url = '{config.network_url}'")
+print(f"config.block_confirmations = {config.block_confirmations.value}")
 print(f"config.metadata_cache_uri = '{config.metadata_cache_uri}'")
 print(f"config.provider_url = '{config.provider_url}'")
 print(f"config.network_name = '{config.network_name}'")

--- a/READMEs/fixed-rate-exchange-flow.md
+++ b/READMEs/fixed-rate-exchange-flow.md
@@ -93,6 +93,7 @@ config = ExampleConfig.get_config()
 ocean = Ocean(config)
 
 print(f"config.network_url = '{config.network_url}'")
+print(f"config.block_confirmations = {config.block_confirmations.value}")
 print(f"config.metadata_cache_uri = '{config.metadata_cache_uri}'")
 print(f"config.provider_url = '{config.provider_url}'")
 

--- a/READMEs/get-test-OCEAN.md
+++ b/READMEs/get-test-OCEAN.md
@@ -80,9 +80,9 @@ In a Python console:
 
 ```python
 #setup
-import os
+from ocean_lib.example_config import ExampleConfig
 from ocean_lib.ocean.ocean import Ocean
-config = {'network': os.getenv('OCEAN_NETWORK_URL')}
+config = ExampleConfig.get_config()
 ocean = Ocean(config)
 
 #create an ERC20 object of OCEAN token

--- a/READMEs/overview.md
+++ b/READMEs/overview.md
@@ -8,9 +8,9 @@ quick overview of the main functions and submodules:
 
 ```python
 from ocean_lib.ocean.ocean import Ocean
-from ocean_lib.config import Config
+from ocean_lib.example_config import ExampleConfig
 
-config = Config('config.ini')
+config = ExampleConfig.get_config()
 
 # Ocean instance: create/get datatoken, get dtfactory, user orders (history)
 ocean = Ocean(config)

--- a/READMEs/parameters.md
+++ b/READMEs/parameters.md
@@ -7,58 +7,45 @@ SPDX-License-Identifier: Apache-2.0
 
 We can set any config parameter (a) via an envvar, or (b) via a config file. Envvar values override config file values.
 
-An `Ocean` instance will hold a `Config` instance that holds various config parameters. These parameters need to get set. This is set based on what's input to `Ocean` constructor:
+An `Ocean` instance will hold a `Config` instance that holds various config parameters. These parameters can be set in a variety of ways:
 
-1.  dict input: `Ocean({'network':..})`
-2.  Config object input: `Ocean(Config('config.ini'))`
-3.  no input, so it uses OCEAN_CONFIG_FILE envvar
+1. Config object input
+    * Filled from ExampleConfig: `Ocean(ExampleConfig.get_config())` (recommended)
+    * Filled from config file: `Ocean(Config('config.ini'))`
+    * Filled from config file specified by `OCEAN_CONFIG_FILE` envvar: `Ocean(Config())`
+    * Filled from config dict: `Ocean(Config('network':..}))`
+2.  dict input: `Ocean({'network':..})` (deprecated because it doesn't support all config options)
 
 Here are examples.
 
-## 1. dict input, filled from envvars
+## 1a. Config object input, filled from ExampleConfig (recommended)
 
 First, in console:
 
 ```console
 export OCEAN_NETWORK_URL=https://rinkeby.infura.io/v3/<your Infura project id>
-export METADATA_CACHE_URI=https://aquarius.rinkeby.oceanprotocol.com
-export PROVIDER_URL=https://provider.rinkeby.oceanprotocol.com
 ```
 
-Then, do the following in Python. The `Ocean` constructor takes a `dict`, which in turn is set by envvars.
+Then, in Python:
 
 ```python
-import os
+from ocean_lib.example_config import ExampleConfig
 from ocean_lib.ocean.ocean import Ocean
-d = {
-   'network' : os.getenv('OCEAN_NETWORK_URL'),
-   'metadataCacheUri' : os.getenv('METADATA_CACHE_URI'),
-   'providerUri' : os.getenv('PROVIDER_URL'),
-}
-ocean = Ocean(d)
-```
-For legacy support, you can also use `metadataStoreUri` instead of `metadataCacheUri`.
-
-## 1a. Unsetting envvars
-
-Recall that parameters set by envvars override config file values. So, to use a config value in a file, we must remove its envvar.
-
-Here's how. In the console:
-
-```console
-    unset OCEAN_NETWORK_URL METADATA_CACHE_URI AQUARIUS_URL PROVIDER_URL
+config = ExampleConfig.get_config()
+ocean = Ocean(config)
 ```
 
-## 2. Config object input, filled from config file
+## 1b. Config object input, filled from config file
 
 First, in your working directory, create `config.ini` file and fill as follows:
 
 ```console
     [eth-network]
     network = https://rinkeby.infura.io/v3/<your infura project id>
+    block_confirmations = 1
 
     [resources]
-    metadata_cache_uri = https://aquarius.rinkeby.oceanprotocol.com
+    metadata_cache_uri = https://aquarius.oceanprotocol.com
     provider.url = https://provider.rinkeby.oceanprotocol.com
 ```
 
@@ -67,13 +54,13 @@ Then, in Python:
 ```python
 from ocean_lib.config import Config
 from ocean_lib.ocean.ocean import Ocean
-c = Config('config.ini')
-ocean = Ocean(c)
+config = Config('config.ini')
+ocean = Ocean(config)
 ```
 
-## 3. No input, so it uses OCEAN_CONFIG_FILE envvar
+## 1c. Config object input, filled using `OCEAN_CONFIG_FILE` envvar
 
-We'll use the `config.ini` file created from the previous example.
+We'll use the `config.ini` file created in 1b (above).
 
 Then, set an envvar for the config file. In the console:
 
@@ -88,12 +75,59 @@ import os
 
 from ocean_lib.config import Config
 from ocean_lib.ocean.ocean import Ocean
-c = Config(os.getenv("OCEAN_CONFIG_FILE"))
-ocean = Ocean(c)
+config = Config()
+ocean = Ocean(config)
+```
+
+## 1d. Config object input, filled using config dict
+
+In python:
+
+```python
+from ocean_lib.ocean.ocean import Ocean
+config_dict = {
+    'eth-network' : {
+        'network' : 'https://rinkeby.infura.io/v3/<your Infura project id>',
+        'block_confirmations' : 1,
+    },
+    'resources' : {
+        'metadataCacheUri' : 'https://aquarius.oceanprotocol.com',
+        'providerUri' : 'https://provider.rinkeby.oceanprotocol.com',
+    },
+}
+config = Config(options_dict=config_dict)
+ocean = Ocean(config)
+```
+
+## 2. dict input (deprecated because it doesn't support all config options)
+
+In python:
+
+```python
+from ocean_lib.ocean.ocean import Ocean
+config_dict = {
+   'network' : 'https://rinkeby.infura.io/v3/<your Infura project id>',
+   'metadataCacheUri' : 'https://aquarius.oceanprotocol.com',
+   'providerUri' : 'https://provider.rinkeby.oceanprotocol.com',
+}
+ocean = Ocean(config_dict)
+```
+
+For legacy support, you can also use `metadataStoreUri` instead of `metadataCacheUri`.
+
+
+## Appendix: Unsetting envvars
+
+Recall that parameters set by envvars override config file values. So, to use a config value in a file, we must remove its envvar.
+
+Here's how. In the console:
+
+```console
+    unset OCEAN_NETWORK_URL METADATA_CACHE_URI AQUARIUS_URL PROVIDER_URL
 ```
 
 ## Further details
 
-The file [config.py](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/config.py) lists all the config parameters.
-
-For the most precise description of config parameter logic, see the [Ocean() constructor implementation](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean.py).
+* [example_config.py](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/example_config.py) contains the default config values that differ depending on the `chain_id`.
+* [config.py](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/config.py) lists all the config parameters.
+* [Ocean() constructor implementation](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean.py) shows the most precise description of config parameter logic.

--- a/READMEs/parameters.md
+++ b/READMEs/parameters.md
@@ -7,45 +7,58 @@ SPDX-License-Identifier: Apache-2.0
 
 We can set any config parameter (a) via an envvar, or (b) via a config file. Envvar values override config file values.
 
-An `Ocean` instance will hold a `Config` instance that holds various config parameters. These parameters can be set in a variety of ways:
+An `Ocean` instance will hold a `Config` instance that holds various config parameters. These parameters need to get set. This is set based on what's input to `Ocean` constructor:
 
-1. Config object input
-    * Filled from ExampleConfig: `Ocean(ExampleConfig.get_config())` (recommended)
-    * Filled from config file: `Ocean(Config('config.ini'))`
-    * Filled from config file specified by `OCEAN_CONFIG_FILE` envvar: `Ocean(Config())`
-    * Filled from config dict: `Ocean(Config('network':..}))`
-2.  dict input: `Ocean({'network':..})` (deprecated because it doesn't support all config options)
+1.  dict input: `Ocean({'network':..})`
+2.  Config object input: `Ocean(Config('config.ini'))`
+3.  no input, so it uses OCEAN_CONFIG_FILE envvar
 
 Here are examples.
 
-## 1a. Config object input, filled from ExampleConfig (recommended)
+## 1. dict input, filled from envvars
 
 First, in console:
 
 ```console
 export OCEAN_NETWORK_URL=https://rinkeby.infura.io/v3/<your Infura project id>
+export METADATA_CACHE_URI=https://aquarius.rinkeby.oceanprotocol.com
+export PROVIDER_URL=https://provider.rinkeby.oceanprotocol.com
 ```
 
-Then, in Python:
+Then, do the following in Python. The `Ocean` constructor takes a `dict`, which in turn is set by envvars.
 
 ```python
-from ocean_lib.example_config import ExampleConfig
+import os
 from ocean_lib.ocean.ocean import Ocean
-config = ExampleConfig.get_config()
-ocean = Ocean(config)
+d = {
+   'network' : os.getenv('OCEAN_NETWORK_URL'),
+   'metadataCacheUri' : os.getenv('METADATA_CACHE_URI'),
+   'providerUri' : os.getenv('PROVIDER_URL'),
+}
+ocean = Ocean(d)
+```
+For legacy support, you can also use `metadataStoreUri` instead of `metadataCacheUri`.
+
+## 1a. Unsetting envvars
+
+Recall that parameters set by envvars override config file values. So, to use a config value in a file, we must remove its envvar.
+
+Here's how. In the console:
+
+```console
+    unset OCEAN_NETWORK_URL METADATA_CACHE_URI AQUARIUS_URL PROVIDER_URL
 ```
 
-## 1b. Config object input, filled from config file
+## 2. Config object input, filled from config file
 
 First, in your working directory, create `config.ini` file and fill as follows:
 
 ```console
     [eth-network]
     network = https://rinkeby.infura.io/v3/<your infura project id>
-    block_confirmations = 1
 
     [resources]
-    metadata_cache_uri = https://aquarius.oceanprotocol.com
+    metadata_cache_uri = https://aquarius.rinkeby.oceanprotocol.com
     provider.url = https://provider.rinkeby.oceanprotocol.com
 ```
 
@@ -54,13 +67,13 @@ Then, in Python:
 ```python
 from ocean_lib.config import Config
 from ocean_lib.ocean.ocean import Ocean
-config = Config('config.ini')
-ocean = Ocean(config)
+c = Config('config.ini')
+ocean = Ocean(c)
 ```
 
-## 1c. Config object input, filled using `OCEAN_CONFIG_FILE` envvar
+## 3. No input, so it uses OCEAN_CONFIG_FILE envvar
 
-We'll use the `config.ini` file created in 1b (above).
+We'll use the `config.ini` file created from the previous example.
 
 Then, set an envvar for the config file. In the console:
 
@@ -75,59 +88,12 @@ import os
 
 from ocean_lib.config import Config
 from ocean_lib.ocean.ocean import Ocean
-config = Config()
-ocean = Ocean(config)
-```
-
-## 1d. Config object input, filled using config dict
-
-In python:
-
-```python
-from ocean_lib.ocean.ocean import Ocean
-config_dict = {
-    'eth-network' : {
-        'network' : 'https://rinkeby.infura.io/v3/<your Infura project id>',
-        'block_confirmations' : 1,
-    },
-    'resources' : {
-        'metadataCacheUri' : 'https://aquarius.oceanprotocol.com',
-        'providerUri' : 'https://provider.rinkeby.oceanprotocol.com',
-    },
-}
-config = Config(options_dict=config_dict)
-ocean = Ocean(config)
-```
-
-## 2. dict input (deprecated because it doesn't support all config options)
-
-In python:
-
-```python
-from ocean_lib.ocean.ocean import Ocean
-config_dict = {
-   'network' : 'https://rinkeby.infura.io/v3/<your Infura project id>',
-   'metadataCacheUri' : 'https://aquarius.oceanprotocol.com',
-   'providerUri' : 'https://provider.rinkeby.oceanprotocol.com',
-}
-ocean = Ocean(config_dict)
-```
-
-For legacy support, you can also use `metadataStoreUri` instead of `metadataCacheUri`.
-
-
-## Appendix: Unsetting envvars
-
-Recall that parameters set by envvars override config file values. So, to use a config value in a file, we must remove its envvar.
-
-Here's how. In the console:
-
-```console
-    unset OCEAN_NETWORK_URL METADATA_CACHE_URI AQUARIUS_URL PROVIDER_URL
+c = Config(os.getenv("OCEAN_CONFIG_FILE"))
+ocean = Ocean(c)
 ```
 
 ## Further details
 
-* [example_config.py](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/example_config.py) contains the default config values that differ depending on the `chain_id`.
-* [config.py](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/config.py) lists all the config parameters.
-* [Ocean() constructor implementation](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean.py) shows the most precise description of config parameter logic.
+The file [config.py](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/config.py) lists all the config parameters.
+
+For the most precise description of config parameter logic, see the [Ocean() constructor implementation](https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean.py).

--- a/READMEs/services.md
+++ b/READMEs/services.md
@@ -24,7 +24,7 @@ In your working directory, create a file `config.ini` and fill it with the follo
     network = https://rinkeby.infura.io/v3/<your Infura project id>
 
     [resources]
-    metadata_cache_uri = https://aquarius.rinkeby.oceanprotocol.com
+    metadata_cache_uri = https://aquarius.oceanprotocol.com
     provider.url = https://provider.rinkeby.oceanprotocol.com
 
 Ensure that envvars don't override the config file values:

--- a/config.ini
+++ b/config.ini
@@ -2,6 +2,7 @@
 
 network = http://127.0.0.1:8545
 address.file = ~/.ocean/ocean-contracts/artifacts/address.json
+block_confirmations = 0
 
 
 [resources]

--- a/ocean_lib/config.py
+++ b/ocean_lib/config.py
@@ -44,7 +44,6 @@ NAME_DOWNLOADS_PATH = "downloads.path"
 
 SECTION_ETH_NETWORK = "eth-network"
 SECTION_RESOURCES = "resources"
-SECTION_UTIL = "util"
 
 environ_names_and_sections = {
     NAME_DATA_TOKEN_FACTORY_ADDRESS: [


### PR DESCRIPTION
Closes #509 .

Changes proposed in this PR:

- Fix all example flow READMEs to use `ExampleConfig`
- Fix all `metadata_cache_uri` examples that referenced the old network-speicific Aquarius URLs.
- Add `block_confirmations` to `config.ini`
- Remove `Config.SECTION_UITL` constant. Vestige of past design.