### PR TITLE
Delete c2d option from the datatokens flow and insert only in c2d README

### DIFF
--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -28,11 +28,11 @@ Use the `--with-c2d` option when running barge in order to include the Compute-t
 ./start_ocean.sh --with-c2d
 ```
 When running barge with c2d enabled, use the following bash script to wait until
-the `artifacts` directory and `address.json` file are successfully created and c2d is fully deployed:
+c2d is fully deployed:
 ```console
 for i in $(seq 1 50); do
     sleep 5
-    [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
+    [ -f "$HOME/.ocean/ocean-c2d/ready" ] && break
     done
 ```
 To get started with this guide, please refer to [data-nfts-and-datatokens-flow](data-nfts-and-datatokens-flow.md) and complete the following steps :

--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -23,7 +23,18 @@ Let's go through each step.
 ## 1. Setup
 
 ### First steps
-
+Use the `--with-c2d` option when running barge in order to include the Compute-to-Data backend
+```console
+./start_ocean.sh --with-c2d
+```
+When running barge with c2d enabled, use the following bash script to wait until
+the `artifacts` directory and `address.json` file are successfully created and c2d is fully deployed:
+```console
+for i in $(seq 1 50); do
+    sleep 5
+    [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
+    done
+```
 To get started with this guide, please refer to [data-nfts-and-datatokens-flow](data-nfts-and-datatokens-flow.md) and complete the following steps :
 - [x] Setup : Prerequisites
 - [x] Setup : Download barge and run services

--- a/READMEs/data-nfts-and-datatokens-flow.md
+++ b/READMEs/data-nfts-and-datatokens-flow.md
@@ -29,6 +29,15 @@ docker system prune -a --volumes
 # Run barge: start Ganache, Provider, Aquarius; deploy contracts; update ~/.ocean
 ./start_ocean.sh
 ```
+Wait for the `artifacts` directory and `address.json` file are successfully created
+by using the following snippet in your console:
+
+```console
+for i in $(seq 1 50); do
+    sleep 5
+    [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" ] && break
+    done
+```
 
 ## Install the library from v4 sources
 

--- a/READMEs/data-nfts-and-datatokens-flow.md
+++ b/READMEs/data-nfts-and-datatokens-flow.md
@@ -27,17 +27,7 @@ cd barge
 docker system prune -a --volumes
 
 # Run barge: start Ganache, Provider, Aquarius; deploy contracts; update ~/.ocean
-# The `--with-c2d` option tells barge to include the Compute-to-Data backend
-./start_ocean.sh --with-c2d
-```
-
-When running barge with c2d enabled, use the following bash script to wait until
-the `artifacts` directory and `address.json` file are successfully created and c2d is fully deployed:
-```console
-for i in $(seq 1 50); do
-    sleep 5
-    [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
-    done
+./start_ocean.sh
 ```
 
 ## Install the library from v4 sources


### PR DESCRIPTION
Fixes #862  .

Changes proposed in this PR:

- delete c2d option from the datatokens flow `Download barge and run services` section and insert only in c2d README