### PR TITLE
Issue694 remove compute status filtering

### DIFF
--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -355,7 +355,7 @@ Here is a list of possible results: [Operator Service Status description](https:
 Once you get `{'ok': True, 'status': 70, 'statusText': 'Job finished'}`, Bob can check the result of the job.
 
 ```python
-result = ocean.compute.result_file(DATA_did, job_id, 0, bob_wallet)  # 0 index, means we retrieve the results from the first dataset index
+result = ocean.compute.result(DATA_did, job_id, 0, bob_wallet)  # 0 index, means we retrieve the results from the first dataset index
 
 import pickle
 model = pickle.loads(result)  # the gaussian model result

--- a/ocean_lib/data_provider/data_service_provider.py
+++ b/ocean_lib/data_provider/data_service_provider.py
@@ -388,26 +388,6 @@ class DataServiceProvider:
     @staticmethod
     @enforce_types
     def compute_job_result(
-        did: str, job_id: str, service_endpoint: str, consumer: Wallet
-    ) -> Dict[str, Any]:
-        """
-
-        :param did: hex str the asset/DDO id
-        :param job_id: str id of compute job that was returned from `start_compute_job`
-        :param service_endpoint: str url of the provider service endpoint for compute service
-        :param consumer_address: hex str the ethereum address of the consumer's account
-        :param signature: hex str signed message to allow the provider to authorize the consumer
-
-        :return: dict of job_id to result urls. When job_id is not provided, this will return
-            result for each job_id that exist for the did
-        """
-        return DataServiceProvider._send_compute_request(
-            "get", did, job_id, service_endpoint, consumer
-        )
-
-    @staticmethod
-    @enforce_types
-    def compute_job_result_file(
         job_id: str, index: int, service_endpoint: str, consumer: Wallet
     ) -> Dict[str, Any]:
         """

--- a/ocean_lib/data_provider/test/test_data_service_provider.py
+++ b/ocean_lib/data_provider/test/test_data_service_provider.py
@@ -125,9 +125,9 @@ def test_send_compute_request_failure(with_evil_client, provider_wallet):
         )
 
 
-def test_compute_job_result(with_nice_client, provider_wallet):
+def test_compute_job_status(with_nice_client, provider_wallet):
     """Tests successful compute job starting."""
-    result = DataSP.compute_job_result(
+    result = DataSP.compute_job_status(
         "some_did", "some_job_id", "http://mock", provider_wallet
     )
     assert result == {"good_job": "with_mock"}

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -34,17 +34,14 @@ class OceanCompute:
 
     @staticmethod
     @enforce_types
-    def _status_from_job_info(job_info: Dict[str, Any]) -> Dict[str, Any]:
+    def _add_ok_to_job_info(job_info: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Helper function to extract the status dict with an added boolean for quick validation
-        :param job_info: dict having status and statusText keys
-        :return:
+        Helper method to add the "ok" key to the job info dict for quick validation.
+        :param job_info: dict returned by computeStatus endpoint in provider
+        :return: dict with the "ok" key added
         """
-        return {
-            "ok": job_info["status"] not in (31, 32),
-            "status": job_info["status"],
-            "statusText": job_info["statusText"],
-        }
+        job_info.update({"ok": job_info["status"] not in (31, 32)})
+        return job_info
 
     @enforce_types
     def start(
@@ -94,38 +91,17 @@ class OceanCompute:
         :param did: str id of the asset offering the compute service of this job
         :param job_id: str id of the compute job
         :param wallet: Wallet instance
-        :return: dict the status for an existing compute job, keys are (ok, status, statusText)
+        :return: dict the status for an existing compute job
         """
         _, service_endpoint = self._get_service_endpoint(did)
-
-        return OceanCompute._status_from_job_info(
+        return OceanCompute._add_ok_to_job_info(
             self._data_provider.compute_job_status(
                 did, job_id, service_endpoint, wallet
             )
         )
 
     @enforce_types
-    def result(self, did: str, job_id: str, wallet: Wallet) -> Dict[str, Any]:
-        """
-        Gets job result.
-
-        :param did: str id of the asset offering the compute service of this job
-        :param job_id: str id of the compute job
-        :param wallet: Wallet instance
-        :return: dict the results/logs urls for an existing compute job, keys are (did, urls, logs)
-        """
-        _, service_endpoint = self._get_service_endpoint(did)
-        info_dict = self._data_provider.compute_job_result(
-            did, job_id, service_endpoint, wallet
-        )
-        return {
-            "did": info_dict.get("resultsDid", ""),
-            "urls": info_dict.get("resultsUrl", []),
-            "logs": info_dict.get("algorithmLogUrl", []),
-        }
-
-    @enforce_types
-    def result_file(
+    def result(
         self, did: str, job_id: str, index: int, wallet: Wallet
     ) -> Dict[str, Any]:
         """
@@ -154,7 +130,7 @@ class OceanCompute:
         :return: dict the status for the stopped compute job, keys are (ok, status, statusText)
         """
         _, service_endpoint = self._get_service_endpoint(did)
-        return self._status_from_job_info(
+        return self._add_ok_to_job_info(
             self._data_provider.stop_compute_job(did, job_id, service_endpoint, wallet)
         )
 

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -86,7 +86,7 @@ class OceanCompute:
         job_info = self._data_provider.compute_job_status(
             did, job_id, service_endpoint, wallet
         )
-        job_info.update({"ok": job_info["status"] not in (31, 32)})
+        job_info.update({"ok": job_info.get("status") not in (31, 32, None)})
         return job_info
 
     @enforce_types
@@ -122,7 +122,7 @@ class OceanCompute:
         job_info = self._data_provider.stop_compute_job(
             did, job_id, service_endpoint, wallet
         )
-        job_info.update({"ok": job_info["status"] not in (31, 32)})
+        job_info.update({"ok": job_info.get("status") not in (31, 32, None)})
         return job_info
 
     @enforce_types

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -102,7 +102,7 @@ class OceanCompute:
         :return: dict the results/logs urls for an existing compute job, keys are (did, urls, logs)
         """
         _, service_endpoint = self._get_compute_result_file_endpoint(did)
-        result = self._data_provider.compute_job_result_file(
+        result = self._data_provider.compute_job_result(
             job_id, index, service_endpoint, wallet
         )
 

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -32,17 +32,6 @@ class OceanCompute:
         self._config = config
         self._data_provider = data_provider
 
-    @staticmethod
-    @enforce_types
-    def _add_ok_to_job_info(job_info: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Helper method to add the "ok" key to the job info dict for quick validation.
-        :param job_info: dict returned by computeStatus endpoint in provider
-        :return: dict with the "ok" key added
-        """
-        job_info.update({"ok": job_info["status"] not in (31, 32)})
-        return job_info
-
     @enforce_types
     def start(
         self,
@@ -94,11 +83,11 @@ class OceanCompute:
         :return: dict the status for an existing compute job
         """
         _, service_endpoint = self._get_service_endpoint(did)
-        return OceanCompute._add_ok_to_job_info(
-            self._data_provider.compute_job_status(
-                did, job_id, service_endpoint, wallet
-            )
+        job_info = self._data_provider.compute_job_status(
+            did, job_id, service_endpoint, wallet
         )
+        job_info.update({"ok": job_info["status"] not in (31, 32)})
+        return job_info
 
     @enforce_types
     def result(
@@ -130,9 +119,11 @@ class OceanCompute:
         :return: dict the status for the stopped compute job, keys are (ok, status, statusText)
         """
         _, service_endpoint = self._get_service_endpoint(did)
-        return self._add_ok_to_job_info(
-            self._data_provider.stop_compute_job(did, job_id, service_endpoint, wallet)
+        job_info = self._data_provider.stop_compute_job(
+            did, job_id, service_endpoint, wallet
         )
+        job_info.update({"ok": job_info["status"] not in (31, 32)})
+        return job_info
 
     @enforce_types
     def _get_service_endpoint(

--- a/tests/integration/test_compute_flow.py
+++ b/tests/integration/test_compute_flow.py
@@ -268,12 +268,6 @@ def run_compute_test(
     assert status, f"something not right about the compute job, got status: {status}"
 
     if with_result:
-        result = ocean_instance.compute.result(
-            dataset_and_userdata.asset.did, job_id, consumer_wallet
-        )
-        print(f"got job status after requesting result: {result}")
-        assert "did" in result, "something not right about the compute job, no did."
-
         succeeded = False
         for _ in range(0, 200):
             status = ocean_instance.compute.status(
@@ -287,7 +281,7 @@ def run_compute_test(
             time.sleep(5)
 
         assert succeeded, "compute job unsuccessful"
-        result_file = ocean_instance.compute.result_file(
+        result_file = ocean_instance.compute.result(
             dataset_and_userdata.asset.did, job_id, 0, consumer_wallet
         )
         assert result_file is not None


### PR DESCRIPTION
Fixes #694.

Changes proposed in this PR:

- Remove compute status filters
- Refactor `OceanCompute` `status()`, `result()`, and `result_file()`.
- Refactor `DataServiceProvider` `compute_job_status()`, `compute_job_result()`, and `compute_job_result_file()`