### PR TITLE
Bump version: 0.8.5 → 0.8.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.5
+current_version = 0.8.6
 commit = True
 tag = True
 

--- a/.copyright.tmpl
+++ b/.copyright.tmpl
@@ -1,2 +1,2 @@
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,5 +1,5 @@
 ##
-## Copyright 2021 Ocean Protocol Foundation
+## Copyright 2022 Ocean Protocol Foundation
 ## SPDX-License-Identifier: Apache-2.0
 ##
 name: black

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ##
-## Copyright 2021 Ocean Protocol Foundation
+## Copyright 2022 Ocean Protocol Foundation
 ## SPDX-License-Identifier: Apache-2.0
 ##
 name: Ocean.py release

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,5 +1,5 @@
 ##
-## Copyright 2021 Ocean Protocol Foundation
+## Copyright 2022 Ocean Protocol Foundation
 ## SPDX-License-Identifier: Apache-2.0
 ##
 name: Ocean.py tests

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           repository: "oceanprotocol/barge"
           path: 'barge'
+          ref: v3
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 ##
-## Copyright 2021 Ocean Protocol Foundation
+## Copyright 2022 Ocean Protocol Foundation
 ## SPDX-License-Identifier: Apache-2.0
 ##
 repos:
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
     hooks:
     - id: isort
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 22.1.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.9.2
     hooks:
     - id: flake8
 -   repo: https://github.com/johann-petrak/licenseheaders.git

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,5 +1,5 @@
 ##
