### PR TITLE
Deprecate chain id from config dict function.

### DIFF
--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -10,6 +10,7 @@ from enforce_typing import enforce_types
 
 from ocean_lib.ocean.util import get_web3
 from ocean_lib.web3_internal.constants import GAS_LIMIT_DEFAULT
+from ocean_lib.web3_internal.utils import get_chain_id_from_url
 
 logging.basicConfig(level=logging.INFO)
 
@@ -83,8 +84,7 @@ CONFIG_NETWORK_HELPER = {
 
 @enforce_types
 def get_config_dict(network_url: str) -> dict:
-    web3 = get_web3(network_url)
-    chain_id = web3.eth.chain_id
+    chain_id = get_chain_id_from_url(network_url)
 
     config_helper = copy.deepcopy(config_defaults)
     config_helper.update(CONFIG_NETWORK_HELPER[chain_id])

--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -19,7 +19,6 @@ DEFAULT_PROVIDER_URL = "http://172.15.0.4:8030"
 
 config_defaults = {
     "RPC_URL": "http://127.0.0.1:8545",
-    "CHAIN_ID": 8996,
     "GAS_LIMIT": GAS_LIMIT_DEFAULT,
     "BLOCK_CONFIRMATIONS": 0,
     "TRANSACTION_TIMEOUT": 10 * 60,  # 10 minutes
@@ -89,7 +88,6 @@ def get_config_dict(network_url: str) -> dict:
 
     config_helper = copy.deepcopy(config_defaults)
     config_helper.update(CONFIG_NETWORK_HELPER[chain_id])
-    config_helper["CHAIN_ID"] = chain_id
     config_helper["RPC_URL"] = network_url
 
     if chain_id != 8996:

--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -83,8 +83,8 @@ CONFIG_NETWORK_HELPER = {
 
 @enforce_types
 def get_config_dict(network_url: str) -> dict:
-    w3 = get_web3(network_url)
-    chain_id = w3.eth.chain_id
+    web3 = get_web3(network_url)
+    chain_id = web3.eth.chain_id
 
     config_helper = copy.deepcopy(config_defaults)
     config_helper.update(CONFIG_NETWORK_HELPER[chain_id])

--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -83,9 +83,9 @@ CONFIG_NETWORK_HELPER = {
 
 
 @enforce_types
-def get_config_dict(chain_id: int, network_url: str) -> dict:
-    if chain_id not in CONFIG_NETWORK_HELPER:
-        raise ValueError("The chain id for the specific RPC could not be fetched!")
+def get_config_dict(network_url: str) -> dict:
+    w3 = get_web3(network_url)
+    chain_id = w3.eth.chain_id
 
     config_helper = copy.deepcopy(config_defaults)
     config_helper.update(CONFIG_NETWORK_HELPER[chain_id])
@@ -112,12 +112,8 @@ class ExampleConfig:
 
         if not network_url:
             network_url = "http://127.0.0.1:8545"
-            chain_id = 8996
-        else:
-            w3 = get_web3(network_url)
-            chain_id = w3.eth.chain_id
 
-        config_dict = get_config_dict(chain_id, network_url)
+        config_dict = get_config_dict(network_url)
         config_dict["RPC_URL"] = network_url
 
         return config_dict

--- a/ocean_lib/example_config.py
+++ b/ocean_lib/example_config.py
@@ -8,9 +8,8 @@ import logging
 
 from enforce_typing import enforce_types
 
-from ocean_lib.ocean.util import get_web3
+from ocean_lib.utils.utilities import get_chain_id_from_url
 from ocean_lib.web3_internal.constants import GAS_LIMIT_DEFAULT
-from ocean_lib.web3_internal.utils import get_chain_id_from_url
 
 logging.basicConfig(level=logging.INFO)
 

--- a/ocean_lib/test/test_example_config.py
+++ b/ocean_lib/test/test_example_config.py
@@ -9,7 +9,6 @@ from ocean_lib.example_config import (
     DEFAULT_PROVIDER_URL,
     METADATA_CACHE_URI,
     ExampleConfig,
-    get_config_dict,
 )
 from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
 from ocean_lib.ocean.util import get_contracts_addresses
@@ -22,7 +21,6 @@ def test_ganache_example_config():
 
     config = ExampleConfig.get_config()
 
-    assert config["CHAIN_ID"] == 8996
     assert config["RPC_URL"] == "http://127.0.0.1:8545"
     assert config["METADATA_CACHE_URI"] == DEFAULT_METADATA_CACHE_URI
     assert config["PROVIDER_URL"] == DEFAULT_PROVIDER_URL
@@ -35,7 +33,6 @@ def test_polygon_example_config():
 
     config = ExampleConfig.get_config("https://polygon-rpc.com")
 
-    assert config["CHAIN_ID"] == 137
     assert config["RPC_URL"] == "https://polygon-rpc.com"
     assert config["METADATA_CACHE_URI"] == METADATA_CACHE_URI
     assert config["PROVIDER_URL"] == "https://v4.provider.polygon.oceanprotocol.com"
@@ -48,7 +45,6 @@ def test_bsc_example_config():
 
     config = ExampleConfig.get_config("https://bsc-dataseed.binance.org")
 
-    assert config["CHAIN_ID"] == 56
     assert config["RPC_URL"] == "https://bsc-dataseed.binance.org"
     assert config["METADATA_CACHE_URI"] == METADATA_CACHE_URI
     assert config["PROVIDER_URL"] == "https://v4.provider.bsc.oceanprotocol.com"
@@ -61,7 +57,6 @@ def test_moonbeam_alpha_example_config(monkeypatch):
 
     config = ExampleConfig.get_config("https://rpc.testnet.moonbeam.network")
 
-    assert config["CHAIN_ID"] == 1287
     assert config["RPC_URL"] == "https://rpc.testnet.moonbeam.network"
     assert config["METADATA_CACHE_URI"] == METADATA_CACHE_URI
     assert config["PROVIDER_URL"] == "https://v4.provider.moonbase.oceanprotocol.com"

--- a/ocean_lib/test/test_example_config.py
+++ b/ocean_lib/test/test_example_config.py
@@ -69,13 +69,6 @@ def test_moonbeam_alpha_example_config(monkeypatch):
 
 
 @pytest.mark.unit
-def test_noconfig(monkeypatch):
-    """Tests the config fails with wrong chain id."""
-    with pytest.raises(ValueError, match="could not be fetched!"):
-        get_config_dict(0, "")
-
-
-@pytest.mark.unit
 def test_get_address_of_type(monkeypatch):
     config = ExampleConfig.get_config("https://polygon-rpc.com")
 

--- a/ocean_lib/utils/test/test_utilities.py
+++ b/ocean_lib/utils/test/test_utilities.py
@@ -5,6 +5,7 @@
 import pytest
 
 from ocean_lib.utils import utilities
+from ocean_lib.utils.utilities import get_chain_id_from_url
 
 
 @pytest.mark.unit
@@ -14,3 +15,10 @@ def test_convert():
     text_bytes = utilities.convert_to_bytes(input_text)
     print("output %s" % utilities.convert_to_string(text_bytes))
     assert input_text == utilities.convert_to_text(text_bytes)
+
+
+@pytest.mark.unit
+def test_chain_id_from_url(config):
+    chain_id = get_chain_id_from_url(config["RPC_URL"])
+    assert isinstance(chain_id, int)
+    assert chain_id == 8996

--- a/ocean_lib/utils/utilities.py
+++ b/ocean_lib/utils/utilities.py
@@ -12,6 +12,8 @@ from eth_typing import HexStr
 from eth_typing.encoding import Primitives
 from web3.main import Web3
 
+from tests.resources.helper_functions import get_web3
+
 
 @enforce_types
 def to_lpad_32byte(val: Primitives) -> bytes:
@@ -87,3 +89,11 @@ def create_checksum(text: str) -> str:
     :return: str
     """
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+@enforce_types
+def get_chain_id_from_url(network_url: str) -> int:
+    web3 = get_web3(network_url)
+    chain_id = web3.eth.chain_id
+
+    return chain_id

--- a/ocean_lib/web3_internal/contract_utils.py
+++ b/ocean_lib/web3_internal/contract_utils.py
@@ -17,7 +17,7 @@ from web3.main import Web3
 
 import artifacts  # noqa
 
-from ocean_lib.ocean.util import get_web3
+from tests.resources.helper_functions import get_web3
 
 logger = logging.getLogger(__name__)
 

--- a/ocean_lib/web3_internal/contract_utils.py
+++ b/ocean_lib/web3_internal/contract_utils.py
@@ -17,6 +17,8 @@ from web3.main import Web3
 
 import artifacts  # noqa
 
+from ocean_lib.ocean.util import get_web3
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,7 +61,8 @@ def get_addresses_with_fallback(config):
 @enforce_types
 def get_contracts_addresses(config) -> Optional[Dict[str, str]]:
     """Get addresses for all contract names, per network and address_file given."""
-    chain_id = config["CHAIN_ID"]
+    web3 = get_web3(config["RPC_URL"])
+    chain_id = web3.eth.chain_id
     addresses = get_addresses_with_fallback(config)
 
     network_addresses = [

--- a/ocean_lib/web3_internal/contract_utils.py
+++ b/ocean_lib/web3_internal/contract_utils.py
@@ -17,7 +17,7 @@ from web3.main import Web3
 
 import artifacts  # noqa
 
-from ocean_lib.web3_internal.utils import get_chain_id_from_url
+from ocean_lib.utils.utilities import get_chain_id_from_url
 
 logger = logging.getLogger(__name__)
 

--- a/ocean_lib/web3_internal/contract_utils.py
+++ b/ocean_lib/web3_internal/contract_utils.py
@@ -17,6 +17,7 @@ from web3.main import Web3
 
 import artifacts  # noqa
 
+from ocean_lib.web3_internal.utils import get_chain_id_from_url
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +62,7 @@ def get_addresses_with_fallback(config):
 def get_contracts_addresses(config) -> Optional[Dict[str, str]]:
     """Get addresses for all contract names, per network and address_file given."""
 
-    from ocean_lib.ocean.util import get_web3
-
-    web3 = get_web3(config["RPC_URL"])
-    chain_id = web3.eth.chain_id
+    chain_id = get_chain_id_from_url(config["RPC_URL"])
     addresses = get_addresses_with_fallback(config)
 
     network_addresses = [

--- a/ocean_lib/web3_internal/contract_utils.py
+++ b/ocean_lib/web3_internal/contract_utils.py
@@ -17,7 +17,6 @@ from web3.main import Web3
 
 import artifacts  # noqa
 
-from tests.resources.helper_functions import get_web3
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +60,9 @@ def get_addresses_with_fallback(config):
 @enforce_types
 def get_contracts_addresses(config) -> Optional[Dict[str, str]]:
     """Get addresses for all contract names, per network and address_file given."""
+
+    from ocean_lib.ocean.util import get_web3
+
     web3 = get_web3(config["RPC_URL"])
     chain_id = web3.eth.chain_id
     addresses = get_addresses_with_fallback(config)

--- a/ocean_lib/web3_internal/test/test_utils.py
+++ b/ocean_lib/web3_internal/test/test_utils.py
@@ -14,6 +14,7 @@ from ocean_lib.web3_internal.utils import (
     get_chain_id,
     get_gas_price,
     prepare_prefixed_hash,
+    get_chain_id_from_url,
 )
 
 
@@ -65,3 +66,9 @@ def test_gas_scaling_factor(web3, monkeypatch):
     monkeypatch.setenv(ENV_MAX_GAS_PRICE, "80000")
     gas_price_with_scaling = get_gas_price(web3, tx=dict())
     assert gas_price_with_scaling["gasPrice"] == 30000
+
+
+def test_chain_id_from_url(config):
+    chain_id = get_chain_id_from_url(config["RPC_URL"])
+    assert isinstance(chain_id, int)
+    assert chain_id == 8996

--- a/ocean_lib/web3_internal/test/test_utils.py
+++ b/ocean_lib/web3_internal/test/test_utils.py
@@ -14,7 +14,6 @@ from ocean_lib.web3_internal.utils import (
     get_chain_id,
     get_gas_price,
     prepare_prefixed_hash,
-    get_chain_id_from_url,
 )
 
 
@@ -66,9 +65,3 @@ def test_gas_scaling_factor(web3, monkeypatch):
     monkeypatch.setenv(ENV_MAX_GAS_PRICE, "80000")
     gas_price_with_scaling = get_gas_price(web3, tx=dict())
     assert gas_price_with_scaling["gasPrice"] == 30000
-
-
-def test_chain_id_from_url(config):
-    chain_id = get_chain_id_from_url(config["RPC_URL"])
-    assert isinstance(chain_id, int)
-    assert chain_id == 8996

--- a/ocean_lib/web3_internal/utils.py
+++ b/ocean_lib/web3_internal/utils.py
@@ -149,10 +149,3 @@ def get_gas_price(web3_object: Web3, tx: dict) -> dict:
     tx["gas"] = GAS_LIMIT_DEFAULT
 
     return tx
-
-
-def get_chain_id_from_url(network_url: str) -> int:
-    web3 = get_web3(network_url)
-    chain_id = web3.eth.chain_id
-
-    return chain_id

--- a/ocean_lib/web3_internal/utils.py
+++ b/ocean_lib/web3_internal/utils.py
@@ -15,6 +15,7 @@ from eth_utils import decode_hex
 from hexbytes.main import HexBytes
 from web3.main import Web3
 
+from ocean_lib.ocean.util import get_web3
 from ocean_lib.web3_internal.constants import (
     ENV_GAS_PRICE,
     ENV_MAX_GAS_PRICE,
@@ -148,3 +149,10 @@ def get_gas_price(web3_object: Web3, tx: dict) -> dict:
     tx["gas"] = GAS_LIMIT_DEFAULT
 
     return tx
+
+
+def get_chain_id_from_url(network_url: str) -> int:
+    web3 = get_web3(network_url)
+    chain_id = web3.eth.chain_id
+
+    return chain_id

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -97,7 +97,8 @@ def get_provider_wallet() -> Wallet:
 
 
 def get_factory_deployer_wallet(config):
-    if config["CHAIN_ID"] == 8996:
+    web3 = get_web3(config["RPC_URL"])
+    if web3.eth.chain_id == 8996:
         return get_ganache_wallet()
 
     private_key = os.environ.get("FACTORY_DEPLOYER_PRIVATE_KEY")


### PR DESCRIPTION
Fixes #968  .

Changes proposed in this PR:

- removed chain_id parameter from config dict generation function
- removed checks for invalid chain_id because we have fallback to ganache network url.