### PR TITLE
Testing NFT transfer

### DIFF
--- a/ocean_lib/models/erc20_token.py
+++ b/ocean_lib/models/erc20_token.py
@@ -51,10 +51,6 @@ class ERC20Token(ContractBase):
         return self.events.PublishMarketFeeChanged()
 
     @property
-    def event_PublishMarketFee(self):
-        return self.events.PublishMarketFee()
-
-    @property
     def event_ConsumeMarketFee(self):
         return self.events.ConsumeMarketFee()
 

--- a/ocean_lib/models/erc20_token.py
+++ b/ocean_lib/models/erc20_token.py
@@ -12,7 +12,7 @@ from ocean_lib.web3_internal.wallet import Wallet
 
 class RolesERC20(IntEnum):
     MINTER = 0
-    PAYMENT_COLLECTOR = 1
+    PAYMENT_MANAGER = 1
 
 
 @enforce_types

--- a/ocean_lib/models/erc20_token.py
+++ b/ocean_lib/models/erc20_token.py
@@ -12,7 +12,7 @@ from ocean_lib.web3_internal.wallet import Wallet
 
 class RolesERC20(IntEnum):
     MINTER = 0
-    FEE_MANAGER = 1
+    PAYMENT_COLLECTOR = 1
 
 
 @enforce_types
@@ -27,7 +27,6 @@ class ERC20Token(ContractBase):
     EVENT_ORDER_REUSED = "OrderReused"
     EVENT_ORDER_EXECUTED = "OrderExecuted"
     EVENT_PUBLISH_MARKET_FEE_CHANGED = "PublishMarketFeeChanged"
-    EVENT_PUBLISH_MARKET_FEE = "PublishMarketFee"
     EVENT_CONSUME_MARKET_FEE = "ConsumeMarketFee"
     EVENT_PROVIDER_FEE = "ProviderFee"
     EVENT_MINTER_PROPOSED = "MinterProposed"

--- a/ocean_lib/models/erc721_factory.py
+++ b/ocean_lib/models/erc721_factory.py
@@ -25,6 +25,7 @@ class ERC721FactoryContract(ERCTokenFactoryBase):
     EVENT_NEW_POOL = "NewPool"
     EVENT_NEW_FIXED_RATE = "NewFixedRate"
     EVENT_DISPENSER_CREATED = "DispenserCreated"
+    EVENT_TRANSFER = "Transfer"
 
     @property
     def event_NFTCreated(self):
@@ -53,6 +54,10 @@ class ERC721FactoryContract(ERCTokenFactoryBase):
     @property
     def event_DispenserCreated(self):
         return self.events.DispenserCreated()
+
+    @property
+    def event_Transfer(self):
+        return self.events.Transfer()
 
     def verify_nft(self, nft: str) -> bool:
         """Checks that a token was registered."""

--- a/ocean_lib/models/test/test_erc20_enterprise.py
+++ b/ocean_lib/models/test/test_erc20_enterprise.py
@@ -196,7 +196,6 @@ def test_buy_from_fre_and_order(
         fixed_rate=to_wei(1),
         market_fee=to_wei("0.1"),
         with_mint=1,
-        payment_collector=0,
         from_wallet=publisher_wallet,
     )
 

--- a/ocean_lib/models/test/test_erc20_enterprise.py
+++ b/ocean_lib/models/test/test_erc20_enterprise.py
@@ -196,6 +196,7 @@ def test_buy_from_fre_and_order(
         fixed_rate=to_wei(1),
         market_fee=to_wei("0.1"),
         with_mint=1,
+        payment_collector=0,
         from_wallet=publisher_wallet,
     )
 

--- a/ocean_lib/models/test/test_erc20_token.py
+++ b/ocean_lib/models/test/test_erc20_token.py
@@ -196,7 +196,7 @@ def test_main(web3, config, publisher_wallet, consumer_wallet, factory_router):
 
     permissions = erc20.get_permissions(publisher_wallet.address)
     assert not permissions[RolesERC20.MINTER]
-    assert not permissions[RolesERC20.FEE_MANAGER]
+    assert not permissions[RolesERC20.PAYMENT_COLLECTOR]
 
     # User should succeed to call startOrder on a ERC20 without publishFees, consumeFeeAmount on top is ZERO
     # Get new tokens

