### PR TITLE
CI support for V4

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           repository: "oceanprotocol/barge"
           path: 'barge'
+          ref: v4
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         env:

--- a/artifacts/install-remote.sh
+++ b/artifacts/install-remote.sh
@@ -1,0 +1,9 @@
+##
+## Copyright 2021 Ocean Protocol Foundation
+## SPDX-License-Identifier: Apache-2.0
+##
+
+rm -rf $VIRTUAL_ENV/lib/python3.8/site-packages/artifacts/
+mkdir ${VIRTUAL_ENV}/lib/python3.8/site-packages/artifacts/
+
+find ./artifacts -name '*.json' -exec cp -prv '{}' ${VIRTUAL_ENV}'/lib/python3.8/site-packages/artifacts/' ';'

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,8 @@
+##
+## Copyright 2021 Ocean Protocol Foundation
+## SPDX-License-Identifier: Apache-2.0
+##
+
 rm -rf $VIRTUAL_ENV/lib/python3.8/site-packages/artifacts/
 mkdir ${VIRTUAL_ENV}/lib/python3.8/site-packages/artifacts/
 cp ${HOME}/.ocean/ocean-contracts/artifacts/address.json $VIRTUAL_ENV/lib/python3.8/site-packages/artifacts/address.json

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
 ; requirements.txt with the pinned versions and uncomment the following line:
 ;     -r{toxinidir}/requirements.txt
 commands =
+    sh artifacts/install-remote.sh
     coverage run --source ocean_lib -m py.test --basetemp={envtmpdir}
     coverage report
     coverage xml


### PR DESCRIPTION
Fixes #574 .

Changes proposed in this PR:

- updated `tox.ini` file to run the artifacts locally;
- updated `tox.yml` flow to use v4 branch when barge is running;
- added a new installing script in the artifacts folder.