### PR TITLE
Removed pass-through function for contracts' addresses retrieval

### DIFF
--- a/ocean_lib/ocean/test/test_util.py
+++ b/ocean_lib/ocean/test/test_util.py
@@ -35,7 +35,7 @@ def test_get_web3_connection_provider(monkeypatch):
 
 @pytest.mark.unit
 def test_get_ocean_token_address(config):
-    addresses = util.get_contracts_addresses(config)
+    addresses = util.get_contracts_addresses_web3(config)
     assert addresses
     assert isinstance(addresses, dict)
     assert "Ocean" in addresses
@@ -47,7 +47,7 @@ def test_get_ocean_token_address(config):
 
 @pytest.mark.unit
 def test_get_address_by_type(config):
-    addresses = util.get_contracts_addresses(config)
+    addresses = util.get_contracts_addresses_web3(config)
 
     address = get_address_of_type(config, "Ocean")
     assert Web3.isChecksumAddress(address), "It is not a checksum token address."

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -10,9 +10,7 @@ from web3.main import Web3
 from web3.middleware import geth_poa_middleware
 
 from ocean_lib.ocean.networkutil import chainIdToNetwork
-from ocean_lib.web3_internal.contract_utils import (
-    get_contracts_addresses as get_contracts_addresses_web3,
-)
+from ocean_lib.web3_internal.contract_utils import get_contracts_addresses_web3
 from ocean_lib.web3_internal.web3_overrides.http_provider import CustomHTTPProvider
 
 GANACHE_URL = "http://127.0.0.1:8545"
@@ -73,15 +71,11 @@ def get_web3_connection_provider(
         raise AssertionError(msg)
 
 
-def get_contracts_addresses(config) -> Dict[str, str]:
-    return get_contracts_addresses_web3(config)
-
-
 @enforce_types
 def get_address_of_type(
     config_dict: dict, address_type: str, key: Optional[str] = None
 ) -> str:
-    addresses = get_contracts_addresses(config_dict)
+    addresses = get_contracts_addresses_web3(config_dict)
     if address_type not in addresses.keys():
         raise KeyError(f"{address_type} address is not set in the config file")
     address = (
@@ -97,6 +91,6 @@ def get_ocean_token_address(config_dict: dict) -> str:
     """Returns the Ocean token address for given network or web3 instance
     Requires either network name or web3 instance.
     """
-    addresses = get_contracts_addresses(config_dict)
+    addresses = get_contracts_addresses_web3(config_dict)
 
     return Web3.toChecksumAddress(addresses.get("Ocean").lower()) if addresses else None

--- a/ocean_lib/test/test_example_config.py
+++ b/ocean_lib/test/test_example_config.py
@@ -12,7 +12,7 @@ from ocean_lib.example_config import (
     get_config_dict,
 )
 from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
-from ocean_lib.ocean.util import get_contracts_addresses
+from ocean_lib.ocean.util import get_contracts_addresses_web3
 from tests.resources.helper_functions import get_address_of_type
 
 
@@ -80,5 +80,5 @@ def test_get_address_of_type(monkeypatch):
     config = ExampleConfig.get_config("https://polygon-rpc.com")
 
     data_nft_factory = get_address_of_type(config, DataNFTFactoryContract.CONTRACT_NAME)
-    addresses = get_contracts_addresses(config)
+    addresses = get_contracts_addresses_web3(config)
     assert addresses[DataNFTFactoryContract.CONTRACT_NAME] == data_nft_factory

--- a/ocean_lib/web3_internal/contract_utils.py
+++ b/ocean_lib/web3_internal/contract_utils.py
@@ -57,7 +57,7 @@ def get_addresses_with_fallback(config):
 
 
 @enforce_types
-def get_contracts_addresses(config) -> Optional[Dict[str, str]]:
+def get_contracts_addresses_web3(config) -> Optional[Dict[str, str]]:
     """Get addresses for all contract names, per network and address_file given."""
     chain_id = config["CHAIN_ID"]
     addresses = get_addresses_with_fallback(config)

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -23,7 +23,7 @@ from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
 from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.ocean.ocean import Ocean
-from ocean_lib.ocean.util import get_contracts_addresses
+from ocean_lib.ocean.util import get_contracts_addresses_web3
 from ocean_lib.ocean.util import get_web3 as util_get_web3
 from ocean_lib.structures.file_objects import FilesTypeFactory
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
@@ -47,7 +47,7 @@ def get_example_config():
 def get_address_of_type(
     config_dict: dict, address_type: str, key: Optional[str] = None
 ) -> str:
-    addresses = get_contracts_addresses(config_dict)
+    addresses = get_contracts_addresses_web3(config_dict)
 
     if address_type not in addresses.keys():
         raise KeyError(f"{address_type} address is not set in the config file")


### PR DESCRIPTION
Fixes #970  .

Changes proposed in this PR:

- removed pass-through function
- renamed it into `get_contracts_addresses_web3`