### PR TITLE
Multiple orders

### DIFF
--- a/ocean_lib/models/erc721_factory.py
+++ b/ocean_lib/models/erc721_factory.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 from enforce_typing import enforce_types
 from ocean_lib.models.erc_token_factory_base import ERCTokenFactoryBase
 from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
-from ocean_lib.models.models_structures import OrderData
 from ocean_lib.web3_internal.wallet import Wallet
 from web3.datastructures import AttributeDict
 
@@ -127,9 +126,6 @@ class ERC721FactoryContract(ERCTokenFactoryBase):
         - r, bytes
         - s, bytes
         """
-        if orders and isinstance(orders[0], OrderData):
-            orders = [tuple(o) for o in orders]
-
         return self.send_transaction("startMultipleTokenOrder", (orders,), from_wallet)
 
     def create_nft_with_erc(

--- a/ocean_lib/models/erc721_factory.py
+++ b/ocean_lib/models/erc721_factory.py
@@ -5,12 +5,11 @@
 from typing import List, Optional
 
 from enforce_typing import enforce_types
-from eth_abi import encode_single
-from web3.datastructures import AttributeDict
-
 from ocean_lib.models.erc_token_factory_base import ERCTokenFactoryBase
 from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
+from ocean_lib.models.models_structures import OrderData
 from ocean_lib.web3_internal.wallet import Wallet
+from web3.datastructures import AttributeDict
 
 
 @enforce_types
@@ -114,7 +113,7 @@ class ERC721FactoryContract(ERCTokenFactoryBase):
     def template_count(self) -> int:
         return self.contract.caller.templateCount()
 
-    def start_multiple_token_order(self, orders, from_wallet: Wallet) -> str:
+    def start_multiple_token_order(self, orders: list, from_wallet: Wallet) -> str:
         """An order contains the following keys:
 
         - tokenAddress, str
@@ -128,16 +127,10 @@ class ERC721FactoryContract(ERCTokenFactoryBase):
         - r, bytes
         - s, bytes
         """
-        # encode_abi('(address,address,uint256,address,address,uint256,uin8,bytes32,bytes32,bytes)'[], [mytuple])
+        if orders and isinstance(orders[0], OrderData):
+            orders = [tuple(o) for o in orders]
 
-        encodedOrders = encode_single(
-            "(address,address,uint256,address,address,uint256,uint8,bytes32,bytes32,bytes)[]",
-            orders,
-        )
-
-        return self.send_transaction(
-            "startMultipleTokenOrder", (encodedOrders,), from_wallet
-        )
+        return self.send_transaction("startMultipleTokenOrder", (orders,), from_wallet)
 
     def create_nft_with_erc(
         self, nft_create_data: dict, erc_create_data: dict, from_wallet: Wallet

--- a/ocean_lib/models/erc721_factory.py
+++ b/ocean_lib/models/erc721_factory.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from enforce_typing import enforce_types
 from ocean_lib.models.erc_token_factory_base import ERCTokenFactoryBase
 from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
+from ocean_lib.models.models_structures import OrderData
 from ocean_lib.web3_internal.wallet import Wallet
 from web3.datastructures import AttributeDict
 
@@ -126,6 +127,10 @@ class ERC721FactoryContract(ERCTokenFactoryBase):
         - r, bytes
         - s, bytes
         """
+        # TODO: this will be handled in web3 py
+        if orders and isinstance(orders[0], OrderData):
+            orders = [tuple(o) for o in orders]
+
         return self.send_transaction("startMultipleTokenOrder", (orders,), from_wallet)
 
     def create_nft_with_erc(

--- a/ocean_lib/models/models_structures.py
+++ b/ocean_lib/models/models_structures.py
@@ -86,18 +86,26 @@ Operations = NamedTuple(
     ],
 )
 
-OrderData = NamedTuple(
-    "OrderData",
+ProviderFees = NamedTuple(
+    "ProviderFees",
     [
-        ("token_address", str),
-        ("consumer", str),
-        ("service_index", int),
         ("provider_fee_address", str),
         ("provider_fee_token", str),
         ("provider_fee_amount", int),
         ("v", str),
         ("r", str),
         ("s", str),
+        ("validUntil", int),
         ("provider_data", bytes),
+    ],
+)
+
+OrderData = NamedTuple(
+    "OrderData",
+    [
+        ("token_address", str),
+        ("consumer", str),
+        ("service_index", int),
+        ("provider_fees", ProviderFees),
     ],
 )

--- a/ocean_lib/models/models_structures.py
+++ b/ocean_lib/models/models_structures.py
@@ -85,3 +85,19 @@ Operations = NamedTuple(
         ("market_fee_address", int),
     ],
 )
