### PR TITLE
Integrate EIP 1559.

### DIFF
--- a/ocean_lib/test/test_example_config.py
+++ b/ocean_lib/test/test_example_config.py
@@ -11,6 +11,9 @@ from ocean_lib.config import (
     SECTION_ETH_NETWORK,
 )
 from ocean_lib.example_config import NETWORK_NAME, ExampleConfig, get_config_dict
+from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
+from ocean_lib.ocean.util import get_contracts_addresses
+from tests.resources.helper_functions import get_address_of_type
 
 
 @pytest.mark.unit
@@ -86,3 +89,14 @@ def test_noconfig(monkeypatch):
     monkeypatch.setenv("OCEAN_NETWORK_URL", "https://bad.network")
     with pytest.raises(ValueError, match="could not be fetched!"):
         get_config_dict(0)
+
+
+@pytest.mark.unit
+def test_get_address_of_type(monkeypatch):
+    monkeypatch.setenv("OCEAN_NETWORK_URL", "https://polygon-rpc.com")
+    config = ExampleConfig.get_config()
+
+    assert config.network_name == "polygon"
+    data_nft_factory = get_address_of_type(config, DataNFTFactoryContract.CONTRACT_NAME)
+    addresses = get_contracts_addresses(config.address_file, config.network_name)
+    assert addresses[DataNFTFactoryContract.CONTRACT_NAME] == data_nft_factory

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -5,7 +5,6 @@
 
 """All contracts inherit from `ContractBase` class."""
 import logging
-import os
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import requests
@@ -18,13 +17,12 @@ from web3._utils.filters import construct_event_filter_params
 from web3.contract import ContractEvent, ContractEvents
 from web3.datastructures import AttributeDict
 from web3.exceptions import MismatchedABI, ValidationError
-from ocean_lib.web3_internal.constants import ENV_GAS_PRICE
 from ocean_lib.web3_internal.contract_utils import (
     get_contract_definition,
     get_contracts_addresses,
     load_contract,
 )
-from ocean_lib.web3_internal.utils import get_max_fee_per_gas, get_gas_price
+from ocean_lib.web3_internal.utils import get_gas_price
 from ocean_lib.web3_internal.wallet import Wallet
 from ocean_lib.web3_internal.web3_overrides.contract import CustomContractFunction
 
@@ -194,16 +192,8 @@ class ContractBase(object):
             "chainId": self.web3.eth.chain_id,
         }
 
-        fee_tx = get_max_fee_per_gas(web3=self.web3, tx=_transact)
-        if fee_tx:
-            _transact.update(fee_tx)
-            _transact["gas"] = self.web3.eth.estimate_gas(_transact)
-        else:
-            _transact["gasPrice"] = get_gas_price(self.web3)
-
-            gas_price = os.environ.get(ENV_GAS_PRICE, None)
-            if gas_price:
-                _transact["gasPrice"] = int(gas_price)
+        gas_tx = get_gas_price(web3_object=self.web3, tx=_transact)
+        _transact.update(gas_tx)
 
         if transact:
             _transact.update(transact)
@@ -241,16 +231,15 @@ class ContractBase(object):
 
         _contract = web3.eth.contract(abi=_json["abi"], bytecode=_json["bytecode"])
         built_tx = _contract.constructor(*args).buildTransaction(
-            {
-                "from": ContractBase.to_checksum_address(deployer_wallet.address),
-                "gasPrice": get_gas_price(web3),
-            }
+            {"from": ContractBase.to_checksum_address(deployer_wallet.address)}
         )
+
         if "chainId" not in built_tx:
             built_tx["chainId"] = web3.eth.chain_id
 
