### PR TITLE
Bump to contracts alpha 26

### DIFF
--- a/ocean_lib/models/fixed_rate_exchange.py
+++ b/ocean_lib/models/fixed_rate_exchange.py
@@ -103,12 +103,8 @@ class FixedRateExchange(ContractBase):
     def get_opc_fee(self, base_token: str) -> int:
         return self.contract.caller.getOPCFee(base_token)
 
-    def generate_exchange_id(
-        self, base_token: str, datatoken: str
-    ) -> bytes:
-        return self.contract.caller.generateExchangeId(
-            base_token, datatoken
-        )
+    def generate_exchange_id(self, base_token: str, datatoken: str) -> bytes:
+        return self.contract.caller.generateExchangeId(base_token, datatoken)
 
     def get_basetoken_out_price(self, exchange_id: bytes, dt_amount: int) -> int:
         return self.contract.caller.getBaseTokenOutPrice(exchange_id, dt_amount)
@@ -176,10 +172,24 @@ class FixedRateExchange(ContractBase):
         )
 
     def collect_bt(self, exchange_id: bytes, amount: int, from_wallet: Wallet) -> str:
-        return self.send_transaction("collectBT", (exchange_id,amount,), from_wallet)
+        return self.send_transaction(
+            "collectBT",
+            (
+                exchange_id,
+                amount,
+            ),
+            from_wallet,
+        )
 
-    def collect_dt(self, exchange_id: bytes, amount: int,from_wallet: Wallet) -> str:
-        return self.send_transaction("collectDT", (exchange_id,amount,), from_wallet)
+    def collect_dt(self, exchange_id: bytes, amount: int, from_wallet: Wallet) -> str:
+        return self.send_transaction(
+            "collectDT",
+            (
+                exchange_id,
+                amount,
+            ),
+            from_wallet,
+        )
 
     def collect_market_fee(self, exchange_id: bytes, from_wallet: Wallet) -> str:
         return self.send_transaction("collectMarketFee", (exchange_id,), from_wallet)

--- a/ocean_lib/models/fixed_rate_exchange.py
+++ b/ocean_lib/models/fixed_rate_exchange.py
@@ -104,10 +104,10 @@ class FixedRateExchange(ContractBase):
         return self.contract.caller.getOPCFee(base_token)
 
     def generate_exchange_id(
-        self, base_token: str, datatoken: str, exchange_owner: str
+        self, base_token: str, datatoken: str
     ) -> bytes:
         return self.contract.caller.generateExchangeId(
-            base_token, datatoken, exchange_owner
+            base_token, datatoken
         )
 
     def get_basetoken_out_price(self, exchange_id: bytes, dt_amount: int) -> int:

--- a/ocean_lib/models/fixed_rate_exchange.py
+++ b/ocean_lib/models/fixed_rate_exchange.py
@@ -175,11 +175,11 @@ class FixedRateExchange(ContractBase):
             from_wallet,
         )
 
-    def collect_bt(self, exchange_id: bytes, from_wallet: Wallet) -> str:
-        return self.send_transaction("collectBT", (exchange_id,), from_wallet)
+    def collect_bt(self, exchange_id: bytes, amount: int, from_wallet: Wallet) -> str:
+        return self.send_transaction("collectBT", (exchange_id,amount,), from_wallet)
 
-    def collect_dt(self, exchange_id: bytes, from_wallet: Wallet) -> str:
-        return self.send_transaction("collectDT", (exchange_id,), from_wallet)
+    def collect_dt(self, exchange_id: bytes, amount: int,from_wallet: Wallet) -> str:
+        return self.send_transaction("collectDT", (exchange_id,amount,), from_wallet)
 
     def collect_market_fee(self, exchange_id: bytes, from_wallet: Wallet) -> str:
         return self.send_transaction("collectMarketFee", (exchange_id,), from_wallet)

--- a/ocean_lib/models/test/test_dispenser.py
+++ b/ocean_lib/models/test/test_dispenser.py
@@ -184,17 +184,6 @@ def test_main(web3, config, publisher_wallet, consumer_wallet, factory_deployer_
         from_wallet=consumer_wallet,
     )
 