-## Copyright 2021 Ocean Protocol Foundation
+## Copyright 2022 Ocean Protocol Foundation
 ## SPDX-License-Identifier: Apache-2.0
 ##
 pep257:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 See [`releases`](https://github.com/oceanprotocol/ocean.py/releases).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/ALG_ddo.md
+++ b/READMEs/ALG_ddo.md
@@ -1,3 +1,7 @@
+<!--
+Copyright 2022 Ocean Protocol Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
 (HACK to help debugging. Remove later)
 
 In Python console:

--- a/READMEs/DATA_ddo.md
+++ b/READMEs/DATA_ddo.md
@@ -1,3 +1,7 @@
+<!--
+Copyright 2022 Ocean Protocol Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
 (HACK to help debugging. Remove later)
 
 In Python console:

--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/datatokens-flow.md
+++ b/READMEs/datatokens-flow.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/developers.md
+++ b/READMEs/developers.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/dispenser-flow.md
+++ b/READMEs/dispenser-flow.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/fixed-rate-exchange-flow.md
+++ b/READMEs/fixed-rate-exchange-flow.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/get-test-OCEAN.md
+++ b/READMEs/get-test-OCEAN.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/marketplace-flow.md
+++ b/READMEs/marketplace-flow.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/overview.md
+++ b/READMEs/overview.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/parameters.md
+++ b/READMEs/parameters.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/release-process.md
+++ b/READMEs/release-process.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/services.md
+++ b/READMEs/services.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/READMEs/wallets.md
+++ b/READMEs/wallets.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-## Copyright 2021 Ocean Protocol Foundation
+## Copyright 2022 Ocean Protocol Foundation
 ## SPDX-License-Identifier: Apache-2.0
 ##
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json
@@ -7,6 +7,7 @@ import os
 import uuid
 
 import pytest
+
 from ocean_lib.common.aquarius.aquarius_provider import AquariusProvider
 from ocean_lib.web3_internal.currency import from_wei, to_wei
 from ocean_lib.web3_internal.transactions import send_ether

--- a/ocean_lib/__init__.py
+++ b/ocean_lib/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/ocean_lib/__init__.py
+++ b/ocean_lib/__init__.py
@@ -7,5 +7,5 @@
 
 __author__ = """OceanProtocol"""
 # fmt: off
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 # fmt: on

--- a/ocean_lib/assets/__init__.py
+++ b/ocean_lib/assets/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/assets/asset.py
+++ b/ocean_lib/assets/asset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import copy
@@ -11,6 +11,7 @@ from typing import Any, List, Optional, Union
 from enforce_typing import enforce_types
 from eth_account.account import Account
 from eth_utils import add_0x_prefix
+
 from ocean_lib.assets.credentials import AddressCredential
 from ocean_lib.assets.did import did_to_id
 from ocean_lib.common.agreements.consumable import ConsumableCodes

--- a/ocean_lib/assets/asset_downloader.py
+++ b/ocean_lib/assets/asset_downloader.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -8,6 +8,7 @@ import os
 from typing import Optional, Type
 
 from enforce_typing import enforce_types
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.common.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider

--- a/ocean_lib/assets/asset_resolver.py
+++ b/ocean_lib/assets/asset_resolver.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """DID Resolver module."""
@@ -10,10 +10,11 @@ import logging
 from typing import Optional
 
 from enforce_typing import enforce_types
+from web3.main import Web3
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.common.aquarius.aquarius_provider import AquariusProvider
 from ocean_lib.models.data_token import DataToken
-from web3.main import Web3
 
 logger = logging.getLogger("keeper")
 

--- a/ocean_lib/assets/credentials.py
+++ b/ocean_lib/assets/credentials.py
@@ -1,10 +1,11 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from typing import Optional
 
 from enforce_typing import enforce_types
+
 from ocean_lib.common.agreements.consumable import ConsumableCodes, MalformedCredential
 
 

--- a/ocean_lib/assets/did.py
+++ b/ocean_lib/assets/did.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """DID Lib to do DID's and DDO's."""
@@ -8,8 +8,9 @@ from typing import Dict, Union
 
 from enforce_typing import enforce_types
 from eth_utils import remove_0x_prefix
-from ocean_lib.utils.utilities import checksum
 from web3 import Web3
+
+from ocean_lib.utils.utilities import checksum
 
 OCEAN_PREFIX = "did:op:"
 

--- a/ocean_lib/assets/test/__init__.py
+++ b/ocean_lib/assets/test/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/assets/test/test_asset.py
+++ b/ocean_lib/assets/test/test_asset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from ocean_lib.assets.asset import V3Asset

--- a/ocean_lib/assets/test/test_asset_downloader.py
+++ b/ocean_lib/assets/test/test_asset_downloader.py
@@ -1,10 +1,11 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import os
 
 import pytest
+
 from ocean_lib.assets.asset_downloader import download_asset_files
 from ocean_lib.common.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider

--- a/ocean_lib/assets/test/test_asset_resolver.py
+++ b/ocean_lib/assets/test/test_asset_resolver.py
@@ -1,10 +1,11 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json
 
 import pytest
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.assets.asset_resolver import resolve_asset
 from tests.resources.ddo_helpers import wait_for_ddo

--- a/ocean_lib/assets/test/test_did.py
+++ b/ocean_lib/assets/test/test_did.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """
@@ -11,6 +11,8 @@
 import secrets
 
 import pytest
+from web3 import Web3
+
 from ocean_lib.assets.did import (
     DID,
     OCEAN_PREFIX,
@@ -19,7 +21,6 @@ from ocean_lib.assets.did import (
     did_to_id_bytes,
     id_to_did,
 )
-from web3 import Web3
 
 TEST_SERVICE_TYPE = "ocean-meta-storage"
 TEST_SERVICE_URL = "http://localhost:8005"

--- a/ocean_lib/assets/test/test_utils.py
+++ b/ocean_lib/assets/test/test_utils.py
@@ -1,10 +1,11 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest.mock import patch
 
 import pytest
+
 from ocean_lib.assets.did import DID
 from ocean_lib.assets.trusted_algorithms import (
     add_publisher_trusted_algorithm,

--- a/ocean_lib/assets/trusted_algorithms.py
+++ b/ocean_lib/assets/trusted_algorithms.py
@@ -1,11 +1,12 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json
 from typing import Optional, Union
 
 from enforce_typing import enforce_types
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.assets.asset_resolver import resolve_asset
 from ocean_lib.common.agreements.service_types import ServiceTypes

--- a/ocean_lib/common/__init__.py
+++ b/ocean_lib/common/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/common/agreements/__init__.py
+++ b/ocean_lib/common/agreements/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/common/agreements/consumable.py
+++ b/ocean_lib/common/agreements/consumable.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from enforce_typing import enforce_types

--- a/ocean_lib/common/agreements/service_types.py
+++ b/ocean_lib/common/agreements/service_types.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """Agreements module."""

--- a/ocean_lib/common/aquarius/__init__.py
+++ b/ocean_lib/common/aquarius/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """Ocean Aquarius module."""

--- a/ocean_lib/common/aquarius/aquarius.py
+++ b/ocean_lib/common/aquarius/aquarius.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """
@@ -12,6 +12,7 @@ import logging
 from typing import Optional, Tuple, Union
 
 from enforce_typing import enforce_types
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.common.http_requests.requests_session import get_requests_session
 

--- a/ocean_lib/common/aquarius/aquarius_provider.py
+++ b/ocean_lib/common/aquarius/aquarius_provider.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from typing import Any

--- a/ocean_lib/common/aquarius/test/test_aquarius.py
+++ b/ocean_lib/common/aquarius/test/test_aquarius.py
@@ -1,8 +1,9 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import pytest
+
 from ocean_lib.common.aquarius.aquarius import Aquarius
 from tests.resources.ddo_helpers import wait_for_ddo
 from tests.resources.helper_functions import get_publisher_wallet

--- a/ocean_lib/common/http_requests/__init__.py
+++ b/ocean_lib/common/http_requests/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/common/http_requests/requests_session.py
+++ b/ocean_lib/common/http_requests/requests_session.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from enforce_typing import enforce_types

--- a/ocean_lib/config.py
+++ b/ocean_lib/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -9,8 +9,9 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
-import artifacts
 from enforce_typing import enforce_types
+
+import artifacts
 from ocean_lib.integer import Integer
 from ocean_lib.ocean.env_constants import ENV_CONFIG_FILE
 from ocean_lib.web3_internal.constants import GAS_LIMIT_DEFAULT

--- a/ocean_lib/data_provider/__init__.py
+++ b/ocean_lib/data_provider/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/data_provider/data_service_provider.py
+++ b/ocean_lib/data_provider/data_service_provider.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -10,7 +10,6 @@ import os
 import re
 from collections import namedtuple
 from decimal import Decimal
-from datetime import datetime
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -19,6 +18,10 @@ from unittest.mock import Mock
 import requests
 from enforce_typing import enforce_types
 from eth_account.messages import encode_defunct
+from requests.exceptions import InvalidURL
+from requests.models import PreparedRequest, Response
+from requests.sessions import Session
+
 from ocean_lib.common.agreements.service_types import ServiceTypes
 from ocean_lib.common.http_requests.requests_session import get_requests_session
 from ocean_lib.config import Config
@@ -28,9 +31,6 @@ from ocean_lib.ocean.env_constants import ENV_PROVIDER_API_VERSION
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.transactions import sign_hash
 from ocean_lib.web3_internal.wallet import Wallet
-from requests.exceptions import InvalidURL
-from requests.models import PreparedRequest, Response
-from requests.sessions import Session
 
 logger = logging.getLogger(__name__)
 

--- a/ocean_lib/data_provider/test/__init__.py
+++ b/ocean_lib/data_provider/test/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/data_provider/test/test_data_service_provider.py
+++ b/ocean_lib/data_provider/test/test_data_service_provider.py
@@ -1,17 +1,18 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
 from unittest.mock import Mock
 
 import pytest
+from requests.exceptions import InvalidURL
+from requests.models import Response
+
 from ocean_lib.common.http_requests.requests_session import get_requests_session
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider as DataSP
 from ocean_lib.data_provider.data_service_provider import urljoin
 from ocean_lib.exceptions import OceanEncryptAssetUrlsError
-from requests.exceptions import InvalidURL
-from requests.models import Response
 from tests.resources.helper_functions import get_publisher_ocean_instance
 from tests.resources.mocks.http_client_mock import (
     HttpClientEmptyMock,

--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -8,6 +8,7 @@ import logging
 import os
 
 from enforce_typing import enforce_types
+
 from ocean_lib.config import (
     DEFAULT_METADATA_CACHE_URI,
     DEFAULT_PROVIDER_URL,

--- a/ocean_lib/exceptions.py
+++ b/ocean_lib/exceptions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/ocean_lib/integer.py
+++ b/ocean_lib/integer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from enforce_typing.decorator import enforce_types

--- a/ocean_lib/models/__init__.py
+++ b/ocean_lib/models/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/models/algorithm_metadata.py
+++ b/ocean_lib/models/algorithm_metadata.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json

--- a/ocean_lib/models/balancer_constants.py
+++ b/ocean_lib/models/balancer_constants.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """
@@ -22,11 +22,11 @@ GASLIMIT_BFACTORY_NEWMPOOL = 5000000  # from ref above
 
 # from contracts/BConst.sol
 # FIXME: grab info directly from contract
-BCONST_BONE = 10 ** 18
+BCONST_BONE = 10**18
 BCONST_MIN_WEIGHT = BCONST_BONE  # Enforced in BPool.sol
 BCONST_MAX_WEIGHT = BCONST_BONE * 50  # ""
 BCONST_MAX_TOTAL_WEIGHT = BCONST_BONE * 50  # ""
-BCONST_MIN_BALANCE = int(BCONST_BONE / 10 ** 12)  # "". value is 10**6
+BCONST_MIN_BALANCE = int(BCONST_BONE / 10**12)  # "". value is 10**6
 
 INIT_WEIGHT_DT = to_wei(9)
 INIT_WEIGHT_OCEAN = to_wei(1)

--- a/ocean_lib/models/bfactory.py
+++ b/ocean_lib/models/bfactory.py
@@ -1,11 +1,12 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from enforce_typing import enforce_types
+from web3.logs import DISCARD
+
 from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.logs import DISCARD
 
 from . import balancer_constants
 

--- a/ocean_lib/models/bpool.py
+++ b/ocean_lib/models/bpool.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
@@ -8,12 +8,13 @@ from typing import Optional, Tuple
 
 from enforce_typing import enforce_types
 from eth_utils import remove_0x_prefix
+from web3.datastructures import AttributeDict
+from web3.main import Web3
+
 from ocean_lib.models import balancer_constants
 from ocean_lib.models.btoken import BToken
 from ocean_lib.web3_internal.currency import from_wei
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.datastructures import AttributeDict
-from web3.main import Web3
 
 logger = logging.getLogger(__name__)
 

--- a/ocean_lib/models/btoken.py
+++ b/ocean_lib/models/btoken.py
@@ -1,8 +1,9 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from enforce_typing import enforce_types
+
 from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.wallet import Wallet
 

--- a/ocean_lib/models/compute_input.py
+++ b/ocean_lib/models/compute_input.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/ocean_lib/models/data_token.py
+++ b/ocean_lib/models/data_token.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json
@@ -12,16 +12,17 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import requests
 from enforce_typing import enforce_types
 from eth_utils import remove_0x_prefix
-from ocean_lib.common.http_requests.requests_session import get_requests_session
-from ocean_lib.data_provider.data_service_provider import DataServiceProvider
-from ocean_lib.web3_internal.contract_base import ContractBase
-from ocean_lib.web3_internal.currency import from_wei, pretty_ether_and_wei, to_wei
-from ocean_lib.web3_internal.wallet import Wallet
 from web3 import Web3
 from web3.datastructures import AttributeDict
 from web3.exceptions import MismatchedABI
 from web3.logs import DISCARD
 from websockets import ConnectionClosed
+
+from ocean_lib.common.http_requests.requests_session import get_requests_session
+from ocean_lib.data_provider.data_service_provider import DataServiceProvider
+from ocean_lib.web3_internal.contract_base import ContractBase
+from ocean_lib.web3_internal.currency import from_wei, pretty_ether_and_wei, to_wei
+from ocean_lib.web3_internal.wallet import Wallet
 
 OrderValues = namedtuple(
     "OrderValues",

--- a/ocean_lib/models/dispenser.py
+++ b/ocean_lib/models/dispenser.py
@@ -1,8 +1,9 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from enforce_typing import enforce_types
+
 from ocean_lib.models.data_token import DataToken
 from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.wallet import Wallet

--- a/ocean_lib/models/dtfactory.py
+++ b/ocean_lib/models/dtfactory.py
@@ -1,14 +1,15 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
 
 from enforce_typing import enforce_types
-from ocean_lib.web3_internal.contract_base import ContractBase
-from ocean_lib.web3_internal.wallet import Wallet
 from web3.datastructures import AttributeDict
 from web3.logs import DISCARD
+
+from ocean_lib.web3_internal.contract_base import ContractBase
+from ocean_lib.web3_internal.wallet import Wallet
 
 
 class DTFactory(ContractBase):

--- a/ocean_lib/models/fixed_rate_exchange.py
+++ b/ocean_lib/models/fixed_rate_exchange.py
@@ -1,11 +1,12 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from collections import namedtuple
 from typing import Optional, Union
 
 from enforce_typing import enforce_types
+
 from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.wallet import Wallet

--- a/ocean_lib/models/metadata.py
+++ b/ocean_lib/models/metadata.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import time
@@ -7,9 +7,10 @@ from typing import Optional
 
 from enforce_typing import enforce_types
 from eth_utils import remove_0x_prefix
+from web3.datastructures import AttributeDict
+
 from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.datastructures import AttributeDict
 
 
 class MetadataContract(ContractBase):

--- a/ocean_lib/models/order.py
+++ b/ocean_lib/models/order.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/ocean_lib/models/test/conftest.py
+++ b/ocean_lib/models/test/conftest.py
@@ -1,11 +1,13 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import os
 
 import pytest
 from enforce_typing import enforce_types
+from web3.main import Web3
+
 from ocean_lib.example_config import ExampleConfig
 from ocean_lib.models import btoken
 from ocean_lib.models.bfactory import BFactory
@@ -22,10 +24,9 @@ from tests.resources.helper_functions import (
     get_ganache_wallet,
     get_web3,
 )
-from web3.main import Web3
 
 _NETWORK = "ganache"
-HUGEINT = 2 ** 255
+HUGEINT = 2**255
 BobInfo = None
 AliceInfo = None
 

--- a/ocean_lib/models/test/test_algorithm_metadata.py
+++ b/ocean_lib/models/test/test_algorithm_metadata.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json

--- a/ocean_lib/models/test/test_balancer_core_direct_flow.py
+++ b/ocean_lib/models/test/test_balancer_core_direct_flow.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from ocean_lib.models import balancer_constants
@@ -90,7 +90,7 @@ def test_complete_flow(
         maxAmountIn=to_wei(2),
         tokenOut_address=DT_address,
         tokenAmountOut=to_wei(1),
-        maxPrice=2 ** 255,
+        maxPrice=2**255,
         from_wallet=bob_wallet,
     )
 
@@ -121,7 +121,7 @@ def test_complete_flow(
         tokenAmountIn=to_wei(1),
         tokenOut_address=OCEAN_address,
         minAmountOut=to_wei("0.0001"),
-        maxPrice=2 ** 255,
+        maxPrice=2**255,
         from_wallet=alice_wallet,
     )
 

--- a/ocean_lib/models/test/test_balancer_simple_for_users_flow.py
+++ b/ocean_lib/models/test/test_balancer_simple_for_users_flow.py
@@ -1,8 +1,9 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import pytest
+
 from ocean_lib.web3_internal.currency import to_wei
 
 

--- a/ocean_lib/models/test/test_bfactory.py
+++ b/ocean_lib/models/test/test_bfactory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from ocean_lib.models.bfactory import BFactory

--- a/ocean_lib/models/test/test_bpool.py
+++ b/ocean_lib/models/test/test_bpool.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from decimal import Decimal
@@ -7,6 +7,8 @@ from typing import Union
 
 import pytest
 from enforce_typing import enforce_types
+from web3.main import Web3
+
 from ocean_lib.config import Config
 from ocean_lib.models.bfactory import BFactory
 from ocean_lib.models.bpool import BPool
@@ -15,9 +17,8 @@ from ocean_lib.models.test.conftest import alice_info
 from ocean_lib.ocean.util import get_bfactory_address
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.main import Web3
 
-HUGEINT = 2 ** 255
+HUGEINT = 2**255
 
 
 def test_notokens_basic(

--- a/ocean_lib/models/test/test_btoken.py
+++ b/ocean_lib/models/test/test_btoken.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from ocean_lib.models.btoken import BToken

--- a/ocean_lib/models/test/test_compute_input.py
+++ b/ocean_lib/models/test/test_compute_input.py
@@ -1,8 +1,9 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import pytest
+
 from ocean_lib.models.compute_input import ComputeInput
 
 

--- a/ocean_lib/models/test/test_datatoken.py
+++ b/ocean_lib/models/test/test_datatoken.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json
@@ -8,12 +8,13 @@ import time
 from unittest.mock import patch
 
 import pytest
+from web3.exceptions import TimeExhausted, TransactionNotFound
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.models.data_token import DataToken
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.currency import to_wei
 from tests.resources.ddo_helpers import get_resource_path
-from web3.exceptions import TimeExhausted, TransactionNotFound
 
 
 def test_ERC20(alice_ocean, alice_wallet, alice_address, bob_wallet, bob_address):

--- a/ocean_lib/models/test/test_ddo.py
+++ b/ocean_lib/models/test/test_ddo.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import lzma
@@ -7,6 +7,9 @@ import uuid
 
 import pytest
 from eth_utils import add_0x_prefix, remove_0x_prefix
+from web3.logs import DISCARD
+from web3.main import Web3
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.assets.credentials import AddressCredential
 from ocean_lib.common.agreements.consumable import ConsumableCodes, MalformedCredential
@@ -17,8 +20,6 @@ from ocean_lib.ocean.util import get_contracts_addresses
 from ocean_lib.utils.utilities import checksum
 from tests.resources.ddo_helpers import get_resource_path
 from tests.resources.helper_functions import get_consumer_wallet, get_publisher_wallet
-from web3.logs import DISCARD
-from web3.main import Web3
 
 
 def get_ddo_sample(datatoken_address):

--- a/ocean_lib/models/test/test_dispenser.py
+++ b/ocean_lib/models/test/test_dispenser.py
@@ -1,9 +1,10 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
 import pytest
+
 from ocean_lib.models.dispenser import DispenserContract
 
 

--- a/ocean_lib/models/test/test_dtfactory.py
+++ b/ocean_lib/models/test/test_dtfactory.py
@@ -1,14 +1,15 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest.mock import patch
 
 import pytest
+from web3.exceptions import TimeExhausted
+
 from ocean_lib.models.data_token import DataToken
 from ocean_lib.models.dtfactory import DTFactory
 from ocean_lib.web3_internal.currency import to_wei
-from web3.exceptions import TimeExhausted
 
 
 def test_data_token_creation(web3, alice_wallet, dtfactory_address):

--- a/ocean_lib/models/test/test_fixed_rate_exchange.py
+++ b/ocean_lib/models/test/test_fixed_rate_exchange.py
@@ -1,11 +1,12 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
+from web3.exceptions import ValidationError
+
 from ocean_lib.models.data_token import DataToken
 from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
 from ocean_lib.web3_internal.currency import from_wei, to_wei
-from web3.exceptions import ValidationError
 
 
 def run_failing_tx(contract, fn, *args):

--- a/ocean_lib/models/test/test_metadata.py
+++ b/ocean_lib/models/test/test_metadata.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/ocean_lib/models/test/test_order.py
+++ b/ocean_lib/models/test/test_order.py
@@ -1,10 +1,11 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import os
 
 from eth_utils import remove_0x_prefix
+
 from ocean_lib.common.agreements.service_types import ServiceTypes
 from ocean_lib.models.data_token import DataToken
 from ocean_lib.models.order import Order

--- a/ocean_lib/ocean/__init__.py
+++ b/ocean_lib/ocean/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/ocean/env_constants.py
+++ b/ocean_lib/ocean/env_constants.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """

--- a/ocean_lib/ocean/mint_fake_ocean.py
+++ b/ocean_lib/ocean/mint_fake_ocean.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -9,6 +9,8 @@ from typing import Dict, List, Optional, Type, Union
 
 from enforce_typing import enforce_types
 from eth_utils import remove_0x_prefix
+from web3.datastructures import AttributeDict
+
 from ocean_lib.config import Config
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.data_token import DataToken
@@ -29,7 +31,6 @@ from ocean_lib.ocean.util import (
 )
 from ocean_lib.web3_internal.utils import get_network_name
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.datastructures import AttributeDict
 
 logger = logging.getLogger("ocean")
 

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -14,6 +14,8 @@ from typing import Optional, Tuple, Type, Union
 from enforce_typing import enforce_types
 from eth_account.messages import encode_defunct
 from eth_utils import add_0x_prefix, remove_0x_prefix
+from web3.main import Web3
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.assets.asset_downloader import download_asset_files
 from ocean_lib.assets.asset_resolver import resolve_asset
@@ -43,7 +45,6 @@ from ocean_lib.web3_internal.currency import pretty_ether_and_wei
 from ocean_lib.web3_internal.transactions import sign_hash
 from ocean_lib.web3_internal.utils import get_network_name
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.main import Web3
 
 logger = logging.getLogger("ocean")
 

--- a/ocean_lib/ocean/ocean_compute.py
+++ b/ocean_lib/ocean/ocean_compute.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from enforce_typing import enforce_types
 from eth_account.messages import encode_defunct
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.assets.asset_resolver import resolve_asset
 from ocean_lib.assets.trusted_algorithms import create_publisher_trusted_algorithms

--- a/ocean_lib/ocean/ocean_exchange.py
+++ b/ocean_lib/ocean/ocean_exchange.py
@@ -1,12 +1,15 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from typing import Optional, Tuple, Union, List
+from typing import List, Optional, Tuple, Union
 
 from enforce_typing import enforce_types
 from web3.datastructures import AttributeDict
+from web3.exceptions import ValidationError
+from web3.logs import DISCARD
+from web3.main import Web3
 
 from ocean_lib.config import Config
 from ocean_lib.exceptions import InsufficientBalance, VerifyTxFailed
@@ -16,9 +19,6 @@ from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
 from ocean_lib.ocean.util import get_dtfactory_address
 from ocean_lib.web3_internal.currency import pretty_ether_and_wei
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.exceptions import ValidationError
-from web3.logs import DISCARD
-from web3.main import Web3
 
 
 class OceanExchange:

--- a/ocean_lib/ocean/ocean_pool.py
+++ b/ocean_lib/ocean/ocean_pool.py
@@ -1,11 +1,14 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
 from decimal import Decimal
 
 from enforce_typing import enforce_types
+from scipy.interpolate import interp1d
+from web3.main import Web3
+
 from ocean_lib.exceptions import InsufficientBalance, VerifyTxFailed
 from ocean_lib.models import balancer_constants
 from ocean_lib.models.bfactory import BFactory
@@ -15,8 +18,6 @@ from ocean_lib.models.data_token import DataToken
 from ocean_lib.models.dtfactory import DTFactory
 from ocean_lib.web3_internal.currency import from_wei, to_wei
 from ocean_lib.web3_internal.wallet import Wallet
-from scipy.interpolate import interp1d
-from web3.main import Web3
 
 logger = logging.getLogger(__name__)
 
@@ -321,7 +322,7 @@ class OceanPool:
             maxAmountIn=max_OCEAN_amount,  # ""
             tokenOut_address=dtoken_address,  # leaving pool
             tokenAmountOut=amount,  # ""
-            maxPrice=2 ** 255,  # here we limit by max_num_OCEAN, not price
+            maxPrice=2**255,  # here we limit by max_num_OCEAN, not price
             from_wallet=from_wallet,
         )
 
@@ -356,7 +357,7 @@ class OceanPool:
             tokenAmountIn=amount,  # ""
             tokenOut_address=self.ocean_address,  # leaving pool
             minAmountOut=min_OCEAN_amount,  # ""
-            maxPrice=2 ** 255,  # here we limit by max_num_OCEAN, not price
+            maxPrice=2**255,  # here we limit by max_num_OCEAN, not price
             from_wallet=from_wallet,
         )
 

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import time
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 from eth_utils import add_0x_prefix
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.assets.did import DID, did_to_id
 from ocean_lib.common.agreements.consumable import ConsumableCodes

--- a/ocean_lib/ocean/test/test_ocean_compute.py
+++ b/ocean_lib/ocean/test/test_ocean_compute.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from datetime import datetime

--- a/ocean_lib/ocean/test/test_ocean_exchange.py
+++ b/ocean_lib/ocean/test/test_ocean_exchange.py
@@ -1,12 +1,12 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
 import pytest
+
 from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
 from ocean_lib.ocean.ocean_exchange import OceanExchange
-
 from ocean_lib.ocean.util import get_contracts_addresses
 from ocean_lib.web3_internal.currency import pretty_ether_and_wei, to_wei
 from tests.resources.helper_functions import get_consumer_wallet, get_publisher_wallet

--- a/ocean_lib/ocean/test/test_ocean_pool.py
+++ b/ocean_lib/ocean/test/test_ocean_pool.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from ocean_lib.ocean.util import get_ocean_token_address

--- a/ocean_lib/ocean/test/test_util.py
+++ b/ocean_lib/ocean/test/test_util.py
@@ -1,9 +1,10 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
 import pytest
+
 from ocean_lib.ocean import util
 from ocean_lib.ocean.util import (
     get_bfactory_address,

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -1,10 +1,14 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from typing import Dict, Optional, Union
 
 from enforce_typing import enforce_types
+from web3 import WebsocketProvider
+from web3.main import Web3
+from web3.middleware import geth_poa_middleware
+
 from ocean_lib.models.bfactory import BFactory
 from ocean_lib.models.dtfactory import DTFactory
 from ocean_lib.web3_internal.contract_utils import (
@@ -12,9 +16,6 @@ from ocean_lib.web3_internal.contract_utils import (
 )
 from ocean_lib.web3_internal.utils import get_network_name
 from ocean_lib.web3_internal.web3_overrides.http_provider import CustomHTTPProvider
-from web3 import WebsocketProvider
-from web3.main import Web3
-from web3.middleware import geth_poa_middleware
 
 GANACHE_URL = "http://127.0.0.1:8545"
 

--- a/ocean_lib/services/service.py
+++ b/ocean_lib/services/service.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 from enforce_typing import enforce_types
+
 from ocean_lib.common.agreements.service_types import ServiceTypes, ServiceTypesIndices
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 

--- a/ocean_lib/services/test/test_service.py
+++ b/ocean_lib/services/test/test_service.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from ocean_lib.common.agreements.service_types import ServiceTypes

--- a/ocean_lib/test/__init__.py
+++ b/ocean_lib/test/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/test/test_config.py
+++ b/ocean_lib/test/test_config.py
@@ -1,10 +1,11 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import os.path
 
 import pytest
+
 from ocean_lib.config import (
     NAME_ADDRESS_FILE,
     NAME_AQUARIUS_URL,
@@ -13,9 +14,9 @@ from ocean_lib.config import (
     deprecated_environ_names,
     environ_names_and_sections,
 )
-from ocean_lib.ocean.util import GANACHE_URL
 from ocean_lib.ocean.env_constants import ENV_CONFIG_FILE
 from ocean_lib.ocean.ocean import Ocean
+from ocean_lib.ocean.util import GANACHE_URL
 from tests.resources.ddo_helpers import get_resource_path
 
 

--- a/ocean_lib/test/test_example_config.py
+++ b/ocean_lib/test/test_example_config.py
@@ -1,13 +1,13 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
 from ocean_lib.config import (
     DEFAULT_METADATA_CACHE_URI,
     DEFAULT_PROVIDER_URL,
-    SECTION_ETH_NETWORK,
     METADATA_CACHE_URI,
+    SECTION_ETH_NETWORK,
 )
 from ocean_lib.example_config import NETWORK_NAME, ExampleConfig
 

--- a/ocean_lib/test/test_exceptions.py
+++ b/ocean_lib/test/test_exceptions.py
@@ -1,11 +1,12 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import uuid
 from unittest.mock import patch
 
 import pytest
+
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.exceptions import AquariusError, ContractNotFound, InsufficientBalance
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS

--- a/ocean_lib/utils/__init__.py
+++ b/ocean_lib/utils/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/utils/test/test_utilities.py
+++ b/ocean_lib/utils/test/test_utilities.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from ocean_lib.utils import utilities

--- a/ocean_lib/utils/utilities.py
+++ b/ocean_lib/utils/utilities.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 """Utilities class"""

--- a/ocean_lib/web3_internal/__init__.py
+++ b/ocean_lib/web3_internal/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/web3_internal/constants.py
+++ b/ocean_lib/web3_internal/constants.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -16,10 +16,10 @@ MIN_GAS_PRICE = 1000000000
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
-MAX_UINT256 = 2 ** 256 - 1
+MAX_UINT256 = 2**256 - 1
 
-MAX_INT256 = 2 ** 255 - 1
-MIN_INT256 = 2 ** 255 * -1
+MAX_INT256 = 2**255 - 1
+MIN_INT256 = 2**255 * -1
 
 DEFAULT_NETWORK_NAME = "ganache"
 NETWORK_NAME_MAP = {

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -12,14 +12,6 @@ import requests
 from enforce_typing import enforce_types
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
-from ocean_lib.web3_internal.constants import ENV_GAS_PRICE
-from ocean_lib.web3_internal.contract_utils import (
-    get_contract_definition,
-    get_contracts_addresses,
-    load_contract,
-)
-from ocean_lib.web3_internal.wallet import Wallet
-from ocean_lib.web3_internal.web3_overrides.contract import CustomContractFunction
 from web3 import Web3
 from web3._utils.events import get_event_data
 from web3._utils.filters import construct_event_filter_params
@@ -28,6 +20,15 @@ from web3.contract import ContractEvent, ContractEvents
 from web3.datastructures import AttributeDict
 from web3.exceptions import MismatchedABI, ValidationError
 from websockets import ConnectionClosed
+
+from ocean_lib.web3_internal.constants import ENV_GAS_PRICE
+from ocean_lib.web3_internal.contract_utils import (
+    get_contract_definition,
+    get_contracts_addresses,
+    load_contract,
+)
+from ocean_lib.web3_internal.wallet import Wallet
+from ocean_lib.web3_internal.web3_overrides.contract import CustomContractFunction
 
 logger = logging.getLogger(__name__)
 

--- a/ocean_lib/web3_internal/contract_utils.py
+++ b/ocean_lib/web3_internal/contract_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import importlib
@@ -8,11 +8,12 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
-import artifacts  # noqa
 from enforce_typing import enforce_types
 from jsonsempai import magic  # noqa: F401
 from web3.contract import Contract
 from web3.main import Web3
+
+import artifacts  # noqa
 
 logger = logging.getLogger(__name__)
 

--- a/ocean_lib/web3_internal/currency.py
+++ b/ocean_lib/web3_internal/currency.py
@@ -1,13 +1,14 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from decimal import ROUND_DOWN, Context, Decimal, localcontext
 from typing import Union
 
 from enforce_typing import enforce_types
-from ocean_lib.web3_internal.constants import MAX_UINT256
 from web3.main import Web3
+
+from ocean_lib.web3_internal.constants import MAX_UINT256
 
 """decimal.Context tuned to accomadate MAX_WEI.
 

--- a/ocean_lib/web3_internal/event_filter.py
+++ b/ocean_lib/web3_internal/event_filter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging

--- a/ocean_lib/web3_internal/event_listener.py
+++ b/ocean_lib/web3_internal/event_listener.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -10,9 +10,10 @@ from threading import Thread
 from typing import Callable, Optional, Union
 
 from enforce_typing import enforce_types
+from web3.main import Web3
+
 from ocean_lib.web3_internal.contract_utils import load_contract
 from ocean_lib.web3_internal.event_filter import EventFilter
-from web3.main import Web3
 
 logger = logging.getLogger(__name__)
 

--- a/ocean_lib/web3_internal/test/__init__.py
+++ b/ocean_lib/web3_internal/test/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/web3_internal/test/conftest.py
+++ b/ocean_lib/web3_internal/test/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -10,6 +10,7 @@
 #  here we simply import that conftest's contents.
 
 import pytest
+
 from ocean_lib.example_config import ExampleConfig
 from ocean_lib.models.test.conftest import *  # noqa: F401 F403
 

--- a/ocean_lib/web3_internal/test/test_contract_base.py
+++ b/ocean_lib/web3_internal/test/test_contract_base.py
@@ -1,14 +1,15 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
 import pytest
 from enforce_typing import enforce_types
+from web3.contract import ContractCaller
+
 from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.wallet import Wallet
-from web3.contract import ContractCaller
 
 
 @enforce_types

--- a/ocean_lib/web3_internal/test/test_currency.py
+++ b/ocean_lib/web3_internal/test/test_currency.py
@@ -1,10 +1,11 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from decimal import Decimal, localcontext
 
 import pytest
+
 from ocean_lib.web3_internal.currency import (
     ETHEREUM_DECIMAL_CONTEXT,
     MAX_ETHER,

--- a/ocean_lib/web3_internal/test/test_event_filter.py
+++ b/ocean_lib/web3_internal/test/test_event_filter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/ocean_lib/web3_internal/test/test_transactions.py
+++ b/ocean_lib/web3_internal/test/test_transactions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from ocean_lib.web3_internal.currency import to_wei

--- a/ocean_lib/web3_internal/test/test_utils.py
+++ b/ocean_lib/web3_internal/test/test_utils.py
@@ -1,10 +1,11 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import os
 
 import pytest
+
 from ocean_lib.web3_internal.utils import (
     generate_multi_value_hash,
     get_chain_id,

--- a/ocean_lib/web3_internal/test/test_wallet.py
+++ b/ocean_lib/web3_internal/test/test_wallet.py
@@ -1,11 +1,12 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import os
 
 import pytest
 from eth_account.messages import encode_defunct
+
 from ocean_lib.web3_internal.wallet import Wallet
 
 

--- a/ocean_lib/web3_internal/transactions.py
+++ b/ocean_lib/web3_internal/transactions.py
@@ -1,18 +1,19 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from typing import Optional, Union
 
 from enforce_typing import enforce_types
 from eth_account.messages import SignableMessage
+from web3.datastructures import AttributeDict
+from web3.main import Web3
+
 from ocean_lib.web3_internal.constants import BLOCK_NUMBER_POLL_INTERVAL
 from ocean_lib.web3_internal.wallet import Wallet
 from ocean_lib.web3_internal.web3_overrides.utils import (
     wait_for_transaction_receipt_and_block_confirmations,
 )
-from web3.datastructures import AttributeDict
-from web3.main import Web3
 
 
 @enforce_types

--- a/ocean_lib/web3_internal/utils.py
+++ b/ocean_lib/web3_internal/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
@@ -7,16 +7,17 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Any, List, Optional
 
-import artifacts
 from enforce_typing import enforce_types
 from eth_account.account import Account
 from eth_account.messages import encode_defunct
 from eth_keys import keys
 from eth_utils import big_endian_to_int, decode_hex
 from hexbytes.main import HexBytes
+from web3.main import Web3
+
+import artifacts
 from ocean_lib.web3_internal.constants import DEFAULT_NETWORK_NAME, NETWORK_NAME_MAP
 from ocean_lib.web3_internal.web3_overrides.signature import SignatureFix
-from web3.main import Web3
 
 Signature = namedtuple("Signature", ("v", "r", "s"))
 

--- a/ocean_lib/web3_internal/wallet.py
+++ b/ocean_lib/web3_internal/wallet.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
@@ -10,13 +10,14 @@ from enforce_typing import enforce_types
 from eth_account.datastructures import SignedMessage
 from eth_account.messages import SignableMessage
 from hexbytes.main import HexBytes
+from web3.main import Web3
+
 from ocean_lib.integer import Integer
 from ocean_lib.web3_internal.constants import ENV_MAX_GAS_PRICE, MIN_GAS_PRICE
 from ocean_lib.web3_internal.utils import (
     private_key_to_address,
     private_key_to_public_key,
 )
-from web3.main import Web3
 
 logger = logging.getLogger(__name__)
 

--- a/ocean_lib/web3_internal/web3_overrides/__init__.py
+++ b/ocean_lib/web3_internal/web3_overrides/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/web3_internal/web3_overrides/contract.py
+++ b/ocean_lib/web3_internal/web3_overrides/contract.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
@@ -7,6 +7,9 @@ from typing import Any, Dict, Optional
 
 from enforce_typing import enforce_types
 from hexbytes.main import HexBytes
+from web3.contract import prepare_transaction
+from web3.main import Web3
+
 from ocean_lib.integer import Integer
 from ocean_lib.web3_internal.constants import BLOCK_NUMBER_POLL_INTERVAL
 from ocean_lib.web3_internal.utils import get_chain_id
@@ -14,8 +17,6 @@ from ocean_lib.web3_internal.wallet import Wallet
 from ocean_lib.web3_internal.web3_overrides.utils import (
     wait_for_transaction_receipt_and_block_confirmations,
 )
-from web3.contract import prepare_transaction
-from web3.main import Web3
 
 
 @enforce_types

--- a/ocean_lib/web3_internal/web3_overrides/http_provider.py
+++ b/ocean_lib/web3_internal/web3_overrides/http_provider.py
@@ -1,12 +1,13 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from typing import Any, Dict
 
 from enforce_typing import enforce_types
-from ocean_lib.web3_internal.web3_overrides.request import make_post_request
 from web3 import HTTPProvider
+
+from ocean_lib.web3_internal.web3_overrides.request import make_post_request
 
 
 class CustomHTTPProvider(HTTPProvider):

--- a/ocean_lib/web3_internal/web3_overrides/request.py
+++ b/ocean_lib/web3_internal/web3_overrides/request.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/ocean_lib/web3_internal/web3_overrides/signature.py
+++ b/ocean_lib/web3_internal/web3_overrides/signature.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import codecs

--- a/ocean_lib/web3_internal/web3_overrides/test/__init__.py
+++ b/ocean_lib/web3_internal/web3_overrides/test/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/ocean_lib/web3_internal/web3_overrides/test/test_contract.py
+++ b/ocean_lib/web3_internal/web3_overrides/test/test_contract.py
@@ -1,8 +1,9 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import pytest
+
 from ocean_lib.models.test.conftest import *  # noqa
 from ocean_lib.web3_internal.currency import to_wei
 from ocean_lib.web3_internal.test.test_contract_base import MyFactory

--- a/ocean_lib/web3_internal/web3_overrides/test/test_utils.py
+++ b/ocean_lib/web3_internal/web3_overrides/test/test_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 from threading import Event, Thread, current_thread

--- a/ocean_lib/web3_internal/web3_overrides/utils.py
+++ b/ocean_lib/web3_internal/web3_overrides/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import time

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ dev_requirements = [
     "watchdog",
     "flake8",
     "isort",
-    "black==21.4b0",
+    "black==22.3.0",
     "pre-commit",
     # for the following: maybe needed, maybe not
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -58,13 +58,12 @@ dev_requirements = [
     "pkginfo",
     "twine",
     "watchdog",
-    "flake8",
-    "isort",
-    "black==22.3.0",
+    "flake8==3.9.2",
+    "isort==5.10.1",
+    "black==22.1.0",
+    "licenseheaders==v0.8.8",
     "pre-commit",
-    # for the following: maybe needed, maybe not
     "pytest",
-    "licenseheaders",
     "pytest-env",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     url="https://github.com/oceanprotocol/ocean.py",
     # fmt: off
     # bumpversion.sh needs single-quotes
-    version='0.8.5',
+    version='0.8.6',
     # fmt: on
     zip_safe=False,
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/integration/test_compute_flow.py
+++ b/tests/integration/test_compute_flow.py
@@ -1,10 +1,12 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import time
 
 import pytest
+from web3.logs import DISCARD
+
 from ocean_lib.assets.trusted_algorithms import create_publisher_trusted_algorithms
 from ocean_lib.common.agreements.service_types import ServiceTypes
 from ocean_lib.models.compute_input import ComputeInput
@@ -27,7 +29,6 @@ from tests.resources.helper_functions import (
     get_publisher_ocean_instance,
     get_publisher_wallet,
 )
-from web3.logs import DISCARD
 
 
 class Setup:

--- a/tests/integration/test_market_flow.py
+++ b/tests/integration/test_market_flow.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -7,6 +7,7 @@ import os
 
 from ocean_lib.assets.asset import V3Asset
 from ocean_lib.common.agreements.service_types import ServiceTypes
+from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.services.service import Service
 from ocean_lib.web3_internal.currency import to_wei
 from tests.resources.ddo_helpers import get_metadata, get_registered_ddo
@@ -19,7 +20,6 @@ from tests.resources.helper_functions import (
     get_publisher_wallet,
     mint_tokens_and_wait,
 )
-from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 
 
 def test_market_flow():

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import json

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -11,6 +11,7 @@ import time
 import coloredlogs
 import yaml
 from enforce_typing import enforce_types
+
 from ocean_lib.example_config import ExampleConfig
 from ocean_lib.models.data_token import DataToken
 from ocean_lib.ocean.ocean import Ocean

--- a/tests/resources/mocks/__init__.py
+++ b/tests/resources/mocks/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/resources/mocks/data_provider_mock.py
+++ b/tests/resources/mocks/data_provider_mock.py
@@ -1,15 +1,16 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 
 import json
 import os
 
+from requests.models import PreparedRequest
+
 from ocean_lib.common.agreements.service_types import ServiceTypes
 from ocean_lib.common.http_requests.requests_session import get_requests_session
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider, logger
-from requests.models import PreparedRequest
 
 
 class DataProviderMock(DataServiceProvider):

--- a/tests/resources/mocks/http_client_mock.py
+++ b/tests/resources/mocks/http_client_mock.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
 import inspect


### PR DESCRIPTION
Fixes #821.

Changes proposed in this PR:

- Bump version from 0.8.5 to 0.8 6
- Fix black CI check by backporting #691
  - Update .pre-commit-config.yaml using `pre-commit autoupdate`
  - Bind `black`, `isort`, `flake8`, and `licenseheaders` versions in `setup.py` to match `.pre-commit-config.yaml`
  - Update licenseheaders template to 2022
  - Run pre-commit checks on all files using `pre-commit run --all-files`
- Fix tox CI check by using v3 barge