### PR TITLE
Upgrade web3.py to 5.25.0 (v3)

### DIFF
--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -231,6 +231,7 @@ class ContractBase(object):
             "from": from_wallet.address,
             "account_key": from_wallet.key,
             "chainId": self.web3.eth.chain_id,
+            "gasPrice": self.get_gas_price(self.web3),
         }
 
         gas_price = os.environ.get(ENV_GAS_PRICE, None)
@@ -257,6 +258,11 @@ class ContractBase(object):
         if event:
             return event().argument_names
 
+    @staticmethod
+    @enforce_types
+    def get_gas_price(web3) -> int:
+        return int(web3.eth.gas_price * 1.1)
+
     @classmethod
     @enforce_types
     def deploy(cls, web3: Web3, deployer_wallet: Wallet, *args) -> str:
@@ -273,7 +279,7 @@ class ContractBase(object):
 
         _contract = web3.eth.contract(abi=_json["abi"], bytecode=_json["bytecode"])
         built_tx = _contract.constructor(*args).buildTransaction(
-            {"from": deployer_wallet.address}
+            {"from": deployer_wallet.address, "gasPrice": cls.get_gas_price(web3)}
         )
         if "chainId" not in built_tx:
             built_tx["chainId"] = web3.eth.chain_id

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -209,6 +209,11 @@ class ContractBase(object):
             callback, timeout_callback=timeout_callback, timeout=timeout, blocking=wait
         )
 
+    @staticmethod
+    @enforce_types
+    def get_gas_price(web3) -> int:
+        return int(web3.eth.gas_price * 1.1)
+
     @enforce_types
     def send_transaction(
         self,
@@ -257,11 +262,6 @@ class ContractBase(object):
         event = getattr(self.contract.events, event_name, None)
         if event:
             return event().argument_names
-
-    @staticmethod
-    @enforce_types
-    def get_gas_price(web3) -> int:
-        return int(web3.eth.gas_price * 1.1)
 
     @classmethod
     @enforce_types

--- a/ocean_lib/web3_internal/transactions.py
+++ b/ocean_lib/web3_internal/transactions.py
@@ -16,6 +16,11 @@ from web3.main import Web3
 
 
 @enforce_types
+def get_gas_price(web3) -> int:
+    return int(web3.eth.gas_price * 1.1)
+
+
+@enforce_types
 def sign_hash(msg_hash: SignableMessage, wallet: Wallet) -> str:
     """
     This method use `personal_sign`for signing a message. This will always prepend the
@@ -41,6 +46,7 @@ def send_ether(from_wallet: Wallet, to_address: str, amount: int) -> AttributeDi
         "to": to_address,
         "value": amount,
         "chainId": chain_id,
+        "gasPrice": get_gas_price(web3),
     }
     tx["gas"] = web3.eth.estimate_gas(tx)
     raw_tx = from_wallet.sign_tx(tx)
@@ -72,6 +78,7 @@ def cancel_or_replace_transaction(
         "to": from_wallet.address,
         "value": 0,
         "chainId": chain_id,
+        "gasPrice": get_gas_price(web3),
     }
     gas = gas_limit if gas_limit is not None else web3.eth.estimate_gas(tx)
     tx["gas"] = gas + 1

--- a/ocean_lib/web3_internal/web3_overrides/test/test_utils.py
+++ b/ocean_lib/web3_internal/web3_overrides/test/test_utils.py
@@ -5,6 +5,7 @@
 from threading import Event, Thread, current_thread
 
 from ocean_lib.web3_internal.constants import BLOCK_NUMBER_POLL_INTERVAL
+from ocean_lib.web3_internal.transactions import get_gas_price
 from ocean_lib.web3_internal.web3_overrides.utils import (
     wait_for_transaction_receipt_and_block_confirmations,
 )
@@ -24,6 +25,7 @@ def test_block_confirmations():
         "to": bob_address,
         "value": 1,
         "chainId": web3.eth.chain_id,
+        "gasPrice": get_gas_price(web3),
     }
     tx["gas"] = web3.eth.estimate_gas(tx)
     raw_tx = alice_wallet.sign_tx(tx)
@@ -64,6 +66,7 @@ def send_dummy_transactions(from_wallet, to_address):
             "to": to_address,
             "value": 1,
             "chainId": web3.eth.chain_id,
+            "gasPrice": get_gas_price(web3),
         }
         tx["gas"] = web3.eth.estimate_gas(tx)
         raw_tx = from_wallet.sign_tx(tx)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requirements = [
     "pycryptodomex",
     "tqdm",
     "pytz",
-    "web3==5.19.0",
+    "web3==5.25.0",
     "cryptography==3.3.2",
     "scipy",
     "enforce-typing==1.0.0.post1",


### PR DESCRIPTION
Towards #521

Changes proposed in this PR:

- Upgrade web3.py to 5.25.0
- Continue using legacy transactions (not EIP-1559) by adding `gasPrice` to all transaction dicts