+
+OrderData = NamedTuple(
+    "OrderData",
+    [
+        ("token_address", str),
+        ("consumer", str),
+        ("service_index", int),
+        ("provider_fee_address", str),
+        ("provider_fee_token", str),
+        ("provider_fee_amount", int),
+        ("v", str),
+        ("r", str),
+        ("s", str),
+        ("provider_data", bytes),
+    ],
+)

--- a/ocean_lib/models/test/test_erc721_factory.py
+++ b/ocean_lib/models/test/test_erc721_factory.py
@@ -534,8 +534,14 @@ def test_start_multiple_order(
     provider_data = b"\x00"
 
     message = Web3.solidityKeccak(
-        ["bytes", "address", "address", "uint256"],
-        [provider_data, provider_fee_address, provider_fee_token, provider_fee_amount],
+        ["bytes", "address", "address", "uint256", "uint256"],
+        [
+            provider_data,
+            provider_fee_address,
+            provider_fee_token,
+            provider_fee_amount,
+            0,
+        ],
     )
     signed = web3.eth.sign(provider_fee_address, data=message)
     signature = split_signature(signed)
@@ -544,13 +550,16 @@ def test_start_multiple_order(
         erc20_address,
         consumer_wallet.address,
         1,
-        provider_fee_address,
-        provider_fee_token,
-        provider_fee_amount,
-        signature.v,
-        signature.r,
-        signature.s,
-        provider_data,
+        (
+            provider_fee_address,
+            provider_fee_token,
+            provider_fee_amount,
+            signature.v,
+            signature.r,
+            signature.s,
+            0,
+            provider_data,
+        ),
     )
 
     orders = [order_data, order_data]

--- a/ocean_lib/models/test/test_erc721_factory.py
+++ b/ocean_lib/models/test/test_erc721_factory.py
@@ -9,6 +9,7 @@ from ocean_lib.models.erc721_factory import ERC721FactoryContract
 from ocean_lib.models.erc721_token import ERC721Token
 from ocean_lib.models.models_structures import ErcCreateData, OrderData
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
+from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.utils import split_signature
 from tests.resources.helper_functions import get_address_of_type
 from web3 import exceptions
@@ -486,7 +487,7 @@ def test_start_multiple_order(
             publisher_wallet.address,
             ZERO_ADDRESS,
         ],
-        [web3.toWei("2", "ether"), 0],
+        [to_wei("2"), 0],
         [b""],
     )
     tx_result = erc721_token.create_erc20(erc_create_data, consumer_wallet)
@@ -515,7 +516,7 @@ def test_start_multiple_order(
 
     # Tests starting multiple token orders successfully
     erc20_token = ERC20Token(web3, erc20_address)
-    dt_amount = web3.toWei("2", "ether")
+    dt_amount = to_wei("2")
     mock_dai_contract_address = get_address_of_type(config, "MockDAI")
     assert erc20_token.balanceOf(consumer_wallet.address) == 0
 


### PR DESCRIPTION
Work on #639.

Here's the current state of this: we need to manually convert NamedTuples to regular tuples. I tested this functionality with our current web3.py and it works properly, but it means we can not use higher level APIs such as nested tuples, tuple lists and named tuples without converting them manually.

Testing with my changes in the web3.py, we can safely remove the forced conversions, which are now marked with a TODO.

---
My plan is to standardise all tuple sending inside ocean.py after this fix is merged into web3.py. This way, we can allow users to use regular tuples, dictionaries etc. but we can also standardise and reuse NamedTuple structures throughout our application. E.g. provider fees, ERC20 create data, Pool data, FRE data, OrderData etc. Right now, the structures are all over the place e.g.:

- we use the CreateERC20 tuple directly inside of some functions, regular tuples in others. We can not offer both options at once (see regular creation vs. factory creation for simultaneous creation of ERC721 and ERC20)
- we depend on "knowing" the contents of our tuples instead of sending them as passthroughs, meaning whenever some item will change, it will have to change thoughout the entire application
- ProviderFees is reused many times, but it is the opposite of DRY. Instead of reusing a specific NamedTuple structure, we redefine its components everywhere we reuse it.
- without a data structure, with "free" tuples inside the application, any changes are tedious and need attention to ordering etc.

Should we create a separate issue for this? While it is true that this PR fixes a blocker, I would like to add this tuple standardisation into ocean.py since it will greatly benefit us and our users.