### PR TITLE
Add side staking cap tests

### DIFF
--- a/ocean_lib/models/bpool.py
+++ b/ocean_lib/models/bpool.py
@@ -294,6 +294,7 @@ class BPool(BTokenBase):
             "rebind", (token_address, balance, weight), from_wallet
         )
 
+    @enforce_types
     def get_spot_price(
         self, token_in: str, token_out: str, consume_market_swap_fee
     ) -> int:
@@ -333,6 +334,10 @@ class BPool(BTokenBase):
     def get_max_in_ratio(self) -> int:
         return self.contract.caller.MAX_IN_RATIO()
 
+    @enforce_types
+    def get_min_fee(self) -> int:
+        return self.contract.caller.MIN_FEE()
+    
     @enforce_types
     def join_pool(
         self, pool_amount_out: int, max_amounts_in: List[int], from_wallet: Wallet

--- a/ocean_lib/models/bpool.py
+++ b/ocean_lib/models/bpool.py
@@ -337,7 +337,7 @@ class BPool(BTokenBase):
     @enforce_types
     def get_min_fee(self) -> int:
         return self.contract.caller.MIN_FEE()
-    
+
     @enforce_types
     def join_pool(
         self, pool_amount_out: int, max_amounts_in: List[int], from_wallet: Wallet

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -388,30 +388,6 @@ def test_side_staking(
     # Get vesting should be callable by anyone
     side_staking.get_vesting(erc20.address, another_consumer_wallet)
 
-    # Only pool can call this function
-    with pytest.raises(exceptions.ContractLogicError) as err:
-        side_staking.can_stake(erc20.address, 10)
-    assert (
-        err.value.args[0]
-        == "execution reverted: VM Exception while processing transaction: revert ERR: Only pool can call this"
-    )
-
-    # Only pool can call this function
-    with pytest.raises(exceptions.ContractLogicError) as err:
-        side_staking.stake(erc20.address, 10, consumer_wallet)
-    assert (
-        err.value.args[0]
-        == "execution reverted: VM Exception while processing transaction: revert ERR: Only pool can call this"
-    )
-
-    # Only pool can call this function
-    with pytest.raises(exceptions.ContractLogicError) as err:
-        side_staking.unstake(erc20.address, 10, 5, consumer_wallet)
-    assert (
-        err.value.args[0]
-        == "execution reverted: VM Exception while processing transaction: revert ERR: Only pool can call this"
-    )
-
 
 @pytest.mark.unit
 def test_side_staking_steal(

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -425,6 +425,7 @@ def test_side_staking(
         == "execution reverted: VM Exception while processing transaction: revert ERR: Only pool can call this"
     )
 
+
 @pytest.mark.unit
 def test_side_staking_bot_consistency(
     web3, config, publisher_wallet, consumer_wallet, another_consumer_wallet

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -2,19 +2,27 @@
 # Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
+from re import I
+from eth_utils import from_wei
 import pytest
 from web3 import exceptions
 
 from ocean_lib.models.bpool import BPool
 from ocean_lib.models.erc20_token import ERC20Token
 from ocean_lib.models.erc721_factory import ERC721FactoryContract
+from ocean_lib.models.erc721_nft import ERC721NFT
 from ocean_lib.models.side_staking import SideStaking
 from ocean_lib.web3_internal.constants import MAX_UINT256
 from ocean_lib.web3_internal.currency import to_wei
 from tests.resources.helper_functions import (
+    create_nft_erc20_with_pool,
     deploy_erc721_erc20,
     get_address_of_type,
+    join_pool_one_side,
+    swap_exact_amount_in_base_token,
+    swap_exact_amount_in_datatoken,
     transfer_ocean_if_balance_lte,
+    wallet_exit_pool,
 )
 
 
@@ -392,3 +400,211 @@ def test_side_staking(
 
     # Get vesting should be callable by anyone
     side_staking.get_vesting(erc20.address, another_consumer_wallet)
+
+    # Only pool can call this function
+    with pytest.raises(exceptions.ContractLogicError) as err:
+        side_staking.can_stake(erc20.address, 10)
+    assert (
+        err.value.args[0]
+        == "execution reverted: VM Exception while processing transaction: revert ERR: Only pool can call this"
+    )
+
+    # Only pool can call this function
+    with pytest.raises(exceptions.ContractLogicError) as err:
+        side_staking.stake(erc20.address, 10, consumer_wallet)
+    assert (
+        err.value.args[0]
+        == "execution reverted: VM Exception while processing transaction: revert ERR: Only pool can call this"
+    )
+
+    # Only pool can call this function
+    with pytest.raises(exceptions.ContractLogicError) as err:
+        side_staking.unstake(erc20.address, 10, 5, consumer_wallet)
+    assert (
+        err.value.args[0]
+        == "execution reverted: VM Exception while processing transaction: revert ERR: Only pool can call this"
+    )
+
+@pytest.mark.unit
+def test_side_staking_bot_consistency(
+    web3, config, publisher_wallet, consumer_wallet, another_consumer_wallet
+):
+    """
+    In this test we try to make a profit in base_token by joining the pool and swapping in different orders. We check that it's not possible
+    to make any profit an therefore steal from the pool.
+    """
+    # Test initial values and setups
+    initial_pool_liquidity = to_wei("50")
+    token_cap = to_wei("100")
+    swap_market_fee = to_wei("0.0001")
+    swap_fee = to_wei("0.0001")
+    big_allowance = to_wei("100000000")
+
+    ocean_token = ERC20Token(web3, get_address_of_type(config, "Ocean"))
+
+    ocean_token.transfer(another_consumer_wallet.address, to_wei("50"), consumer_wallet)
+
+    bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
+        web3,
+        config,
+        publisher_wallet,
+        swap_fee,
+        swap_market_fee,
+        initial_pool_liquidity,
+        token_cap,
+    )
+
+    ocean_token.approve(bpool.address, big_allowance, another_consumer_wallet)
+    erc20_token.approve(bpool.address, big_allowance, another_consumer_wallet)
+
+    # End test initial values and setups
+
+    initial_ocean_user_balance = ocean_token.balanceOf(another_consumer_wallet.address)
+    swap_exact_amount_in_base_token(
+        bpool, erc20_token, ocean_token, another_consumer_wallet, to_wei("20")
+    )
+    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet)
+    wallet_exit_pool(web3, bpool, pool_token, another_consumer_wallet)
+    swap_exact_amount_in_datatoken(
+        bpool,
+        erc20_token,
+        ocean_token,
+        another_consumer_wallet,
+        erc20_token.balanceOf(another_consumer_wallet.address),
+    )
+
+    # Check that users hasn't made any profit
+    assert pool_token.balanceOf(another_consumer_wallet.address) == 0
+    assert erc20_token.balanceOf(another_consumer_wallet.address) == 0
+    assert (
+        ocean_token.balanceOf(another_consumer_wallet.address)
+        <= initial_ocean_user_balance
+    )
+
+    # Test in a different order
+    initial_ocean_user_balance = ocean_token.balanceOf(another_consumer_wallet.address)
+    swap_exact_amount_in_base_token(
+        bpool, erc20_token, ocean_token, another_consumer_wallet, to_wei("20")
+    )
+    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet)
+    swap_exact_amount_in_datatoken(
+        bpool,
+        erc20_token,
+        ocean_token,
+        another_consumer_wallet,
+        erc20_token.balanceOf(another_consumer_wallet.address),
+    )
+    wallet_exit_pool(web3, bpool, pool_token, another_consumer_wallet)
+    swap_exact_amount_in_datatoken(
+        bpool,
+        erc20_token,
+        ocean_token,
+        another_consumer_wallet,
+        erc20_token.balanceOf(another_consumer_wallet.address),
+    )
+
+    # Check that users hasn't made any profit
+    assert pool_token.balanceOf(another_consumer_wallet.address) == 0
+    assert erc20_token.balanceOf(another_consumer_wallet.address) == 0
+    assert (
+        ocean_token.balanceOf(another_consumer_wallet.address)
+        <= initial_ocean_user_balance
+    )
+
+
+def test_side_staking_constant_rate(
+    web3, config, publisher_wallet, consumer_wallet, another_consumer_wallet
+):
+    """
+    In this test we test that the side staking bot keeps the same rate when the datatoken supply is less than the cap.
+    """
+    # Test initial values and setups
+    initial_pool_liquidity = to_wei("1")
+    token_cap = to_wei("5")
+    swap_market_fee = to_wei("0.0001")
+    swap_fee = to_wei("0.0001")
+    big_allowance = to_wei("100000000")
+
+    ocean_token = ERC20Token(web3, get_address_of_type(config, "Ocean"))
+
+    ocean_token.transfer(another_consumer_wallet.address, to_wei("50"), consumer_wallet)
+
+    bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
+        web3,
+        config,
+        publisher_wallet,
+        swap_fee,
+        swap_market_fee,
+        initial_pool_liquidity,
+        token_cap,
+    )
+
+    ocean_token.approve(bpool.address, big_allowance, another_consumer_wallet)
+    erc20_token.approve(bpool.address, big_allowance, another_consumer_wallet)
+
+    # End test initial values and setups
+
+    initial_spot_price_basetoken_datatoken = bpool.get_spot_price(
+        ocean_token.address, erc20_token.address, swap_market_fee
+    )
+    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
+    final_spot_price_basetoken_datatoken = bpool.get_spot_price(
+        ocean_token.address, erc20_token.address, swap_market_fee
+    )
+
+    assert (
+        final_spot_price_basetoken_datatoken != initial_spot_price_basetoken_datatoken
+    )
+
+
+def test_side_staking_over_datatoken_cap(
+    web3, config, publisher_wallet, consumer_wallet, another_consumer_wallet
+):
+    """
+    In this test we test that the side staking bot works as espected when the datatoken supply is over the cap.
+    """
+    # Test initial values and setups
+    initial_pool_liquidity = to_wei("1")
+    token_cap = to_wei("5")
+    swap_market_fee = to_wei("0.0001")
+    swap_fee = to_wei("0.0001")
+    big_allowance = to_wei("100000000")
+
+    ocean_token = ERC20Token(web3, get_address_of_type(config, "Ocean"))
+
+    ocean_token.transfer(another_consumer_wallet.address, to_wei("50"), consumer_wallet)
+
+    bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
+        web3,
+        config,
+        publisher_wallet,
+        swap_fee,
+        swap_market_fee,
+        initial_pool_liquidity,
+        token_cap,
+    )
+
+    ocean_token.approve(bpool.address, big_allowance, another_consumer_wallet)
+    erc20_token.approve(bpool.address, big_allowance, another_consumer_wallet)
+
+    # End test initial values and setups
+
+    erc20_token_total_supply = erc20_token.get_total_supply()
+    assert erc20_token_total_supply == token_cap
+
+    # Fill the pool until the cap is reached
+    previous_pool_datatoken_balance = 0
+    while previous_pool_datatoken_balance != erc20_token.balanceOf(bpool.address):
+        previous_pool_datatoken_balance = erc20_token.balanceOf(bpool.address)
+        join_pool_one_side(
+            web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5")
+        )
+    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
+
+    assert erc20_token.balanceOf(bpool.address) > to_wei("4")
+    assert erc20_token.balanceOf(bpool.address) < to_wei("5")
+
+    # From this point the test that the SS bot doesn't add more datatokens
+    max_erc20_pool_balance = erc20_token.balanceOf(bpool.address)
+    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
+    assert erc20_token.balanceOf(bpool.address) == max_erc20_pool_balance

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -119,17 +119,6 @@ def test_side_staking(
     # Side staking pool address should match the newly created pool
     assert side_staking.get_pool_address(erc20.address) == bpool_address
 
-    assert (
-        erc20.balanceOf(get_address_of_type(config, "Staking"))
-        == MAX_UINT256 - initial_ocean_liquidity
-    )
-    assert bpool.opc_fee() == to_wei("0.001")
-    assert bpool.get_swap_fee() == lp_swap_fee
-    assert bpool.community_fee(ocean_token.address) == 0
-    assert bpool.community_fee(erc20.address) == 0
-    assert bpool.publish_market_fee(ocean_token.address) == 0
-    assert bpool.publish_market_fee(erc20.address) == 0
-
     # Consumer fails to mints new erc20 tokens even if it's minter
     with pytest.raises(exceptions.ContractLogicError) as err:
         erc20.mint(consumer_wallet.address, to_wei("1"), consumer_wallet)
@@ -434,10 +423,10 @@ def test_side_staking_steal(
     # Test initial values and setups
 
     # How to scale the "strategy" keep the same propotion (i.e. x2, x5 x10 all the following values):
-    initial_pool_liquidity_eth = 40 * 5000
-    token_cap_eth = 200 * 5000  # 1M
-    join_pool_step_eth = 20 * 5000
-    datatoken_buy_amount_basetoken_eth = 4 * 5000
+    initial_pool_liquidity_eth = 200000
+    token_cap_eth = 1  # doesnt matter
+    join_pool_step_eth = 20000
+    datatoken_buy_amount_basetoken_eth = 5000
     # ---------------------------------------------------------------------------------------------
 
     initial_pool_liquidity = to_wei(initial_pool_liquidity_eth)
@@ -454,18 +443,14 @@ def test_side_staking_steal(
         cap=to_wei(to_wei("1000000000")),
     )
 
-    erc20.mint(consumer_wallet.address, to_wei("100000000000"), publisher_wallet)
-    erc20.mint(publisher_wallet.address, to_wei("1000000000"), publisher_wallet)
-
-    # ocean_token = ERC20Token(web3, get_address_of_type(config, "Ocean"))
-    ocean_token = erc20
-
-    initial_eth_balance = web3.eth.getBalance(consumer_wallet.address)
-    ocean_token.transfer(
-        another_consumer_wallet.address, to_wei("1000000000"), consumer_wallet
+    erc20.mint(
+        publisher_wallet.address, to_wei("10000000000000000000"), publisher_wallet
     )
 
-    bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
+    # We use an erc20 as ocean to have unlimited balance
+    ocean_token = erc20
+
+    bpool, erc20_token, _, pool_token = create_nft_erc20_with_pool(
         web3,
         config,
         publisher_wallet,
@@ -479,21 +464,38 @@ def test_side_staking_steal(
     ocean_token.approve(bpool.address, big_allowance, another_consumer_wallet)
     erc20_token.approve(bpool.address, big_allowance, another_consumer_wallet)
 
+    erc20.transfer(
+        another_consumer_wallet.address,
+        erc20.balanceOf(publisher_wallet.address),
+        publisher_wallet,
+    )
+
     # End test initial values and setups
 
     initial_ocean_user_balance = ocean_token.balanceOf(another_consumer_wallet.address)
-    swap_exact_amount_in_base_token(
-        bpool,
-        erc20_token,
-        ocean_token,
-        another_consumer_wallet,
-        to_wei(datatoken_buy_amount_basetoken_eth),
-    )
+    spot_prices = []
 
-    # Fill the pool until the cap is reached
-    previous_pool_datatoken_balance = 0
-    while previous_pool_datatoken_balance != erc20_token.balanceOf(bpool.address):
-        previous_pool_datatoken_balance = erc20_token.balanceOf(bpool.address)
+    def add_spot_price():
+        spot_prices.append(
+            bpool.get_spot_price(
+                ocean_token.address, erc20_token.address, swap_market_fee
+            )
+        )
+
+    add_spot_price()
+    for _ in range(10):
+        swap_exact_amount_in_base_token(
+            bpool,
+            erc20_token,
+            ocean_token,
+            another_consumer_wallet,
+            to_wei(datatoken_buy_amount_basetoken_eth),
+        )
+        add_spot_price()
+
+    times = 2
+    amounts_out = []
+    for _ in range(times):
         join_pool_one_side(
             web3,
             bpool,
@@ -501,9 +503,14 @@ def test_side_staking_steal(
             another_consumer_wallet,
             to_wei(join_pool_step_eth),
         )
-    join_pool_one_side(
-        web3, bpool, ocean_token, another_consumer_wallet, to_wei(join_pool_step_eth)
-    )
+        amounts_out.append(
+            bpool.get_amount_out_exact_in(
+                erc20_token.address,
+                ocean_token.address,
+                erc20_token.balanceOf(another_consumer_wallet.address),
+                swap_market_fee,
+            )[0]
+        )
 
     swap_exact_amount_in_datatoken(
         bpool,
@@ -513,7 +520,7 @@ def test_side_staking_steal(
         erc20_token.balanceOf(another_consumer_wallet.address),
     )
 
-    while pool_token.balanceOf(another_consumer_wallet.address) > to_wei("1"):
+    while pool_token.balanceOf(another_consumer_wallet.address) > to_wei("50"):
         wallet_exit_pool_one_side(
             web3,
             bpool,
@@ -536,30 +543,18 @@ def test_side_staking_steal(
     assert pool_token.balanceOf(another_consumer_wallet.address) == 0
     assert erc20_token.balanceOf(another_consumer_wallet.address) == 0
 
-    final_eth_balance = web3.eth.getBalance(consumer_wallet.address)
-
-    profit = from_wei(
-        ocean_token.balanceOf(another_consumer_wallet.address)
-        - initial_ocean_user_balance,
-        "ether",
-    )
-    # assert (
-    #     # from_wei(initial_eth_balance - final_eth_balance, "ether") < 0.00005
-    # )  # eth spent ~ < 0.00004? seems wrong
-
-    # We are stealing from the pool :')
+    # Check that the the attacker is loosing money
     assert (
         ocean_token.balanceOf(another_consumer_wallet.address)
-        > initial_ocean_user_balance
+        < initial_ocean_user_balance
     )
-    assert profit > 37600  # OCEAN stolen
 
 
 def test_side_staking_constant_rate(
     web3, config, publisher_wallet, consumer_wallet, another_consumer_wallet
 ):
     """
-    In this test we test that the side staking bot keeps the same rate when the datatoken supply is less than the cap.
+    In this test we test that the side staking bot keeps the same rate joining the pool one side
     """
     # Test initial values and setups
     initial_pool_liquidity = to_wei("1")
@@ -572,7 +567,7 @@ def test_side_staking_constant_rate(
 
     ocean_token.transfer(another_consumer_wallet.address, to_wei("50"), consumer_wallet)
 
-    bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
+    bpool, erc20_token, _, _ = create_nft_erc20_with_pool(
         web3,
         config,
         publisher_wallet,
@@ -596,102 +591,13 @@ def test_side_staking_constant_rate(
     initial_spot_price_basetoken_datatoken = bpool.get_spot_price(
         ocean_token.address, erc20_token.address, swap_market_fee
     )
-    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
-    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
+    # join the pool max ratio
+    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet)
     final_spot_price_basetoken_datatoken = bpool.get_spot_price(
         ocean_token.address, erc20_token.address, swap_market_fee
     )
 
-    # TODO: Is this assertion normal?
-    assert (
-        final_spot_price_basetoken_datatoken == initial_spot_price_basetoken_datatoken
+    # We check that the spot price is constant with a precision of 10^-10
+    assert int(final_spot_price_basetoken_datatoken / 10**8) == int(
+        initial_spot_price_basetoken_datatoken / 10**8
     )
-    # check that the spot price difference is less than 10%
-    assert (
-        abs(
-            final_spot_price_basetoken_datatoken
-            - initial_spot_price_basetoken_datatoken
-        )
-        / initial_spot_price_basetoken_datatoken
-        < 0.1
-    )
-
-
-def test_side_staking_over_datatoken_cap(
-    web3, config, publisher_wallet, consumer_wallet, another_consumer_wallet
-):
-    """
-    In this test we test that the side staking bot works as espected when the datatoken supply is over the cap.
-    """
-    # Test initial values and setups
-    initial_pool_liquidity = to_wei("1")
-    token_cap = to_wei("5")
-    swap_market_fee = to_wei("0.0001")
-    swap_fee = to_wei("0.0001")
-    big_allowance = to_wei("100000000")
-
-    ocean_token = ERC20Token(web3, get_address_of_type(config, "Ocean"))
-
-    ocean_token.transfer(another_consumer_wallet.address, to_wei("50"), consumer_wallet)
-
-    bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
-        web3,
-        config,
-        publisher_wallet,
-        ocean_token,
-        swap_fee,
-        swap_market_fee,
-        initial_pool_liquidity,
-        token_cap,
-    )
-
-    ocean_token.approve(bpool.address, big_allowance, another_consumer_wallet)
-    erc20_token.approve(bpool.address, big_allowance, another_consumer_wallet)
-
-    # End test initial values and setups
-
-    erc20_token_total_supply = erc20_token.get_total_supply()
-    assert erc20_token_total_supply == token_cap
-
-    # Fill the pool until the cap is reached
-    previous_pool_datatoken_balance = 0
-    while previous_pool_datatoken_balance != erc20_token.balanceOf(bpool.address):
-        previous_pool_datatoken_balance = erc20_token.balanceOf(bpool.address)
-        join_pool_one_side(
-            web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5")
-        )
-    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
-
-    assert erc20_token.balanceOf(bpool.address) > to_wei("4")
-    assert erc20_token.balanceOf(bpool.address) < to_wei("5")
-
-    # From this point the test that the SS bot doesn't add more datatokens
-    max_erc20_pool_balance = erc20_token.balanceOf(bpool.address)
-    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
-    assert erc20_token.balanceOf(bpool.address) == max_erc20_pool_balance
-
-    # Exit one side of the pool so that the ss removes some datatokens
-    while erc20_token.balanceOf(bpool.address) > to_wei("3"):
-        bpool.exit_swap_pool_amount_in(
-            pool_token.balanceOf(another_consumer_wallet.address) // 5,
-            0,
-            another_consumer_wallet,
-        )
-    pool_datatoken_balance_after_1s_exit = erc20_token.balanceOf(bpool.address)
-
-    # Check that the ss bot adds datatokens again
-    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
-    assert erc20_token.balanceOf(bpool.address) >= pool_datatoken_balance_after_1s_exit
-
-    # Fill the pool again until the cap is reached
-    pool_datatoken_balance_to_fill = 0
-    while pool_datatoken_balance_to_fill != erc20_token.balanceOf(bpool.address):
-        pool_datatoken_balance_to_fill = erc20_token.balanceOf(bpool.address)
-        join_pool_one_side(
-            web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5")
-        )
-    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
-
-    # Finally check that the bpool datatoken liquidity is close to the cap
-    assert erc20_token.balanceOf(bpool.address) > to_wei("4")
-    assert erc20_token.balanceOf(bpool.address) < to_wei("5")

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -572,15 +572,15 @@ def test_side_staking_constant_rate(
 
     ocean_token.transfer(another_consumer_wallet.address, to_wei("50"), consumer_wallet)
 
-    bpool, erc20_token, _, _ = create_nft_erc20_with_pool(
-        web3=web3,
-        config=config,
-        publisher_wallet=publisher_wallet,
-        swap_fee=swap_fee,
-        swap_market_fee=swap_market_fee,
-        initial_pool_liquidity=initial_pool_liquidity,
-        token_cap=token_cap,
-        vesting_amount=0,
+    bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
+        web3,
+        config,
+        publisher_wallet,
+        ocean_token,
+        swap_fee,
+        swap_market_fee,
+        initial_pool_liquidity,
+        token_cap,
     )
 
     ocean_token.approve(bpool.address, big_allowance, another_consumer_wallet)
@@ -638,6 +638,7 @@ def test_side_staking_over_datatoken_cap(
         web3,
         config,
         publisher_wallet,
+        ocean_token,
         swap_fee,
         swap_market_fee,
         initial_pool_liquidity,

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -434,29 +434,42 @@ def test_side_staking_steal(
     # Test initial values and setups
 
     # How to scale the "strategy" keep the same propotion (i.e. x2, x5 x10 all the following values):
-    initial_pool_liquidity_eth = 40
-    token_cap_eth = 200
-    join_pool_step_eth = 20
-    datatoken_buy_amount_basetoken_eth = 4
+    initial_pool_liquidity_eth = 40 * 5000
+    token_cap_eth = 200 * 5000  # 1M
+    join_pool_step_eth = 20 * 5000
+    datatoken_buy_amount_basetoken_eth = 4 * 5000
     # ---------------------------------------------------------------------------------------------
 
     initial_pool_liquidity = to_wei(initial_pool_liquidity_eth)
     token_cap = to_wei(token_cap_eth)
     swap_market_fee = to_wei("0.0001")
     swap_fee = to_wei("0.0001")
-    big_allowance = to_wei("100000000")
+    big_allowance = to_wei("10000000000000000")
 
-    ocean_token = ERC20Token(web3, get_address_of_type(config, "Ocean"))
+    _, erc20 = deploy_erc721_erc20(
+        web3=web3,
+        config=config,
+        erc721_publisher=publisher_wallet,
+        erc20_minter=publisher_wallet,
+        cap=to_wei(to_wei("1000000000")),
+    )
+
+    erc20.mint(consumer_wallet.address, to_wei("100000000000"), publisher_wallet)
+    erc20.mint(publisher_wallet.address, to_wei("1000000000"), publisher_wallet)
+
+    # ocean_token = ERC20Token(web3, get_address_of_type(config, "Ocean"))
+    ocean_token = erc20
 
     initial_eth_balance = web3.eth.getBalance(consumer_wallet.address)
     ocean_token.transfer(
-        another_consumer_wallet.address, to_wei("500"), consumer_wallet
+        another_consumer_wallet.address, to_wei("1000000000"), consumer_wallet
     )
 
     bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
         web3,
         config,
         publisher_wallet,
+        ocean_token,
         swap_fee,
         swap_market_fee,
         initial_pool_liquidity,
@@ -530,16 +543,16 @@ def test_side_staking_steal(
         - initial_ocean_user_balance,
         "ether",
     )
-    assert (
-        from_wei(initial_eth_balance - final_eth_balance, "ether") < 0.00005
-    )  # eth spent ~ < 0.00004? seems wrong
+    # assert (
+    #     # from_wei(initial_eth_balance - final_eth_balance, "ether") < 0.00005
+    # )  # eth spent ~ < 0.00004? seems wrong
 
     # We are stealing from the pool :')
     assert (
         ocean_token.balanceOf(another_consumer_wallet.address)
         > initial_ocean_user_balance
     )
-    assert profit > 7.5  # OCEAN stolen
+    assert profit > 37600  # OCEAN stolen
 
 
 def test_side_staking_constant_rate(

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -432,15 +432,16 @@ def test_side_staking_steal(
     In this test we try to steal basetoken from the pull
     """
     # Test initial values and setups
-    initial_pool_liquidity = to_wei("1")
-    token_cap = to_wei("5")
+    initial_pool_liquidity = to_wei("10")
+    token_cap = to_wei("50")
     swap_market_fee = to_wei("0.0001")
     swap_fee = to_wei("0.0001")
     big_allowance = to_wei("100000000")
 
     ocean_token = ERC20Token(web3, get_address_of_type(config, "Ocean"))
 
-    ocean_token.transfer(another_consumer_wallet.address, to_wei("50"), consumer_wallet)
+    initial_eth_balance = web3.eth.getBalance(consumer_wallet.address)
+    ocean_token.transfer(another_consumer_wallet.address, to_wei("500"), consumer_wallet)
 
     bpool, erc20_token, erc721_token, pool_token = create_nft_erc20_with_pool(
         web3,
@@ -459,7 +460,7 @@ def test_side_staking_steal(
 
     initial_ocean_user_balance = ocean_token.balanceOf(another_consumer_wallet.address)
     swap_exact_amount_in_base_token(
-        bpool, erc20_token, ocean_token, another_consumer_wallet, to_wei("0.1")
+        bpool, erc20_token, ocean_token, another_consumer_wallet, to_wei("1")
     )
 
     # Fill the pool until the cap is reached
@@ -467,9 +468,9 @@ def test_side_staking_steal(
     while previous_pool_datatoken_balance != erc20_token.balanceOf(bpool.address):
         previous_pool_datatoken_balance = erc20_token.balanceOf(bpool.address)
         join_pool_one_side(
-            web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5")
+            web3, bpool, ocean_token, another_consumer_wallet, to_wei("5")
         )
-    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("0.5"))
+    join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet, to_wei("5"))
 
     swap_exact_amount_in_datatoken(
         bpool,
@@ -507,36 +508,7 @@ def test_side_staking_steal(
         ocean_token.balanceOf(another_consumer_wallet.address)
         > initial_ocean_user_balance
     )
-
-    # # Test in a different order
-    # initial_ocean_user_balance = ocean_token.balanceOf(another_consumer_wallet.address)
-    # swap_exact_amount_in_base_token(
-    #     bpool, erc20_token, ocean_token, another_consumer_wallet, to_wei("20")
-    # )
-    # join_pool_one_side(web3, bpool, ocean_token, another_consumer_wallet)
-    # swap_exact_amount_in_datatoken(
-    #     bpool,
-    #     erc20_token,
-    #     ocean_token,
-    #     another_consumer_wallet,
-    #     erc20_token.balanceOf(another_consumer_wallet.address),
-    # )
-    # wallet_exit_pool(web3, bpool, pool_token, another_consumer_wallet)
-    # swap_exact_amount_in_datatoken(
-    #     bpool,
-    #     erc20_token,
-    #     ocean_token,
-    #     another_consumer_wallet,
-    #     erc20_token.balanceOf(another_consumer_wallet.address),
-    # )
-
-    # # Check that users hasn't made any profit
-    # assert pool_token.balanceOf(another_consumer_wallet.address) == 0
-    # assert erc20_token.balanceOf(another_consumer_wallet.address) == 0
-    # assert (
-    #     ocean_token.balanceOf(another_consumer_wallet.address)
-    #     <= initial_ocean_user_balance
-    # )
+    assert profit > 1.80  # OCEAN stolen
 
 
 def test_side_staking_constant_rate(

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -2,15 +2,12 @@
 # Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-from re import I
-from eth_utils import from_wei
 import pytest
 from web3 import exceptions
 
 from ocean_lib.models.bpool import BPool
 from ocean_lib.models.erc20_token import ERC20Token
 from ocean_lib.models.erc721_factory import ERC721FactoryContract
-from ocean_lib.models.erc721_nft import ERC721NFT
 from ocean_lib.models.side_staking import SideStaking
 from ocean_lib.web3_internal.constants import MAX_UINT256
 from ocean_lib.web3_internal.currency import to_wei

--- a/ocean_lib/models/test/test_side_staking.py
+++ b/ocean_lib/models/test/test_side_staking.py
@@ -558,12 +558,6 @@ def test_side_staking_constant_rate(
     erc20_token.approve(bpool.address, big_allowance, another_consumer_wallet)
 
     # End test initial values and setups
-
-    # Check remaining datatokens in SS contract
-    # assert erc20_token.balanceOf(get_address_of_type(config, "Staking")) == to_wei(
-    #     "400"
-    # )
-
     initial_spot_price_basetoken_datatoken = bpool.get_spot_price(
         ocean_token.address, erc20_token.address, swap_market_fee
     )

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -482,6 +482,30 @@ def wallet_exit_pool(web3, bpool, pool_token, wallet, amt: int = 0):
     )
 
 
+def wallet_exit_pool_one_side(
+    web3, bpool, base_token, pool_token, wallet, amt: int = 0
+):
+    """
+    Exit pool with one side with amt, if amt is 0, exit pool with max amount.
+    """
+    pool_token_out_balance = bpool.get_balance(
+        base_token.address
+    )  # pool base token balance
+    max_out_ratio = bpool.get_max_out_ratio()  # max ratio
+
+    max_out_ratio_limit = int(from_wei(max_out_ratio, "ether") * pool_token_out_balance)
+
+    web3.eth.wait_for_transaction_receipt(
+        bpool.exit_swap_pool_amount_in(
+            amt
+            if amt
+            else min(max_out_ratio_limit, pool_token.balanceOf(wallet.address)),
+            0,
+            wallet,
+        )
+    )
+
+
 def join_pool_one_side(web3, bpool, base_token, wallet, amt: int = 0):
     """
     Join 1ss pool with amt, if amt is 0, join pool with max amount.

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -540,11 +540,18 @@ def swap_exact_amount_in_datatoken(bpool, datatoken, base_token, wallet, amt: in
 
 
 def swap_exact_amount_in_base_token(bpool, datatoken, base_token, wallet, amt: int = 0):
+    pool_token_out_balance = bpool.get_balance(
+        base_token.address
+    )  # pool base token balance
+    max_out_ratio = bpool.get_max_out_ratio()  # max ratio
+
+    max_out_ratio_limit = int(from_wei(max_out_ratio, "ether") * pool_token_out_balance)
+
     bpool.swap_exact_amount_in(
         base_token.address,
         datatoken.address,
         wallet.address,
-        amt,
+        amt if amt else max_out_ratio_limit,
         to_wei("0"),
         to_wei("100000"),
         to_wei("0"),

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -9,9 +9,9 @@ import os
 from typing import Any, Dict, Optional, Tuple, Union
 
 import coloredlogs
-from eth_utils import from_wei
 import yaml
 from enforce_typing import enforce_types
+from pytest import approx
 from web3 import Web3
 
 from ocean_lib.config import Config
@@ -24,11 +24,10 @@ from ocean_lib.ocean.ocean import Ocean
 from ocean_lib.ocean.util import get_contracts_addresses
 from ocean_lib.ocean.util import get_web3 as util_get_web3
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
-from ocean_lib.web3_internal.currency import to_wei
+from ocean_lib.web3_internal.currency import from_wei, to_wei
 from ocean_lib.web3_internal.utils import split_signature
 from ocean_lib.web3_internal.wallet import Wallet
 from tests.resources.mocks.data_provider_mock import DataProviderMock
-from pytest import approx
 
 _NETWORK = "ganache"
 
@@ -458,7 +457,7 @@ def join_pool_with_max_base_token(bpool, web3, base_token, wallet, amt: int = 0)
     )  # pool base token balance
     max_out_ratio = bpool.get_max_out_ratio()  # max ratio
 
-    max_out_ratio_limit = int(from_wei(max_out_ratio, "ether") * pool_token_out_balance)
+    max_out_ratio_limit = int(from_wei(max_out_ratio) * pool_token_out_balance)
 
     web3.eth.wait_for_transaction_receipt(
         bpool.join_swap_extern_amount_in(
@@ -493,7 +492,7 @@ def wallet_exit_pool_one_side(
     )  # pool base token balance
     max_out_ratio = bpool.get_max_out_ratio()  # max ratio
 
-    max_out_ratio_limit = int(from_wei(max_out_ratio, "ether") * pool_token_out_balance)
+    max_out_ratio_limit = int(from_wei(max_out_ratio) * pool_token_out_balance)
 
     web3.eth.wait_for_transaction_receipt(
         bpool.exit_swap_pool_amount_in(
@@ -515,7 +514,7 @@ def join_pool_one_side(web3, bpool, base_token, wallet, amt: int = 0):
     )  # pool base token balance
     max_out_ratio = bpool.get_max_out_ratio()  # max ratio
 
-    max_out_ratio_limit = int(from_wei(max_out_ratio, "ether") * pool_token_out_balance)
+    max_out_ratio_limit = int(from_wei(max_out_ratio) * pool_token_out_balance)
 
     web3.eth.wait_for_transaction_receipt(
         bpool.join_swap_extern_amount_in(
@@ -545,7 +544,7 @@ def swap_exact_amount_in_base_token(bpool, datatoken, base_token, wallet, amt: i
     )  # pool base token balance
     max_out_ratio = bpool.get_max_out_ratio()  # max ratio
 
-    max_out_ratio_limit = int(from_wei(max_out_ratio, "ether") * pool_token_out_balance)
+    max_out_ratio_limit = int(from_wei(max_out_ratio) * pool_token_out_balance)
 
     bpool.swap_exact_amount_in(
         base_token.address,


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

Fixes #753.

Changes proposed in this PR:

- Test the cap limits of the Side Staking bot
- Try to steal base token from the pool unsuccessful
- Check the "constant" ratio-> To be discussed, see my TODO