-        if "gas" not in built_tx:
-            built_tx["gas"] = web3.eth.estimate_gas(built_tx)
+        if "gas" not in built_tx or "gasPrice" not in built_tx:
+            gas_tx = get_gas_price(web3_object=web3, tx=built_tx)
+            built_tx.update(gas_tx)
 
         raw_tx = deployer_wallet.sign_tx(built_tx)
         logging.debug(

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -233,6 +233,7 @@ class ContractBase(object):
             return None
         tx["maxPriorityFeePerGas"] = web3.eth.max_priority_fee
         tx["maxFeePerGas"] = web3.eth.max_priority_fee + 2 * history["baseFeePerGas"][0]
+
         return tx
 
     @enforce_types

--- a/ocean_lib/web3_internal/contract_base.py
+++ b/ocean_lib/web3_internal/contract_base.py
@@ -208,7 +208,9 @@ class ContractBase(object):
             history = self.web3.eth.fee_history(block_count=1, newest_block="latest")
 
             _transact["gas"] = self.web3.eth.estimate_gas(_transact)
-            fee_tx = ContractBase.get_max_fee_per_gas(tx=_transact, history=history)
+            fee_tx = ContractBase.get_max_fee_per_gas(
+                web3=self.web3, tx=_transact, history=history
+            )
             _transact.update(fee_tx)
         except ValueError as e:
             assert (
@@ -230,13 +232,11 @@ class ContractBase(object):
             from_wallet.transaction_timeout.value,
         ).hex()
 
-    @enforce_types
     @staticmethod
-    def get_max_fee_per_gas(self, tx: dict, history: dict) -> dict:
-        tx["maxPriorityFeePerGas"] = self.web3.eth.max_priority_fee
-        tx["maxFeePerGas"] = (
-            self.web3.eth.max_priority_fee + 2 * history["baseFeePerGas"][0]
-        )
+    @enforce_types
+    def get_max_fee_per_gas(web3: Web3, tx: dict, history: dict) -> dict:
+        tx["maxPriorityFeePerGas"] = web3.eth.max_priority_fee
+        tx["maxFeePerGas"] = web3.eth.max_priority_fee + 2 * history["baseFeePerGas"][0]
         return tx
 
     @enforce_types

--- a/ocean_lib/web3_internal/test/test_contract_base.py
+++ b/ocean_lib/web3_internal/test/test_contract_base.py
@@ -6,10 +6,7 @@
 import pytest
 from enforce_typing import enforce_types
 from web3.contract import ContractCaller
-from web3.gas_strategies.time_based import fast_gas_price_strategy
-from web3.middleware import geth_poa_middleware
 
-from ocean_lib.ocean.util import get_web3
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.wallet import Wallet
@@ -121,20 +118,3 @@ def test_gas_price(web3, alice_wallet, nft_factory_address, monkeypatch):
         ),
         alice_wallet,
     ), "The token could not be created by configuring the gas price env var."
-
-
-def test_gas_scaling_factor(web3, monkeypatch):
-    monkeypatch.setenv("GAS_SCALING_FACTOR", "5.0")
-    gas_price1 = web3.eth.gas_price
-    gas_price_with_scaling = ContractBase.get_gas_price(web3)
-    assert gas_price_with_scaling == gas_price1 * 5
-
-    web3.eth.set_gas_price_strategy(fast_gas_price_strategy)
-    gas_price2 = web3.eth.generate_gas_price()
-
-    monkeypatch.delenv("GAS_SCALING_FACTOR")
-    polygon_web3 = get_web3("https://polygon-rpc.com")
-    polygon_web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-    polygon_web3.eth.set_gas_price_strategy(fast_gas_price_strategy)
-    polygon_gas = polygon_web3.eth.generate_gas_price()
-    assert polygon_gas > gas_price2

--- a/ocean_lib/web3_internal/test/test_utils.py
+++ b/ocean_lib/web3_internal/test/test_utils.py
@@ -5,12 +5,17 @@
 import os
 
 import pytest
+from web3.gas_strategies.time_based import fast_gas_price_strategy
+from web3.middleware import geth_poa_middleware
 
+from ocean_lib.ocean.util import get_web3
+from ocean_lib.web3_internal.constants import ENV_GAS_PRICE, ENV_MAX_GAS_PRICE
 from ocean_lib.web3_internal.utils import (
     generate_multi_value_hash,
     get_chain_id,
     get_network_name,
     prepare_prefixed_hash,
+    get_gas_price,
 )
 
 
@@ -49,3 +54,30 @@ def test_prepare_fixed_hash():
     assert (
         prepare_prefixed_hash("0x0").hex() == expected
     ), "The address is not the expected one."
+
+
+@pytest.mark.unit
+def test_gas_scaling_factor(web3, monkeypatch):
+    monkeypatch.setenv("GAS_SCALING_FACTOR", "5.0")
+    gas_price1 = web3.eth.gas_price
+    gas_price_with_scaling = get_gas_price(web3, tx=dict())
+    assert gas_price_with_scaling["gasPrice"] == gas_price1 * 5
+
+    web3.eth.set_gas_price_strategy(fast_gas_price_strategy)
+    gas_price2 = web3.eth.generate_gas_price()
+
+    monkeypatch.delenv("GAS_SCALING_FACTOR")
+    polygon_web3 = get_web3("https://polygon-rpc.com")
+    polygon_web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    polygon_web3.eth.set_gas_price_strategy(fast_gas_price_strategy)
+    polygon_gas = polygon_web3.eth.generate_gas_price()
+    assert polygon_gas > gas_price2
+
+    monkeypatch.setenv(ENV_GAS_PRICE, "30000")
+    gas_price_with_scaling = get_gas_price(web3, tx=dict())
+    assert gas_price_with_scaling["gasPrice"] == 30000
+
+    monkeypatch.setenv(ENV_GAS_PRICE, "30000")
+    monkeypatch.setenv(ENV_MAX_GAS_PRICE, "80000")
+    gas_price_with_scaling = get_gas_price(web3, tx=dict())
+    assert gas_price_with_scaling["gasPrice"] == 30000

