### PR TITLE
Fix drained wallets issue in setup_all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     - id: isort
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/conftest.py
+++ b/conftest.py
@@ -64,12 +64,12 @@ def setup_all(request, config, web3, ocean_token):
 
     amt_distribute = to_wei("1000")
 
-    for w in (get_publisher_wallet(), get_consumer_wallet()):
+    for w in (get_publisher_wallet(), get_consumer_wallet(), get_ganache_wallet()):
         if get_ether_balance(web3, w.address) < to_wei("2"):
             send_ether(wallet, w.address, to_wei("4"))
 
         if ocean_token.balanceOf(w.address) < to_wei("100"):
-            ocean_token.transfer(w.address, amt_distribute, from_wallet=wallet)
+            ocean_token.mint(w.address, amt_distribute, from_wallet=wallet)
 
 
 @pytest.fixture

--- a/ocean_lib/ocean/mint_fake_ocean.py
+++ b/ocean_lib/ocean/mint_fake_ocean.py
@@ -49,7 +49,7 @@ def mint_fake_OCEAN(config: Config) -> None:
         )
 
         if OCEAN_token.balanceOf(w.address) < amt_distribute:
-            OCEAN_token.transfer(w.address, amt_distribute, from_wallet=deployer_wallet)
+            OCEAN_token.mint(w.address, amt_distribute, from_wallet=deployer_wallet)
 
         if get_ether_balance(web3, w.address) < to_wei("2"):
             send_ether(deployer_wallet, w.address, to_wei("4"))

--- a/tests/flows/test_reuse_order_fees.py
+++ b/tests/flows/test_reuse_order_fees.py
@@ -102,6 +102,13 @@ def test_reuse_order_fees(
     # Grant datatoken infinite approval to spend consumer's base tokens
     bt.approve(dt.address, MAX_WEI, consumer_wallet)
 
+    if base_token_name == "Ocean" and provider_fee_in_unit == "700":
+        bt.mint(
+            consumer_wallet.address,
+            parse_units("2000", bt.decimals()),
+            factory_deployer_wallet,
+        )
+
     # Start order: pay order fees and provider fees
     start_order_tx_id = dt.start_order(
         consumer=consumer_wallet.address,

--- a/tests/flows/test_start_order_fees.py
+++ b/tests/flows/test_start_order_fees.py
@@ -109,6 +109,13 @@ def test_start_order_fees(
 
     opc_collector_address = get_opc_collector_address_from_datatoken(dt)
 
+    if base_token_name == "Ocean" and publish_market_order_fee_in_unit == "500":
+        bt.mint(
+            consumer_wallet.address,
+            parse_units("2000", bt.decimals()),
+            factory_deployer_wallet,
+        )
+
     # Get balances
     publisher_bt_balance_before = bt.balanceOf(publisher_wallet.address)
     publisher_dt_balance_before = dt.balanceOf(publisher_wallet.address)

--- a/tests/integration/test_compute_flow.py
+++ b/tests/integration/test_compute_flow.py
@@ -379,9 +379,7 @@ def test_compute_raw_algo(
         algorithm_meta=raw_algorithm,
     )
 
-    with pytest.raises(
-        DataProviderException, match="cannot run raw algorithm on this did"
-    ):
+    with pytest.raises(DataProviderException, match="no_raw_algo_allowed"):
         run_compute_test(
             ocean_instance=publisher_ocean_instance,
             publisher_wallet=publisher_wallet,
@@ -473,7 +471,7 @@ def test_compute_trusted_algorithm(
     # Expect to fail when non-trusted algorithm is used
     with pytest.raises(
         DataProviderException,
-        match=f"this algorithm did {algorithm_with_different_publisher.did} is not trusted",
+        match="not_trusted_algo",
     ):
         run_compute_test(
             ocean_instance=publisher_ocean_instance,
@@ -526,7 +524,7 @@ def test_compute_update_trusted_algorithm(
     # Expect to fail when non-trusted algorithm is used
     with pytest.raises(
         DataProviderException,
-        match=f"this algorithm did {algorithm_with_different_publisher.did} is not trusted",
+        match="not_trusted_algo",
     ):
         run_compute_test(
             ocean_instance=publisher_ocean_instance,
@@ -561,9 +559,7 @@ def test_compute_trusted_publisher(
     )
 
     # Expect to fail when algorithm with non-trusted publisher is used
-    with pytest.raises(
-        DataProviderException, match="this algorithm is not from a trusted publisher"
-    ):
+    with pytest.raises(DataProviderException, match="not_trusted_algo_publisher"):
         run_compute_test(
             ocean_instance=publisher_ocean_instance,
             publisher_wallet=publisher_wallet,

--- a/tests/resources/mocks/http_client_mock.py
+++ b/tests/resources/mocks/http_client_mock.py
@@ -25,6 +25,7 @@ TEST_SERVICE_ENDPOINTS = {
     "computeEnvironments": ["GET", "/api/services/computeEnvironments"],
     "create_auth_token": ["GET", "/api/services/createAuthToken"],
     "delete_auth_token": ["DELETE", "/api/services/deleteAuthToken"],
+    "validateContainer": ["POST", "/api/services/validateContainer"],
 }
 
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- replace transfer with mint in setup_all.
- mint OCEAN tokens into factory deployer wallet as well.