### PR TITLE
Fix circular dependency

### DIFF
--- a/ocean_lib/models/compute_input.py
+++ b/ocean_lib/models/compute_input.py
@@ -2,17 +2,20 @@
 # Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-from typing import Any, Dict, Optional, Union
+from typing import Dict, Optional, Union
 
 from enforce_typing import enforce_types
+
+from ocean_lib.assets.asset import Asset
+from ocean_lib.services.service import Service
 
 
 class ComputeInput:
     @enforce_types
     def __init__(
         self,
-        asset: Any,  # Asset
-        service: Any,  # Service
+        asset: Asset,
+        service: Service,
         transfer_tx_id: Union[str, bytes] = None,
         userdata: Optional[Dict] = None,
     ) -> None:

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -17,7 +17,7 @@ from ocean_lib.agreements.consumable import AssetNotConsumable, ConsumableCodes
 from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.aquarius import Aquarius
 from ocean_lib.assets.asset import Asset
-from ocean_lib.assets.asset_downloader import download_asset_files
+from ocean_lib.assets.asset_downloader import download_asset_files, is_consumable
 from ocean_lib.config import Config
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.exceptions import AquariusError, ContractNotFound, InsufficientBalance
@@ -628,8 +628,8 @@ class OceanAssets:
                 f"requires {pretty_ether_and_wei(1, dt.symbol())}."
             )
 
-        consumable_result = service.is_consumable(
-            asset, {"type": "address", "value": wallet.address}
+        consumable_result = is_consumable(
+            asset, service, {"type": "address", "value": wallet.address}
         )
         if consumable_result != ConsumableCodes.OK:
             raise AssetNotConsumable(consumable_result)

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -10,6 +10,7 @@ from enforce_typing import enforce_types
 from ocean_lib.agreements.consumable import AssetNotConsumable, ConsumableCodes
 from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.assets.asset import Asset
+from ocean_lib.assets.asset_downloader import is_consumable
 from ocean_lib.assets.asset_resolver import resolve_asset
 from ocean_lib.config import Config
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
@@ -52,8 +53,9 @@ class OceanCompute:
             ServiceTypes.CLOUD_COMPUTE == service.type
         ), "service at serviceId is not of type compute service."
 
-        consumable_result = service.is_consumable(
+        consumable_result = is_consumable(
             asset,
+            service,
             {"type": "address", "value": consumer_wallet.address},
             with_connectivity_check=True,
         )

--- a/ocean_lib/services/service.py
+++ b/ocean_lib/services/service.py
@@ -12,9 +12,7 @@ from typing import Any, Dict, List, Optional
 
 from web3.main import Web3
 
-from ocean_lib.agreements.consumable import ConsumableCodes
 from ocean_lib.agreements.service_types import ServiceTypes, ServiceTypesNames
-from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 
 logger = logging.getLogger(__name__)
 
@@ -171,27 +169,6 @@ class Service:
             values[key] = value
 
         return values
-
-    def is_consumable(
-        self,
-        asset,
-        credential: Optional[dict] = None,
-        with_connectivity_check: bool = True,
-    ) -> bool:
-        """Checks whether an asset is consumable and returns a ConsumableCode."""
-        if asset.is_disabled:
-            return ConsumableCodes.ASSET_DISABLED
-
-        if with_connectivity_check and not DataServiceProvider.check_asset_file_info(
-            asset.did, self.id, self.service_endpoint
-        ):
-            return ConsumableCodes.CONNECTIVITY_FAIL
-
-        # to be parameterized in the future, can implement other credential classes
-        if asset.requires_address_credential:
-            return asset.validate_access(credential)
-
-        return ConsumableCodes.OK
 
     def remove_publisher_trusted_algorithm(self, algo_did: str) -> list:
         """Returns a trusted algorithms list after removal."""

--- a/ocean_lib/services/test/test_service.py
+++ b/ocean_lib/services/test/test_service.py
@@ -2,8 +2,6 @@
 # Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-from unittest.mock import patch
-
 import pytest
 
 from ocean_lib.assets.asset import Asset
@@ -44,22 +42,6 @@ def test_service():
     del service_dict["type"]
     with pytest.raises(IndexError):
         Service.from_dict(service_dict)
-
-    ddo_dict = get_sample_ddo()
-    asset = Asset.from_dict(ddo_dict)
-    with patch(
-        "ocean_lib.services.service.DataServiceProvider.check_asset_file_info"
-    ) as mock:
-        mock.return_value = False
-        assert sa.is_consumable(asset, {}, True) == 2
-
-    with patch(
-        "ocean_lib.services.service.DataServiceProvider.check_asset_file_info"
-    ) as mock:
-        mock.return_value = True
-        assert (
-            sa.is_consumable(asset, {"type": "address", "value": "0xdddd"}, True) == 3
-        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes https://github.com/oceanprotocol/ocean.py/pull/799#discussion_r867643848

Changes proposed in this PR:

- Move `is_consumable()` from `service.py` to `asset_downloader.py`. Doing this breaks the circular import between `Asset`, `Service`, and `DataServiceProvider`:
  - `service.py` no longer imports `DataServiceProvider`
  - `service.py` no longer imports `Asset`
  - All logic that requires all three `Asset`, `Service`, and `DataServiceProvider` is silo'd in the separate file `asset_downloader.py`