--- a/ocean_lib/models/test/test_erc20_token.py
+++ b/ocean_lib/models/test/test_erc20_token.py
@@ -40,9 +40,6 @@ def test_properties(web3, config, publisher_wallet):
         == ERC20Token.EVENT_PUBLISH_MARKET_FEE_CHANGED
     )
     assert (
-        erc20.event_PublishMarketFee.abi["name"] == ERC20Token.EVENT_PUBLISH_MARKET_FEE
-    )
-    assert (
         erc20.event_ConsumeMarketFee.abi["name"] == ERC20Token.EVENT_CONSUME_MARKET_FEE
     )
     assert erc20.event_ProviderFee.abi["name"] == ERC20Token.EVENT_PROVIDER_FEE

--- a/ocean_lib/models/test/test_erc20_token.py
+++ b/ocean_lib/models/test/test_erc20_token.py
@@ -196,7 +196,7 @@ def test_main(web3, config, publisher_wallet, consumer_wallet, factory_router):
 
     permissions = erc20.get_permissions(publisher_wallet.address)
     assert not permissions[RolesERC20.MINTER]
-    assert not permissions[RolesERC20.PAYMENT_COLLECTOR]
+    assert not permissions[RolesERC20.PAYMENT_MANAGER]
 
     # User should succeed to call startOrder on a ERC20 without publishFees, consumeFeeAmount on top is ZERO
     # Get new tokens

--- a/ocean_lib/models/test/test_erc721_factory.py
+++ b/ocean_lib/models/test/test_erc721_factory.py
@@ -55,6 +55,10 @@ def test_properties(web3, config):
         erc721_factory.event_DispenserCreated.abi["name"]
         == ERC721FactoryContract.EVENT_DISPENSER_CREATED
     )
+    assert (
+        erc721_factory.event_Transfer.abi["name"]
+        == ERC721FactoryContract.EVENT_TRANSFER
+    )
 
 
 @pytest.mark.unit

