### PR TITLE
Issue783 fix to wei

### DIFF
--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -26,6 +26,7 @@ from ocean_lib.ocean.ocean_compute import OceanCompute
 from ocean_lib.ocean.util import get_address_of_type, get_ocean_token_address, get_web3
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.currency import DECIMALS_18
+from ocean_lib.web3_internal.currency import parse_units as _parse_units
 from ocean_lib.web3_internal.currency import to_wei as _to_wei
 from ocean_lib.web3_internal.utils import split_signature
 from ocean_lib.web3_internal.wallet import Wallet
@@ -100,10 +101,12 @@ class Ocean:
         return get_ocean_token_address(self.config.address_file, web3=self.web3)
 
     @enforce_types
-    def to_wei(
-        self, amount_in_ether: Union[Decimal, str, int], decimals: int = DECIMALS_18
-    ):
-        return _to_wei(amount_in_ether=amount_in_ether, decimals=decimals)
+    def to_wei(self, amount_in_ether: Union[Decimal, str, int]):
+        return _to_wei(amount_in_ether)
+
+    @enforce_types
+    def parse_units(self, amount: Union[Decimal, str, int], units: int = DECIMALS_18):
+        return _parse_units(amount, units)
 
     @enforce_types
     def create_erc721_nft(

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -26,6 +26,8 @@ from ocean_lib.ocean.ocean_compute import OceanCompute
 from ocean_lib.ocean.util import get_address_of_type, get_ocean_token_address, get_web3
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.currency import DECIMALS_18
+from ocean_lib.web3_internal.currency import format_units as _format_units
+from ocean_lib.web3_internal.currency import from_wei as _from_wei
 from ocean_lib.web3_internal.currency import parse_units as _parse_units
 from ocean_lib.web3_internal.currency import to_wei as _to_wei
 from ocean_lib.web3_internal.utils import split_signature
@@ -105,8 +107,16 @@ class Ocean:
         return _to_wei(amount_in_ether)
 
     @enforce_types
+    def from_wei(self, amount_in_wei: int):
+        return _from_wei(amount_in_wei)
+
+    @enforce_types
     def parse_units(self, amount: Union[Decimal, str, int], units: int = DECIMALS_18):
         return _parse_units(amount, units)
+
+    @enforce_types
+    def format_units(self, amount: Union[Decimal, str, int], units: int = DECIMALS_18):
+        return _format_units(amount, units)
 
     @enforce_types
     def create_erc721_nft(

--- a/ocean_lib/web3_internal/currency.py
+++ b/ocean_lib/web3_internal/currency.py
@@ -44,24 +44,24 @@ def format_units(amount_in_wei: int, decimals: int = DECIMALS_18) -> Decimal:
     # Coerce to Decimal because Web3.fromWei can return int 0
     units_dec = Decimal(10) ** abs(decimals)
     quantize_dec = Decimal(10) ** -abs(decimals)
-    unit = next((name for name, dec in units.items() if dec == units_dec))
-    amount_in_ether = Decimal(Web3.fromWei(amount_in_wei, unit))
+    unit_name = next((name for name, dec in units.items() if dec == units_dec))
+    amount_in_ether = Decimal(Web3.fromWei(amount_in_wei, unit_name))
     return amount_in_ether.quantize(quantize_dec, context=ETHEREUM_DECIMAL_CONTEXT)
 
 
 @enforce_types
-def parse_units(amount: Union[Decimal, str, int], units: int = DECIMALS_18) -> int:
+def parse_units(amount: Union[Decimal, str, int], decimals: int = DECIMALS_18) -> int:
     """
     Convert token amount to wei from ether, quantized to the specified number of decimal places
     float input is purposfully not supported
     """
-    amount = normalize_and_validate_ether(amount, units)
-    units_dec = Decimal(10) ** abs(units)
-    quantize_dec = Decimal(10) ** -abs(units)
-    units = next((name for name, dec in units.items() if dec == units_dec))
+    amount = normalize_and_validate_ether(amount, decimals)
+    units_dec = Decimal(10) ** abs(decimals)
+    quantize_dec = Decimal(10) ** -abs(decimals)
+    unit_name = next((name for name, dec in units.items() if dec == units_dec))
     return Web3.toWei(
         amount.quantize(quantize_dec, context=ETHEREUM_DECIMAL_CONTEXT),
-        units,
+        unit_name,
     )
 
 

--- a/ocean_lib/web3_internal/currency.py
+++ b/ocean_lib/web3_internal/currency.py
@@ -44,6 +44,10 @@ UNITS = [
     "szabo",
     "finney",
     "ether",
+    "kether",
+    "mether",
+    "gether",
+    "tether",
 ]
 
 
@@ -51,13 +55,21 @@ UNITS = [
 def format_units(amount: int, unit_name: Union[str, int] = DECIMALS_18) -> Decimal:
     """Convert token amount EVM-compatible integer to a formatted unit."""
     # Coerce to Decimal because Web3.fromWei can return int 0
-    amount_in_ether = Decimal(Web3.fromWei(amount, "ether"))
-    num_decimals = UNITS.index(unit_name) if isinstance(unit_name, str) else unit_name
-    divisor = Decimal(10) ** -(DECIMALS_18 - num_decimals)
-    quantize_decimals = Decimal(10) ** -abs(num_decimals)
+    num_decimals = (
+        UNITS.index(unit_name) * 3 if isinstance(unit_name, str) else unit_name
+    )
+
+    if amount == 0:
+        return Decimal(0)
+
+    if amount < MIN_WEI or amount > MAX_WEI:
+        raise ValueError("value must be between 1 and 2**256 - 1")
+
+    unit_value = Decimal(10) ** num_decimals
+
     with localcontext(ETHEREUM_DECIMAL_CONTEXT):
-        amount_in_unit = amount_in_ether / divisor
-        return amount_in_unit.quantize(quantize_decimals)
+        decimal_amount = Decimal(value=amount)
+        return decimal_amount / unit_value
 
 
 @enforce_types

--- a/ocean_lib/web3_internal/currency.py
+++ b/ocean_lib/web3_internal/currency.py
@@ -57,7 +57,7 @@ def to_wei(
     Convert token amount to wei from ether, quantized to the specified number of decimal places
     float input is purposfully not supported
     """
-    amount_in_ether = normalize_and_validate_ether(amount_in_ether)
+    amount_in_ether = normalize_and_validate_ether(amount_in_ether, decimals)
     units_dec = Decimal(10) ** abs(decimals)
     quantize_dec = Decimal(10) ** -abs(decimals)
     unit = next((name for name, dec in units.items() if dec == units_dec))
@@ -214,14 +214,18 @@ def moneyfmt(value, places=2, curr="", sep=",", dp=".", pos="", neg="-", trailne
 
 
 @enforce_types
-def normalize_and_validate_ether(amount_in_ether: Union[Decimal, str, int]) -> Decimal:
+def normalize_and_validate_ether(
+    amount_in_ether: Union[Decimal, str, int], decimals: int = DECIMALS_18
+) -> Decimal:
     """Returns an amount in ether, encoded as a Decimal
     Takes Decimal, str, or int as input. Purposefully does not support float."""
     if isinstance(amount_in_ether, str) or isinstance(amount_in_ether, int):
         amount_in_ether = Decimal(amount_in_ether)
 
-    if abs(amount_in_ether) > MAX_ETHER:
-        raise ValueError("Token abs(amount_in_ether) exceeds MAX_ETHER.")
+    if abs(amount_in_ether) > Decimal(MAX_WEI).scaleb(
+        -decimals, context=ETHEREUM_DECIMAL_CONTEXT
+    ):
+        raise ValueError("Token amount exceeds maximum.")
 
     return amount_in_ether
 

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -19,6 +19,9 @@ from ocean_lib.web3_internal.currency import (
     to_wei,
 )
 
+USDT_DECIMALS = 6
+MAX_USDT = Decimal(MAX_WEI).scaleb(-USDT_DECIMALS, context=ETHEREUM_DECIMAL_CONTEXT)
+
 
 @pytest.mark.unit
 def test_from_wei():
@@ -44,7 +47,6 @@ def test_from_wei():
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
             from_wei(MAX_WEI + 1)
 
-    USDT_DECIMALS = 6
     assert from_wei(0, USDT_DECIMALS) == Decimal(
         "0"
     ), "Zero wei of USDT should equal zero ether of USDT"
@@ -55,6 +57,7 @@ def test_from_wei():
         "1.123456"
     ), "Conversion from wei to ether using decimals failed"
     assert from_wei(5278_020000, USDT_DECIMALS) == Decimal("5278.02")
+    assert from_wei(MAX_WEI, USDT_DECIMALS) == MAX_USDT
 
 
 @pytest.mark.unit
@@ -93,7 +96,6 @@ def test_to_wei():
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
             to_wei(MAX_ETHER + 1)
 
-    USDT_DECIMALS = 6
     assert (
         to_wei("0", USDT_DECIMALS) == 0
     ), "Zero ether of USDT should equal zero wei of USDT"
@@ -104,6 +106,7 @@ def test_to_wei():
         to_wei("1.123456789123456789", USDT_DECIMALS) == 1_123456
     ), "Conversion from ether to wei using decimals failed"
     assert to_wei("5278.02", USDT_DECIMALS) == 5278_020000
+    assert to_wei(MAX_USDT, USDT_DECIMALS) == MAX_WEI
 
 
 @pytest.mark.unit

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -65,6 +65,11 @@ def test_format_units():
     assert format_units(5278_020000, USDT_DECIMALS) == Decimal("5278.02")
     assert format_units(MAX_WEI, USDT_DECIMALS) == MAX_USDT
 
+    with pytest.raises(ValueError):
+        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_WEI
+        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+            format_units(MAX_WEI + 1, USDT_DECIMALS)
+
 
 @pytest.mark.unit
 def test_to_wei():
@@ -117,6 +122,11 @@ def test_parse_units():
     ), "Conversion from ether to wei using decimals failed"
     assert parse_units("5278.02", USDT_DECIMALS) == 5278_020000
     assert parse_units(MAX_USDT, USDT_DECIMALS) == MAX_WEI
+
+    with pytest.raises(ValueError):
+        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
+        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+            to_wei(MAX_USDT + 1, USDT_DECIMALS)
 
 
 @pytest.mark.unit

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -48,12 +48,13 @@ def test_from_wei():
     assert from_wei(0, USDT_DECIMALS) == Decimal(
         "0"
     ), "Zero wei of USDT should equal zero ether of USDT"
-    assert from_wei(123456789_123456789, USDT_DECIMALS) == Decimal(
+    assert from_wei(123456, USDT_DECIMALS) == Decimal(
         "0.123456"
     ), "Conversion from wei to ether using decimals failed"
-    assert from_wei(1123456789_123456789, USDT_DECIMALS) == Decimal(
+    assert from_wei(1_123456, USDT_DECIMALS) == Decimal(
         "1.123456"
     ), "Conversion from wei to ether using decimals failed"
+    assert from_wei(5278_020000, USDT_DECIMALS) == Decimal("5278.02")
 
 
 @pytest.mark.unit
@@ -97,11 +98,12 @@ def test_to_wei():
         to_wei("0", USDT_DECIMALS) == 0
     ), "Zero ether of USDT should equal zero wei of USDT"
     assert (
-        to_wei("0.123456789123456789", USDT_DECIMALS) == 123456000_000000000
+        to_wei("0.123456789123456789", USDT_DECIMALS) == 123456
     ), "Conversion from ether to wei using decimals failed"
     assert (
-        to_wei("1.123456789123456789", USDT_DECIMALS) == 1_123456000_000000000
+        to_wei("1.123456789123456789", USDT_DECIMALS) == 1_123456
     ), "Conversion from ether to wei using decimals failed"
+    assert to_wei("5278.02", USDT_DECIMALS) == 5278_020000
 
 
 @pytest.mark.unit

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -70,6 +70,18 @@ def test_format_units():
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
             format_units(MAX_WEI + 1, USDT_DECIMALS)
 
+    assert format_units(0, "mwei") == Decimal("0")
+    assert format_units(123456, "mwei") == Decimal("0.123456")
+    assert format_units(1_123456, "mwei") == Decimal("1.123456")
+    assert format_units(5278_020000, "mwei") == Decimal("5278.02")
+    assert format_units(MIN_WEI, "mwei") == MIN_USDT
+    assert format_units(MAX_WEI, "mwei") == MAX_USDT
+
+    with pytest.raises(ValueError):
+        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_WEI
+        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+            format_units(MAX_WEI + 1, "mwei")
+
     assert format_units(12345, SEVEN_DECIMALS) == Decimal("0.0012345")
     assert format_units(111_1234567, SEVEN_DECIMALS) == Decimal("111.1234567")
     assert format_units(MIN_WEI, SEVEN_DECIMALS) == MIN_SEVEN
@@ -127,6 +139,18 @@ def test_parse_units():
         # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
             parse_units(MAX_USDT + 1, USDT_DECIMALS)
+
+    assert parse_units("0", "mwei") == 0
+    assert parse_units("0.123456789123456789", "mwei") == 123456
+    assert parse_units("1.123456789123456789", "mwei") == 1_123456
+    assert parse_units("5278.02", "mwei") == 5278_020000
+    assert parse_units(MIN_USDT, "mwei") == MIN_WEI
+    assert parse_units(MAX_USDT, "mwei") == MAX_WEI
+
+    with pytest.raises(ValueError):
+        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
+        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+            parse_units(MAX_USDT + 1, "mwei")
 
     assert parse_units("0", SEVEN_DECIMALS) == 0
     assert parse_units("0.123456789", SEVEN_DECIMALS) == 1234567

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -13,7 +13,9 @@ from ocean_lib.web3_internal.currency import (
     MIN_ETHER,
     MIN_WEI,
     ether_fmt,
+    format_units,
     from_wei,
+    parse_units,
     pretty_ether,
     pretty_ether_and_wei,
     to_wei,
@@ -47,17 +49,21 @@ def test_from_wei():
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
             from_wei(MAX_WEI + 1)
 
-    assert from_wei(0, USDT_DECIMALS) == Decimal(
+
+@pytest.mark.unit
+def test_format_units():
+    """Test the format_units function"""
+    assert format_units(0, USDT_DECIMALS) == Decimal(
         "0"
     ), "Zero wei of USDT should equal zero ether of USDT"
-    assert from_wei(123456, USDT_DECIMALS) == Decimal(
+    assert format_units(123456, USDT_DECIMALS) == Decimal(
         "0.123456"
     ), "Conversion from wei to ether using decimals failed"
-    assert from_wei(1_123456, USDT_DECIMALS) == Decimal(
+    assert format_units(1_123456, USDT_DECIMALS) == Decimal(
         "1.123456"
     ), "Conversion from wei to ether using decimals failed"
-    assert from_wei(5278_020000, USDT_DECIMALS) == Decimal("5278.02")
-    assert from_wei(MAX_WEI, USDT_DECIMALS) == MAX_USDT
+    assert format_units(5278_020000, USDT_DECIMALS) == Decimal("5278.02")
+    assert format_units(MAX_WEI, USDT_DECIMALS) == MAX_USDT
 
 
 @pytest.mark.unit
@@ -96,17 +102,21 @@ def test_to_wei():
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
             to_wei(MAX_ETHER + 1)
 
+
+@pytest.mark.unit
+def test_parse_units():
+    """Test the parse_units function"""
     assert (
-        to_wei("0", USDT_DECIMALS) == 0
+        parse_units("0", USDT_DECIMALS) == 0
     ), "Zero ether of USDT should equal zero wei of USDT"
     assert (
-        to_wei("0.123456789123456789", USDT_DECIMALS) == 123456
+        parse_units("0.123456789123456789", USDT_DECIMALS) == 123456
     ), "Conversion from ether to wei using decimals failed"
     assert (
-        to_wei("1.123456789123456789", USDT_DECIMALS) == 1_123456
+        parse_units("1.123456789123456789", USDT_DECIMALS) == 1_123456
     ), "Conversion from ether to wei using decimals failed"
-    assert to_wei("5278.02", USDT_DECIMALS) == 5278_020000
-    assert to_wei(MAX_USDT, USDT_DECIMALS) == MAX_WEI
+    assert parse_units("5278.02", USDT_DECIMALS) == 5278_020000
+    assert parse_units(MAX_USDT, USDT_DECIMALS) == MAX_WEI
 
 
 @pytest.mark.unit

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -22,7 +22,12 @@ from ocean_lib.web3_internal.currency import (
 )
 
 USDT_DECIMALS = 6
+MIN_USDT = Decimal("0.000001")
 MAX_USDT = Decimal(MAX_WEI).scaleb(-USDT_DECIMALS, context=ETHEREUM_DECIMAL_CONTEXT)
+
+SEVEN_DECIMALS = 7
+MIN_SEVEN = Decimal("0.0000001")
+MAX_SEVEN = Decimal(MAX_WEI).scaleb(-SEVEN_DECIMALS, context=ETHEREUM_DECIMAL_CONTEXT)
 
 
 @pytest.mark.unit
@@ -53,22 +58,22 @@ def test_from_wei():
 @pytest.mark.unit
 def test_format_units():
     """Test the format_units function"""
-    assert format_units(0, USDT_DECIMALS) == Decimal(
-        "0"
-    ), "Zero wei of USDT should equal zero ether of USDT"
-    assert format_units(123456, USDT_DECIMALS) == Decimal(
-        "0.123456"
-    ), "Conversion from wei to ether using decimals failed"
-    assert format_units(1_123456, USDT_DECIMALS) == Decimal(
-        "1.123456"
-    ), "Conversion from wei to ether using decimals failed"
+    assert format_units(0, USDT_DECIMALS) == Decimal("0")
+    assert format_units(123456, USDT_DECIMALS) == Decimal("0.123456")
+    assert format_units(1_123456, USDT_DECIMALS) == Decimal("1.123456")
     assert format_units(5278_020000, USDT_DECIMALS) == Decimal("5278.02")
+    assert format_units(MIN_WEI, USDT_DECIMALS) == MIN_USDT
     assert format_units(MAX_WEI, USDT_DECIMALS) == MAX_USDT
 
     with pytest.raises(ValueError):
         # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_WEI
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
             format_units(MAX_WEI + 1, USDT_DECIMALS)
+
+    assert format_units(12345, SEVEN_DECIMALS) == Decimal("0.0012345")
+    assert format_units(111_1234567, SEVEN_DECIMALS) == Decimal("111.1234567")
+    assert format_units(MIN_WEI, SEVEN_DECIMALS) == MIN_SEVEN
+    assert format_units(MAX_WEI, SEVEN_DECIMALS) == MAX_SEVEN
 
 
 @pytest.mark.unit
@@ -111,22 +116,24 @@ def test_to_wei():
 @pytest.mark.unit
 def test_parse_units():
     """Test the parse_units function"""
-    assert (
-        parse_units("0", USDT_DECIMALS) == 0
-    ), "Zero ether of USDT should equal zero wei of USDT"
-    assert (
-        parse_units("0.123456789123456789", USDT_DECIMALS) == 123456
-    ), "Conversion from ether to wei using decimals failed"
-    assert (
-        parse_units("1.123456789123456789", USDT_DECIMALS) == 1_123456
-    ), "Conversion from ether to wei using decimals failed"
+    assert parse_units("0", USDT_DECIMALS) == 0
+    assert parse_units("0.123456789123456789", USDT_DECIMALS) == 123456
+    assert parse_units("1.123456789123456789", USDT_DECIMALS) == 1_123456
     assert parse_units("5278.02", USDT_DECIMALS) == 5278_020000
+    assert parse_units(MIN_USDT, USDT_DECIMALS) == MIN_WEI
     assert parse_units(MAX_USDT, USDT_DECIMALS) == MAX_WEI
 
     with pytest.raises(ValueError):
         # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
             to_wei(MAX_USDT + 1, USDT_DECIMALS)
+
+    assert parse_units("0", SEVEN_DECIMALS) == 0
+    assert parse_units("0.123456789", SEVEN_DECIMALS) == 1234567
+    assert parse_units("1.123456789", SEVEN_DECIMALS) == 1_1234567
+    assert parse_units("5278.02", SEVEN_DECIMALS) == 5278_0200000
+    assert parse_units(MIN_SEVEN, SEVEN_DECIMALS) == MIN_WEI
+    assert parse_units(MAX_SEVEN, SEVEN_DECIMALS) == MAX_WEI
 
 
 @pytest.mark.unit

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -126,7 +126,7 @@ def test_parse_units():
     with pytest.raises(ValueError):
         # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
         with localcontext(ETHEREUM_DECIMAL_CONTEXT):
-            to_wei(MAX_USDT + 1, USDT_DECIMALS)
+            parse_units(MAX_USDT + 1, USDT_DECIMALS)
 
     assert parse_units("0", SEVEN_DECIMALS) == 0
     assert parse_units("0.123456789", SEVEN_DECIMALS) == 1234567

--- a/tests/integration/test_swap_fees_fuzzing.py
+++ b/tests/integration/test_swap_fees_fuzzing.py
@@ -5,24 +5,17 @@
 
 import random
 import traceback
+from decimal import Decimal
 from math import floor
 from time import time
-from decimal import *
-
-import pytest
 
 from ocean_lib.models.bpool import BPool
 from ocean_lib.models.erc20_token import ERC20Token
-from ocean_lib.models.erc721_factory import ERC721FactoryContract
-from ocean_lib.models.side_staking import SideStaking
-from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
-from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.currency import from_wei, to_wei
 from tests.resources.helper_functions import (
     approx_from_wei,
-    deploy_erc721_erc20,
-    get_address_of_type,
     create_nft_erc20_with_pool,
+    get_address_of_type,
 )
 
 BPOOL_FUZZING_TESTS_NBR_OF_RUNS = 1
@@ -103,16 +96,14 @@ def test_fuzzing_pool_ocean(
 
     for _ in range(BPOOL_FUZZING_TESTS_NBR_OF_RUNS):
         try:
-            side_staking = SideStaking(web3, get_address_of_type(config, "Staking"))
-
             # Seed random number generator
             random.seed(time())
 
             # Max number of datatokens that can be minted and added to the liquidity pool
-            cap = to_wei(random.randint(100, 1000000), 18)
+            cap = to_wei(random.randint(100, 1000000))
 
-            swap_fee = to_wei(Decimal(random.uniform(0.00001, 0.1)), 18)
-            swap_market_fee = to_wei(Decimal(random.uniform(0.00001, 0.1)), 18)
+            swap_fee = to_wei(Decimal(random.uniform(0.00001, 0.1)))
+            swap_market_fee = to_wei(Decimal(random.uniform(0.00001, 0.1)))
 
             # Tests consumer calls deployPool(), we then check ocean and market fee"
             ocean_token = ERC20Token(
@@ -138,7 +129,7 @@ def test_fuzzing_pool_ocean(
             ss_DT_vested_blocks = random.randint(
                 min_vesting_period, min_vesting_period * 1000
             )
-            ss_rate = to_wei(Decimal(random.uniform(1 / 10**6, 10**4)), 18)
+            ss_rate = to_wei(Decimal(random.uniform(1 / 10**6, 10**4)))
 
             bpool, erc20_token, _, _ = create_nft_erc20_with_pool(
                 web3=web3,
@@ -393,7 +384,7 @@ def test_fuzzing_pool_ocean(
                 swap_event_args.tokenAmountIn / (to_wei("1") / swap_fee),
                 swap_fees_event_args.LPFeeAmount,
             )
-        except:
+        except Exception:
 
             error = traceback.format_exc()
 


### PR DESCRIPTION
Fixes #783 .

Changes proposed in this PR:

- Fix bug in `to_wei` and `from_wei` where ERC-20 token amounts with decimals other than 18 were not calculated correctly.
- Add `parse_units` and `format_units` methods, (analogous to ethers.js `parseUnits` and `formatUnits`)
- Add `from_wei` and `format_units` pass-throughs to the Ocean API