### PR TITLE
Fix #915 - overview link not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Here are flows to try out, from simple to specific detailed variants.
 - [Understand config parameters](READMEs/parameters.md) - envvars vs files
 - [Learn about off-chain services](READMEs/services.md) - Ocean Provider for data services, Aquarius metadata store
 - [Learn about wallets](READMEs/wallets.md) - on generating, storing, and accessing private keys
-- [Get an overview of ocean.py](READMEs/overview.md) - key modules and functions
 
 ## 🦑 Development
 


### PR DESCRIPTION
Fixes #915.

overview.md was stale, and was therefore deprecated as part of https://github.com/oceanprotocol/ocean.py/commit/23c7339d758d4d11eee61e0f6b6fb735cc498bd0