### PR TITLE
Ensure all addresses returned by utils are checksummed

### DIFF
--- a/ocean_lib/ocean/test/test_util.py
+++ b/ocean_lib/ocean/test/test_util.py
@@ -4,6 +4,7 @@
 #
 
 import pytest
+from web3 import Web3
 
 from ocean_lib.ocean import util
 from ocean_lib.ocean.util import get_address_of_type, get_ocean_token_address
@@ -40,8 +41,17 @@ def test_get_ocean_token_address(config):
     assert "Ocean" in addresses
 
     address = get_ocean_token_address(config.address_file, "ganache")
-    assert address[:2] == "0x", "It is not a token address."
-    assert address == addresses["Ocean"]
+    assert Web3.isChecksumAddress(address), "It is not a checksum token address."
+    assert address == Web3.toChecksumAddress(addresses["Ocean"])
+
+
+@pytest.mark.unit
+def test_get_address_by_type(config):
+    addresses = util.get_contracts_addresses(config.address_file, "ganache")
+
+    address = get_address_of_type(config, "Ocean")
+    assert Web3.isChecksumAddress(address), "It is not a checksum token address."
+    assert address == Web3.toChecksumAddress(addresses["Ocean"])
 
 
 @pytest.mark.unit

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -80,11 +80,12 @@ def get_address_of_type(
     addresses = get_contracts_addresses(config.address_file, config.network_name)
     if address_type not in addresses.keys():
         raise KeyError(f"{address_type} address is not set in the config file")
-    return (
+    address = (
         addresses[address_type]
         if not isinstance(addresses[address_type], dict)
         else addresses[address_type].get(key, addresses[address_type]["1"])
     )
+    return Web3.toChecksumAddress(address)
 
 
 @enforce_types
@@ -97,4 +98,4 @@ def get_ocean_token_address(
     addresses = get_contracts_addresses(
         address_file, network or get_network_name(web3=web3)
     )
-    return addresses.get("Ocean") if addresses else None
+    return Web3.toChecksumAddress(addresses.get("Ocean")) if addresses else None

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -50,11 +50,12 @@ def get_address_of_type(
     addresses = get_contracts_addresses(config.address_file, _NETWORK)
     if address_type not in addresses.keys():
         raise KeyError(f"{address_type} address is not set in the config file")
-    return (
+    address = (
         addresses[address_type]
         if not isinstance(addresses[address_type], dict)
         else addresses[address_type].get(key, addresses[address_type]["1"])
     )
+    return Web3.toChecksumAddress(address)
 
 
 @enforce_types


### PR DESCRIPTION
Fixes #795 .

Changes proposed in this PR:

- Ensure all utils that retrieve an address from `address.json` checksum the address before returning it.