### PR TITLE
Fix #906 - get_free_c2d_environment() fails in C2D README

### DIFF
--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -9,6 +9,7 @@ This quickstart describes a C2D flow.
 
 Here are the steps:
 
+
 1. Setup
 2. Alice publishes data asset
 3. Alice publishes algorithm


### PR DESCRIPTION
Fixes oceanprotocol/barge#315.

Note: this PR does not fix oceanprotocol/barge#315 yet. It's here so that we can use the GUI of the PR, and auto-trigger the CI.