### PR TITLE
Removed multi network aqua duplicates from example_config.

### DIFF
--- a/ocean_lib/config.py
+++ b/ocean_lib/config.py
@@ -22,6 +22,7 @@ DEFAULT_BLOCK_CONFIRMATIONS = 1
 DEFAULT_NETWORK_NAME = "ganache"
 DEFAULT_ADDRESS_FILE = ""
 DEFAULT_METADATA_CACHE_URI = "http://localhost:5000"
+METADATA_CACHE_URI = "https://aquarius.oceanprotocol.com"
 DEFAULT_PROVIDER_URL = "http://localhost:8030"
 DEFAULT_DOWNLOADS_PATH = "consume-downloads"
 

--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -11,6 +11,7 @@ from enforce_typing import enforce_types
 from ocean_lib.config import (
     DEFAULT_METADATA_CACHE_URI,
     DEFAULT_PROVIDER_URL,
+    METADATA_CACHE_URI,
     NAME_BLOCK_CONFIRMATIONS,
     NAME_CHAIN_ID,
     NAME_METADATA_CACHE_URI,
@@ -29,67 +30,56 @@ logging.basicConfig(level=logging.INFO)
 CONFIG_NETWORK_HELPER = {
     1: {
         NAME_PROVIDER_URL: "https://provider.mainnet.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "mainnet",
         NAME_BLOCK_CONFIRMATIONS: 1,
     },
     3: {
         NAME_PROVIDER_URL: "https://provider.ropsten.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "ropsten",
         NAME_BLOCK_CONFIRMATIONS: 1,
     },
     4: {
         NAME_PROVIDER_URL: "https://provider.rinkeby.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "rinkeby",
         NAME_BLOCK_CONFIRMATIONS: 1,
     },
     56: {
         NAME_PROVIDER_URL: "https://provider.bsc.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "bsc",
         NAME_BLOCK_CONFIRMATIONS: 1,
     },
     137: {
         NAME_PROVIDER_URL: "https://provider.polygon.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "polygon",
         NAME_BLOCK_CONFIRMATIONS: 15,
     },
     246: {
         NAME_PROVIDER_URL: "https://provider.energyweb.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "energyweb",
         NAME_BLOCK_CONFIRMATIONS: 3,
     },
     1285: {
         NAME_PROVIDER_URL: "https://provider.moonriver.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "moonriver",
         NAME_BLOCK_CONFIRMATIONS: 3,
     },
     1287: {
         NAME_PROVIDER_URL: "https://provider.moonbeamalpha.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "moonbeamalpha",
         NAME_BLOCK_CONFIRMATIONS: 3,
     },
     1337: {
         NAME_PROVIDER_URL: DEFAULT_PROVIDER_URL,
-        NAME_METADATA_CACHE_URI: DEFAULT_METADATA_CACHE_URI,
         NETWORK_NAME: "ganache",
         NAME_BLOCK_CONFIRMATIONS: 0,
     },
     44787: {
         NAME_PROVIDER_URL: "https://provider.celoalfajores.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "celoalfajores",
         NAME_BLOCK_CONFIRMATIONS: 3,
     },
     80001: {
         NAME_PROVIDER_URL: "https://provider.mumbai.oceanprotocol.com",
-        NAME_METADATA_CACHE_URI: "https://aquarius.oceanprotocol.com",
         NETWORK_NAME: "mumbai",
         NAME_BLOCK_CONFIRMATIONS: 1,
     },
@@ -114,9 +104,9 @@ def get_config_dict(chain_id: int) -> dict:
     config_helper[SECTION_RESOURCES].update(
         {
             NAME_PROVIDER_URL: CONFIG_NETWORK_HELPER[chain_id][NAME_PROVIDER_URL],
-            NAME_METADATA_CACHE_URI: CONFIG_NETWORK_HELPER[chain_id][
-                NAME_METADATA_CACHE_URI
-            ],
+            NAME_METADATA_CACHE_URI: METADATA_CACHE_URI
+            if chain_id != 1337
+            else DEFAULT_METADATA_CACHE_URI,
         }
     )
     return config_helper

--- a/ocean_lib/test/test_example_config.py
+++ b/ocean_lib/test/test_example_config.py
@@ -7,6 +7,7 @@ from ocean_lib.config import (
     DEFAULT_METADATA_CACHE_URI,
     DEFAULT_PROVIDER_URL,
     SECTION_ETH_NETWORK,
+    METADATA_CACHE_URI,
 )
 from ocean_lib.example_config import NETWORK_NAME, ExampleConfig
 
@@ -34,7 +35,7 @@ def test_polygon_example_config(monkeypatch):
 
     assert config.chain_id == 137
     assert config.network_url == "https://rpc-mainnet.maticvigil.com"
-    assert config.metadata_cache_uri == "https://aquarius.oceanprotocol.com"
+    assert config.metadata_cache_uri == METADATA_CACHE_URI
     assert config.provider_url == "https://provider.polygon.oceanprotocol.com"
     assert config.block_confirmations.value == 15
 
@@ -49,7 +50,7 @@ def test_bsc_example_config(monkeypatch):
 
     assert config.chain_id == 56
     assert config.network_url == "https://bsc-dataseed.binance.org"
-    assert config.metadata_cache_uri == "https://aquarius.oceanprotocol.com"
+    assert config.metadata_cache_uri == METADATA_CACHE_URI
     assert config.provider_url == "https://provider.bsc.oceanprotocol.com"
     assert config.block_confirmations.value == 1
 
@@ -64,7 +65,7 @@ def test_moonbeam_alpha_example_config(monkeypatch):
 
     assert config.chain_id == 1287
     assert config.network_url == "https://rpc.testnet.moonbeam.network"
-    assert config.metadata_cache_uri == "https://aquarius.oceanprotocol.com"
+    assert config.metadata_cache_uri == METADATA_CACHE_URI
     assert config.provider_url == "https://provider.moonbeamalpha.oceanprotocol.com"
     assert config.block_confirmations.value == 3
 


### PR DESCRIPTION
Fixes #525  .

Changes proposed in this PR:

- remove multi network aqua duplicates from `example_config` and add a constant in `config.py`;
- update test-example_config tests to use the new constant;
- kept `DEFAULT_METADATA_CACHE_URI` for ganache network.