-    # Tests consumer tries to withdraw all datatokens
-    with pytest.raises(exceptions.ContractLogicError) as err:
-        dispenser.owner_withdraw(
-            datatoken=erc20_token.address, from_wallet=consumer_wallet
-        )
-
-    assert (
-        err.value.args[0]
-        == "execution reverted: VM Exception while processing transaction: revert Invalid owner"
-    )
-
     # Tests publisher withdraws all datatokens
     dispenser.owner_withdraw(
         datatoken=erc20_token.address, from_wallet=publisher_wallet

--- a/ocean_lib/models/test/test_erc20_enterprise.py
+++ b/ocean_lib/models/test/test_erc20_enterprise.py
@@ -145,7 +145,7 @@ def test_buy_from_dispenser_and_order(
 
     tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
     assert tx_receipt.status == 1
-    assert erc20_enterprise_token.get_total_supply() == to_wei("0.03")
+    assert erc20_enterprise_token.get_total_supply() == to_wei("0")
 
     balance_opf_consume = mock_dai_contract.balanceOf(opf_collector_address)
     balance_publish = mock_usdc_contract.balanceOf(publish_fees[0])
@@ -310,7 +310,7 @@ def test_buy_from_fre_and_order(
 
     tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
     assert tx_receipt.status == 1
-    assert erc20_enterprise_token.get_total_supply() == to_wei("0.03")
+    assert erc20_enterprise_token.get_total_supply() == to_wei("0")
 
     provider_fee_balance_after = mock_usdc_contract.balanceOf(
         another_consumer_wallet.address

--- a/ocean_lib/models/test/test_fixed_rate_exchange.py
+++ b/ocean_lib/models/test/test_fixed_rate_exchange.py
@@ -120,8 +120,7 @@ def test_exchange_rate_creation(
 
     # Generate exchange id works
     generated_exchange_id = fixed_exchange.generate_exchange_id(
-        base_token=get_address_of_type(config, "Ocean"),
-        datatoken=erc20.address
+        base_token=get_address_of_type(config, "Ocean"), datatoken=erc20.address
     )
     assert generated_exchange_id == exchange_id
 
@@ -270,7 +269,11 @@ def test_exchange_rate_creation(
 
     erc20_balance_before = erc20.balanceOf(erc20.get_payment_collector())
 
-    tx = fixed_exchange.collect_dt(exchange_id, exchange_details[FixedRateExchangeDetails.DT_SUPPLY], consumer_wallet)
+    tx = fixed_exchange.collect_dt(
+        exchange_id,
+        exchange_details[FixedRateExchangeDetails.DT_SUPPLY],
+        consumer_wallet,
+    )
     tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
 
     logs = fixed_exchange.get_event_log(
@@ -289,9 +292,11 @@ def test_exchange_rate_creation(
 
     bt_balance_before = ocean_token.balanceOf(erc20.get_payment_collector())
 
-    
-
-    tx = fixed_exchange.collect_bt(exchange_id, exchange_details[FixedRateExchangeDetails.BT_SUPPLY], consumer_wallet)
+    tx = fixed_exchange.collect_bt(
+        exchange_id,
+        exchange_details[FixedRateExchangeDetails.BT_SUPPLY],
+        consumer_wallet,
+    )
     tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
 
     logs = fixed_exchange.get_event_log(

--- a/ocean_lib/models/test/test_fixed_rate_exchange.py
+++ b/ocean_lib/models/test/test_fixed_rate_exchange.py
@@ -268,16 +268,9 @@ def test_exchange_rate_creation(
 
     # Fixed Rate Exchange owner withdraws DT balance
 
-    erc20_balance_before = erc20.balanceOf(consumer_wallet.address)
+    erc20_balance_before = erc20.balanceOf(erc20.get_payment_collector())
 
-    # Only owner can withdraw
-    with pytest.raises(exceptions.ContractLogicError) as err:
-        fixed_exchange.collect_dt(exchange_id, another_consumer_wallet)
-    assert (
-        err.value.args[0]
-        == "execution reverted: VM Exception while processing transaction: revert FixedRateExchange: invalid exchange owner"
-    )
-    tx = fixed_exchange.collect_dt(exchange_id, consumer_wallet)
+    tx = fixed_exchange.collect_dt(exchange_id, exchange_details[FixedRateExchangeDetails.DT_SUPPLY], consumer_wallet)
     tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
 
     logs = fixed_exchange.get_event_log(
@@ -288,22 +281,17 @@ def test_exchange_rate_creation(
     )
 
     assert (
-        erc20.balanceOf(consumer_wallet.address)
+        erc20.balanceOf(erc20.get_payment_collector())
         == erc20_balance_before + logs[0].args.amount
     )
 
     # Fixed Rate Exchange owner withdraws BT balance
 
-    bt_balance_before = ocean_token.balanceOf(consumer_wallet.address)
+    bt_balance_before = ocean_token.balanceOf(erc20.get_payment_collector())
 
-    with pytest.raises(exceptions.ContractLogicError) as err:
-        fixed_exchange.collect_bt(exchange_id, another_consumer_wallet)
-    assert (
-        err.value.args[0]
-        == "execution reverted: VM Exception while processing transaction: revert FixedRateExchange: invalid exchange owner"
-    )
+    
 
-    tx = fixed_exchange.collect_bt(exchange_id, consumer_wallet)
+    tx = fixed_exchange.collect_bt(exchange_id, exchange_details[FixedRateExchangeDetails.BT_SUPPLY], consumer_wallet)
     tx_receipt = web3.eth.wait_for_transaction_receipt(tx)
 
     logs = fixed_exchange.get_event_log(
@@ -314,7 +302,7 @@ def test_exchange_rate_creation(
     )
 
     assert (
-        ocean_token.balanceOf(consumer_wallet.address)
+        ocean_token.balanceOf(erc20.get_payment_collector())
         == bt_balance_before + logs[0].args.amount
     )
 

--- a/ocean_lib/models/test/test_fixed_rate_exchange.py
+++ b/ocean_lib/models/test/test_fixed_rate_exchange.py
@@ -121,8 +121,7 @@ def test_exchange_rate_creation(
     # Generate exchange id works
     generated_exchange_id = fixed_exchange.generate_exchange_id(
         base_token=get_address_of_type(config, "Ocean"),
-        datatoken=erc20.address,
-        exchange_owner=consumer_wallet.address,
+        datatoken=erc20.address
     )
     assert generated_exchange_id == exchange_id
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", encoding="utf8") as readme_file:
 # Installed by pip install ocean-lib
 # or pip install -e .
 install_requirements = [
-    "ocean-contracts==1.0.0a24",
+    "ocean-contracts==1.0.0a25",
     "coloredlogs",
     "pyopenssl",
     "PyJWT",  # not jwt

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", encoding="utf8") as readme_file:
 # Installed by pip install ocean-lib
 # or pip install -e .
 install_requirements = [
-    "ocean-contracts==1.0.0a22",
+    "ocean-contracts==1.0.0a23",
     "coloredlogs",
     "pyopenssl",
     "PyJWT",  # not jwt

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", encoding="utf8") as readme_file:
 # Installed by pip install ocean-lib
 # or pip install -e .
 install_requirements = [
-    "ocean-contracts==1.0.0a25",
+    "ocean-contracts==1.0.0a26",
     "coloredlogs",
     "pyopenssl",
     "PyJWT",  # not jwt

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", encoding="utf8") as readme_file:
 # Installed by pip install ocean-lib
 # or pip install -e .
 install_requirements = [
-    "ocean-contracts==1.0.0a23",
+    "ocean-contracts==1.0.0a24",
     "coloredlogs",
     "pyopenssl",
     "PyJWT",  # not jwt


### PR DESCRIPTION
Breaking changes:
 - fixedrate collectBT & collectDT are expecting amount as well
 - fixedrate collectBT & collectDT are sending funds to erc20.getPaymentCollector() instead of owner
 - fixedrate generateExchangeId takes only 2 params (basetoken, datatoken) , the 3rd param (owner) was removed
 - dispenser :  anyone can call collect, datatokens are always sent to erc20.getPaymentCollector()
 - For ERC20Enterprise, OPC will not take 0.03DT as fee