--- a/ocean_lib/models/test/test_erc721_token.py
+++ b/ocean_lib/models/test/test_erc721_token.py
@@ -821,7 +821,7 @@ def test_transfer_nft(web3, config, publisher_wallet, consumer_wallet, factory_r
     bpool_address = pool_event[0].args.poolAddress
     bpool = BPool(web3, bpool_address)
     assert bpool.is_finalized() is True
-    assert bpool.opc_fee() == to_wei("0.001")
+    assert bpool.opc_fee() == to_wei("0.002")
     assert bpool.get_swap_fee() == to_wei("0.003")
     assert bpool.community_fee(base_token.address) == 0
     assert bpool.community_fee(erc20_token.address) == 0
@@ -1047,7 +1047,7 @@ def test_transfer_nft_with_erc20_pool_fre(
     bpool_address = pool_event[0].args.poolAddress
     bpool = BPool(web3, bpool_address)
     assert bpool.is_finalized() is True
-    assert bpool.opc_fee() == to_wei("0.001")
+    assert bpool.opc_fee() == to_wei("0.002")
     assert bpool.get_swap_fee() == to_wei("0.003")
     assert bpool.community_fee(base_token.address) == 0
     assert bpool.community_fee(erc20_token.address) == 0

--- a/ocean_lib/models/test/test_erc721_token.py
+++ b/ocean_lib/models/test/test_erc721_token.py
@@ -647,6 +647,7 @@ def test_fail_transfer_function(web3, config, publisher_wallet, consumer_wallet)
 
 
 def test_transfer_nft(web3, config, publisher_wallet, consumer_wallet, factory_router):
+    """Tests transferring the NFT before deploying an ERC20, a pool, a FRE."""
     erc721_factory_address = get_address_of_type(
         config, ERC721FactoryContract.CONTRACT_NAME
     )
@@ -760,6 +761,7 @@ def test_transfer_nft(web3, config, publisher_wallet, consumer_wallet, factory_r
     erc20_token = ERC20Token(web3, erc20_address)
 
     assert erc20_token.is_minter(publisher_wallet.address) is False
+    assert erc20_token.is_minter(consumer_wallet.address) is True
     erc20_token.add_minter(publisher_wallet.address, consumer_wallet)
     assert (
         erc20_token.get_permissions(publisher_wallet.address)[0] is True
@@ -788,7 +790,7 @@ def test_transfer_nft(web3, config, publisher_wallet, consumer_wallet, factory_r
     assert publish_fees[1] == base_token.address
     assert publish_fees[2] == to_wei(1)
 
-    # The newest owner of the NFT (consumer wallet) has ERC20 deployer role & can deploy a pool, add/swap/remove liquidity
+    # The newest owner of the NFT (consumer wallet) can deploy a pool
     base_token.mint(consumer_wallet.address, to_wei(200), consumer_wallet)
     assert base_token.balanceOf(consumer_wallet.address) == to_wei(200)
     base_token.approve(factory_router.address, to_wei(10000), consumer_wallet)
@@ -896,7 +898,7 @@ def test_transfer_nft(web3, config, publisher_wallet, consumer_wallet, factory_r
     )
     assert bpt_event[0].args.bptAmount  # amount in pool shares
 
-    # The newest owner of the NFT (consumer wallet) has ERC20 deployer role & can deploy a FRE, collect BT/DT, buy/sell DT
+    # The newest owner of the NFT (consumer wallet) has ERC20 deployer role & can deploy a FRE
     fixed_exchange = FixedRateExchange(web3, get_address_of_type(config, "FixedPrice"))
     number_of_exchanges = fixed_exchange.get_number_of_exchanges()
     tx = erc20_token.create_fixed_rate(
@@ -948,3 +950,225 @@ def test_transfer_nft(web3, config, publisher_wallet, consumer_wallet, factory_r
     assert exchange_details[FixedRateExchangeDetails.DT_BALANCE] == 0
     assert exchange_details[FixedRateExchangeDetails.BT_BALANCE] == 0
     assert exchange_details[FixedRateExchangeDetails.WITH_MINT] is False
+
+
+def test_transfer_nft_with_erc20_pool_fre(
+    web3, config, publisher_wallet, consumer_wallet, factory_router
+):
+    """Tests transferring the NFT after deploying an ERC20, a pool, a FRE."""
+    erc721_factory_address = get_address_of_type(
+        config, ERC721FactoryContract.CONTRACT_NAME
+    )
+    erc721_factory = ERC721FactoryContract(web3, erc721_factory_address)
+
+    tx = erc721_factory.deploy_erc721_contract(
+        name="NFT to TRANSFER",
+        symbol="NFTtT",
+        template_index=1,
+        additional_metadata_updater=ZERO_ADDRESS,
+        additional_erc20_deployer=consumer_wallet.address,
+        token_uri="https://oceanprotocol.com/nft/",
+        from_wallet=publisher_wallet,
+    )
+    tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
+    registered_event = erc721_factory.get_event_log(
+        ERC721FactoryContract.EVENT_NFT_CREATED,
+        tx_receipt.blockNumber,
+        web3.eth.block_number,
+        None,
+    )
+    assert registered_event[0].event == "NFTCreated"
+    assert registered_event[0].args.admin == publisher_wallet.address
+    token_address = registered_event[0].args.newTokenAddress
+    erc721_nft = ERC721NFT(web3, token_address)
+    assert erc721_nft.contract.caller.name() == "NFT to TRANSFER"
+    assert erc721_nft.symbol() == "NFTtT"
+
+    # Creates an ERC20
+    tx_result = erc721_nft.create_erc20(
+        template_index=1,
+        datatoken_name="ERC20DT1",
+        datatoken_symbol="ERC20DT1Symbol",
+        datatoken_minter=publisher_wallet.address,
+        datatoken_fee_manager=publisher_wallet.address,
+        datatoken_publishing_market_address=publisher_wallet.address,
+        fee_token_address=ZERO_ADDRESS,
+        datatoken_cap=to_wei(200),
+        publishing_market_fee_amount=0,
+        bytess=[b""],
+        from_wallet=publisher_wallet,
+    )
+    assert tx_result, "Failed to create ERC20 token."
+    tx_receipt = web3.eth.wait_for_transaction_receipt(tx_result)
+    registered_token_event = erc721_factory.get_event_log(
+        ERC721FactoryContract.EVENT_TOKEN_CREATED,
+        tx_receipt.blockNumber,
+        web3.eth.block_number,
+        None,
+    )
+    assert registered_token_event, "Cannot find TokenCreated event."
+    erc20_address = registered_token_event[0].args.newTokenAddress
+    erc20_token = ERC20Token(web3, erc20_address)
+
+    assert erc20_token.is_minter(publisher_wallet.address) is True
+
+    _, base_token = deploy_erc721_erc20(
+        web3, config, publisher_wallet, publisher_wallet, cap=to_wei(250)
+    )
+
+    # The owner of the NFT (publisher wallet) has ERC20 deployer role & can deploy a pool
+    base_token.mint(publisher_wallet.address, to_wei(200), publisher_wallet)
+    assert base_token.balanceOf(publisher_wallet.address) == to_wei(200)
+    base_token.approve(factory_router.address, to_wei(10000), publisher_wallet)
+    tx = erc20_token.deploy_pool(
+        rate=to_wei(1),
+        basetoken_decimals=base_token.decimals(),
+        vesting_amount=to_wei(10),
+        vested_blocks=2500000,
+        initial_liq=to_wei(100),
+        lp_swap_fee=to_wei("0.003"),
+        market_swap_fee=to_wei("0.001"),
+        ss_contract=get_address_of_type(config, "Staking"),
+        basetoken_address=base_token.address,
+        basetoken_sender=publisher_wallet.address,
+        publisher_address=publisher_wallet.address,
+        market_fee_collector=publisher_wallet.address,
+        pool_template_address=get_address_of_type(config, "poolTemplate"),
+        from_wallet=publisher_wallet,
+    )
+    tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
+    pool_event = factory_router.get_event_log(
+        ERC721FactoryContract.EVENT_NEW_POOL,
+        tx_receipt.blockNumber,
+        web3.eth.block_number,
+        None,
+    )
+    assert pool_event[0].event == "NewPool"
+    bpool_address = pool_event[0].args.poolAddress
+    bpool = BPool(web3, bpool_address)
+    assert bpool.is_finalized() is True
+    assert bpool.opc_fee() == to_wei("0.001")
+    assert bpool.get_swap_fee() == to_wei("0.003")
+    assert bpool.community_fee(base_token.address) == 0
+    assert bpool.community_fee(erc20_token.address) == 0
+    assert bpool.publish_market_fee(base_token.address) == 0
+    assert bpool.publish_market_fee(erc20_token.address) == 0
+
+    base_token.approve(bpool_address, to_wei(1000000), publisher_wallet)
+    tx = bpool.join_swap_extern_amount_in(
+        token_amount_in=to_wei(10),
+        min_pool_amount_out=to_wei(1),
+        from_wallet=publisher_wallet,
+    )
+
+    tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
+    join_event = bpool.get_event_log(
+        BPool.EVENT_LOG_JOIN,
+        tx_receipt.blockNumber,
+        web3.eth.block_number,
+        None,
+    )
+    assert join_event[0].args.caller == publisher_wallet.address
+    assert join_event[0].args.tokenIn == base_token.address
+    assert join_event[0].args.tokenAmountIn == to_wei(10)
+
+    bpt_event = bpool.get_event_log(
+        BPool.EVENT_LOG_BPT, tx_receipt.blockNumber, web3.eth.block_number, None
+    )
+    assert bpt_event[0].args.bptAmount  # amount in pool shares
+    assert bpool.get_balance(base_token.address) == to_wei(100) + to_wei(10)
+
+    # The owner of the NFT (publisher wallet) has ERC20 deployer role & can deploy a FRE
+    fixed_exchange = FixedRateExchange(web3, get_address_of_type(config, "FixedPrice"))
+    number_of_exchanges = fixed_exchange.get_number_of_exchanges()
+    tx = erc20_token.create_fixed_rate(
+        fixed_price_address=fixed_exchange.address,
+        basetoken_address=base_token.address,
+        owner=publisher_wallet.address,
+        market_fee_collector=publisher_wallet.address,
+        allowed_swapper=ZERO_ADDRESS,
+        basetoken_decimals=18,
+        datatoken_decimals=18,
+        fixed_rate=to_wei(1),
+        market_fee=to_wei("0.001"),
+        with_mint=0,
+        from_wallet=publisher_wallet,
+    )
+
+    tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
+
+    fre_event = erc20_token.get_event_log(
+        event_name=ERC721FactoryContract.EVENT_NEW_FIXED_RATE,
+        from_block=tx_receipt.blockNumber,
+        to_block=web3.eth.block_number,
+        filters=None,
+    )
+
+    assert fixed_exchange.get_number_of_exchanges() == number_of_exchanges + 1
+    assert fre_event[0].args.owner == publisher_wallet.address
+
+    exchange_id = fre_event[0].args.exchangeId
+
+    exchange_details = fixed_exchange.get_exchange(exchange_id)
+    assert (
+        exchange_details[FixedRateExchangeDetails.EXCHANGE_OWNER]
+        == publisher_wallet.address
+    )
+    assert exchange_details[FixedRateExchangeDetails.DATATOKEN] == erc20_token.address
+    assert (
+        exchange_details[FixedRateExchangeDetails.DT_DECIMALS] == erc20_token.decimals()
+    )
+    assert exchange_details[FixedRateExchangeDetails.BASE_TOKEN] == base_token.address
+    assert (
+        exchange_details[FixedRateExchangeDetails.BT_DECIMALS] == base_token.decimals()
+    )
+    assert exchange_details[FixedRateExchangeDetails.FIXED_RATE] == to_wei(1)
+    assert exchange_details[FixedRateExchangeDetails.ACTIVE] is True
+    assert exchange_details[FixedRateExchangeDetails.DT_SUPPLY] == 0
+    assert exchange_details[FixedRateExchangeDetails.BT_SUPPLY] == 0
+    assert exchange_details[FixedRateExchangeDetails.DT_BALANCE] == 0
+    assert exchange_details[FixedRateExchangeDetails.BT_BALANCE] == 0
+    assert exchange_details[FixedRateExchangeDetails.WITH_MINT] is False
+
+    tx = erc721_nft.safe_transfer_from(
+        publisher_wallet.address,
+        consumer_wallet.address,
+        token_id=1,
+        from_wallet=publisher_wallet,
+    )
+    tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
+    transfer_event = erc721_nft.get_event_log(
+        ERC721FactoryContract.EVENT_TRANSFER,
+        tx_receipt.blockNumber,
+        web3.eth.block_number,
+        None,
+    )
+    assert transfer_event[0].event == "Transfer"
+    assert transfer_event[0].args["from"] == publisher_wallet.address
+    assert transfer_event[0].args.to == consumer_wallet.address
+    assert erc721_nft.balance_of(consumer_wallet.address) == 1
+    assert erc721_nft.balance_of(publisher_wallet.address) == 0
+    assert erc721_nft.is_erc20_deployer(consumer_wallet.address) is True
+    assert erc721_nft.owner_of(1) == consumer_wallet.address
+    permissions = erc20_token.get_permissions(consumer_wallet.address)
+    assert permissions[0] is False  # the newest owner is not the minter
+    erc20_token.add_minter(consumer_wallet.address, consumer_wallet)
+    assert erc20_token.permissions(consumer_wallet.address)[0] is True
+
+    # Consumer wallet is not the publish market fee collector
+    with pytest.raises(exceptions.ContractLogicError) as err:
+        bpool.update_publish_market_fee(
+            consumer_wallet.address, to_wei("0.1"), consumer_wallet
+        )
+    assert (
+        err.value.args[0]
+        == "execution reverted: VM Exception while processing transaction: revert ONLY MARKET COLLECTOR"
+    )
+
+    # Consumer wallet has not become the owner of the publisher's exchange
+    exchange_details = fixed_exchange.get_exchange(exchange_id)
+    assert (
+        exchange_details[FixedRateExchangeDetails.EXCHANGE_OWNER]
+        == publisher_wallet.address
+    )
+    assert exchange_details[FixedRateExchangeDetails.ACTIVE] is True

--- a/tests/readmes/test_erc20_enterprise.py
+++ b/tests/readmes/test_erc20_enterprise.py
@@ -238,7 +238,7 @@ def test_erc20_enterprise_flow_with_fre():
         provider_data=provider_data,
         consumer_market_fee_address=bob_wallet.address,
         consumer_market_fee_token=erc20_enterprise_token.address,
-        consumer_market_fee_amount=0,
+        consumer_market_fee_amount=ocean.to_wei(2),
         exchange_contract=fixed_rate_exchange.address,
         exchange_id=exchange_id,
         max_basetoken_amount=ocean.to_wei(10),


### PR DESCRIPTION
Fixes #745  .

Changes proposed in this PR:

- added 2 large tests for transfer NFTs: one is related to transferring the NFT before deploying an ERC20, a pool and a FRE and one after;
- checked roles & ownership as well in both cases.