--- a/ocean_lib/web3_internal/wallet.py
+++ b/ocean_lib/web3_internal/wallet.py
@@ -126,21 +126,12 @@ class Wallet:
             from ocean_lib.web3_internal.contract_base import ContractBase
 
             if not gas_price:
-                try:
-                    history = self.web3.eth.fee_history(
-                        block_count=1, newest_block="latest"
-                    )
-                    tx["type"] = "0x2"
-                    fee_tx = ContractBase.get_max_fee_per_gas(
-                        web3=self.web3, tx=tx, history=history
-                    )
+                fee_tx = ContractBase.get_max_fee_per_gas(web3=self.web3, tx=tx)
+                if fee_tx:
                     tx.update(fee_tx)
                     tx["gas"] = GAS_LIMIT_DEFAULT
-                except ValueError as e:
-                    assert (
-                        e.args[0]["message"] == "Method eth_feeHistory not supported."
-                    ), f"Another error occurred: {e.args[0]}"
-
+                    tx["type"] = "0x2"
+                else:
                     gas_price = ContractBase.get_gas_price(self.web3)
                     max_gas_price = os.getenv(ENV_MAX_GAS_PRICE, None)
                     if gas_price and max_gas_price:

--- a/ocean_lib/web3_internal/wallet.py
+++ b/ocean_lib/web3_internal/wallet.py
@@ -17,6 +17,8 @@ from ocean_lib.web3_internal.constants import ENV_MAX_GAS_PRICE, GAS_LIMIT_DEFAU
 from ocean_lib.web3_internal.utils import (
     private_key_to_address,
     private_key_to_public_key,
+    get_max_fee_per_gas,
+    get_gas_price,
 )
 
 logger = logging.getLogger(__name__)
@@ -123,16 +125,15 @@ class Wallet:
             )
         else:
             nonce = Wallet._get_nonce(self.web3, account.address)
-            from ocean_lib.web3_internal.contract_base import ContractBase
 
             if not gas_price:
-                fee_tx = ContractBase.get_max_fee_per_gas(web3=self.web3, tx=tx)
+                fee_tx = get_max_fee_per_gas(web3=self.web3, tx=tx)
                 if fee_tx:
                     tx.update(fee_tx)
                     tx["gas"] = GAS_LIMIT_DEFAULT
                     tx["type"] = "0x2"
                 else:
-                    gas_price = ContractBase.get_gas_price(self.web3)
+                    gas_price = get_gas_price(self.web3)
                     max_gas_price = os.getenv(ENV_MAX_GAS_PRICE, None)
                     if gas_price and max_gas_price:
                         gas_price = min(gas_price, int(max_gas_price))

--- a/ocean_lib/web3_internal/wallet.py
+++ b/ocean_lib/web3_internal/wallet.py
@@ -131,7 +131,9 @@ class Wallet:
                         block_count=1, newest_block="latest"
                     )
                     tx["type"] = "0x2"
-                    fee_tx = ContractBase.get_max_fee_per_gas(tx=tx, history=history)
+                    fee_tx = ContractBase.get_max_fee_per_gas(
+                        web3=self.web3, tx=tx, history=history
+                    )
                     tx.update(fee_tx)
                     tx["gas"] = GAS_LIMIT_DEFAULT
                 except ValueError as e:

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -48,7 +48,7 @@ def get_example_config():
 def get_address_of_type(
     config: Config, address_type: str, key: Optional[str] = None
 ) -> str:
-    addresses = get_contracts_addresses(config.address_file, _NETWORK)
+    addresses = get_contracts_addresses(config.address_file, config.network_name)
     if address_type not in addresses.keys():
         raise KeyError(f"{address_type} address is not set in the config file")
     address = (


### PR DESCRIPTION
Fixes #888  .

Changes proposed in this PR:

- modified transactions in order to accept `maxPriorityFeePerGas` & `maxFeePerGas` instead of `gasPrice` for chains that support EIP 1559.
- updated helper functions to accept different networks, not only `ganache`
- tested the modifications with rinkeby & ganache.