### PR TITLE
Refactor to wei

### DIFF
--- a/ocean_lib/web3_internal/currency.py
+++ b/ocean_lib/web3_internal/currency.py
@@ -6,6 +6,7 @@ from decimal import ROUND_DOWN, Context, Decimal, localcontext
 from typing import Union
 
 from enforce_typing import enforce_types
+from eth_utils.currency import units
 
 from ocean_lib.web3_internal.constants import MAX_UINT256
 
@@ -35,29 +36,14 @@ MIN_ETHER = Decimal("0.000000000000000001")
 """The maximum possible token amount on Ethereum-compatible blockchains, denoted in ether"""
 MAX_ETHER = Decimal(MAX_WEI).scaleb(-18, context=ETHEREUM_DECIMAL_CONTEXT)
 
-UNITS = [
-    "wei",
-    "kwei",
-    "mwei",
-    "gwei",
-    "szabo",
-    "finney",
-    "ether",
-    "kether",
-    "mether",
-    "gether",
-    "tether",
-]
-
 
 @enforce_types
 def format_units(amount: int, unit_name: Union[str, int] = DECIMALS_18) -> Decimal:
     """Convert token amount EVM-compatible integer to a formatted unit."""
     # Coerce to Decimal because Web3.fromWei can return int 0
     num_decimals = (
-        UNITS.index(unit_name) * 3 if isinstance(unit_name, str) else unit_name
+        int(units[unit_name].log10()) if isinstance(unit_name, str) else unit_name
     )
-
     if amount == 0:
         return Decimal(0)
 
@@ -79,7 +65,7 @@ def parse_units(
     float input is purposfully not supported
     """
     num_decimals = (
-        UNITS.index(unit_name) * 3 if isinstance(unit_name, str) else unit_name
+        int(units[unit_name].log10()) if isinstance(unit_name, str) else unit_name
     )
 
     decimal_amount = normalize_and_validate_unit(amount, num_decimals)

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -49,9 +49,9 @@ def test_from_wei():
         from_wei(MAX_WEI) == MAX_ETHER
     ), "Conversion from maximum wei to maximum ether failed."
 
-    with pytest.raises(ValueError):
-        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_ETHER
-        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+    # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_ETHER
+    with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+        with pytest.raises(ValueError):
             from_wei(MAX_WEI + 1)
 
 
@@ -65,9 +65,9 @@ def test_format_units():
     assert format_units(MIN_WEI, USDT_DECIMALS) == MIN_USDT
     assert format_units(MAX_WEI, USDT_DECIMALS) == MAX_USDT
 
-    with pytest.raises(ValueError):
-        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_WEI
-        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+    # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_WEI
+    with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+        with pytest.raises(ValueError):
             format_units(MAX_WEI + 1, USDT_DECIMALS)
 
     assert format_units(0, "mwei") == Decimal("0")
@@ -77,9 +77,9 @@ def test_format_units():
     assert format_units(MIN_WEI, "mwei") == MIN_USDT
     assert format_units(MAX_WEI, "mwei") == MAX_USDT
 
-    with pytest.raises(ValueError):
-        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_WEI
-        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+    # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_WEI
+    with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+        with pytest.raises(ValueError):
             format_units(MAX_WEI + 1, "mwei")
 
     assert format_units(12345, SEVEN_DECIMALS) == Decimal("0.0012345")
@@ -119,9 +119,9 @@ def test_to_wei():
         to_wei(MAX_ETHER) == MAX_WEI
     ), "Conversion from maximum ether to maximum wei failed."
 
-    with pytest.raises(ValueError):
-        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_ETHER
-        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+    # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_ETHER
+    with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+        with pytest.raises(ValueError):
             to_wei(MAX_ETHER + 1)
 
 
@@ -135,9 +135,9 @@ def test_parse_units():
     assert parse_units(MIN_USDT, USDT_DECIMALS) == MIN_WEI
     assert parse_units(MAX_USDT, USDT_DECIMALS) == MAX_WEI
 
-    with pytest.raises(ValueError):
-        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
-        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+    # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
+    with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+        with pytest.raises(ValueError):
             parse_units(MAX_USDT + 1, USDT_DECIMALS)
 
     assert parse_units("0", "mwei") == 0
@@ -147,9 +147,9 @@ def test_parse_units():
     assert parse_units(MIN_USDT, "mwei") == MIN_WEI
     assert parse_units(MAX_USDT, "mwei") == MAX_WEI
 
-    with pytest.raises(ValueError):
-        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
-        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+    # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_USDT
+    with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+        with pytest.raises(ValueError):
             parse_units(MAX_USDT + 1, "mwei")
 
     assert parse_units("0", SEVEN_DECIMALS) == 0
@@ -180,9 +180,9 @@ def test_ether_fmt():
         == "115,792,089,237,316,195,423,570,985,008,687,907,853,269,984,665,640,564,039,457.584007913129639935"
     ), "Should have 78 digits, commas, 18 decimal places, no ticker symbol"
 
-    with pytest.raises(ValueError):
-        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_ETHER
-        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+    # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_ETHER
+    with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+        with pytest.raises(ValueError):
             assert ether_fmt(MAX_ETHER + 1)
 
 
@@ -238,9 +238,9 @@ def test_pretty_ether():
     assert pretty_ether("1234567890123") == "1.23e+12"
     assert pretty_ether("12345678901234") == "1.23e+13"
     assert pretty_ether(MAX_ETHER) == "1.15e+59"
-    with pytest.raises(ValueError):
-        # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_ETHER
-        with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+    # Use ETHEREUM_DECIMAL_CONTEXT when performing arithmetic on MAX_ETHER
+    with localcontext(ETHEREUM_DECIMAL_CONTEXT):
+        with pytest.raises(ValueError):
             pretty_ether(MAX_ETHER + 1)
 
 


### PR DESCRIPTION
Towards https://github.com/oceanprotocol/provider/pull/421.

Changes proposed in this PR:

- Address comments on https://github.com/oceanprotocol/provider/pull/421 that are also relevant in ocean.py:
  - Remove UNITS list. Use eth-utils.currency.units + log10() instead.
  - Move localcontext() out of scope for python.raises in test_currency.py. Rule out possibility that localcontext() is throwing ValueError.