### PR TITLE
Fix #981 - Error when running the predict README

### DIFF
--- a/ocean_lib/http_requests/requests_session.py
+++ b/ocean_lib/http_requests/requests_session.py
@@ -8,7 +8,7 @@ from requests.sessions import Session
 
 
 @enforce_types
-
+DEFAULT_TIMEOUT = 30
 
 class TimeoutHTTPAdapter(HTTPAdapter):
     def __init__(self, *args, **kwargs):
@@ -35,13 +35,13 @@ def get_requests_session() -> Session:
     session.mount(
         "http://",
         TimeoutHTTPAdapter(
-            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1, timeout=30
+            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1
         ),
     )
     session.mount(
         "https://",
         TimeoutHTTPAdapter(
-            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1, timeout=30
+            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1
         ),
     )
     return session

--- a/ocean_lib/http_requests/requests_session.py
+++ b/ocean_lib/http_requests/requests_session.py
@@ -19,9 +19,10 @@ class TimeoutHTTPAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def send(self, request, **kwargs):
-        timeout = kwargs.get("timeout")
-        if timeout is None:
-            kwargs["timeout"] = self.timeout
+        #timeout = kwargs.get("timeout")
+        #if timeout is None:
+        kwargs["timeout"] = self.timeout
+        print(kwargs)
         return super().send(request, **kwargs)
 
 
@@ -35,13 +36,13 @@ def get_requests_session() -> Session:
     session.mount(
         "http://",
         TimeoutHTTPAdapter(
-            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1
+            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1, timeout = 30
         ),
     )
     session.mount(
         "https://",
         TimeoutHTTPAdapter(
-            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1
+            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1, timeout = 30
         ),
     )
     return session

--- a/ocean_lib/http_requests/requests_session.py
+++ b/ocean_lib/http_requests/requests_session.py
@@ -8,11 +8,11 @@ from requests.sessions import Session
 
 
 @enforce_types
-DEFAULT_TIMEOUT = 30
+
 
 class TimeoutHTTPAdapter(HTTPAdapter):
     def __init__(self, *args, **kwargs):
-        self.timeout = DEFAULT_TIMEOUT
+        self.timeout = 30
         if "timeout" in kwargs:
             self.timeout = kwargs["timeout"]
             del kwargs["timeout"]

--- a/ocean_lib/http_requests/requests_session.py
+++ b/ocean_lib/http_requests/requests_session.py
@@ -8,8 +8,6 @@ from requests.sessions import Session
 
 
 @enforce_types
-
-
 class TimeoutHTTPAdapter(HTTPAdapter):
     def __init__(self, *args, **kwargs):
         self.timeout = 30
@@ -19,8 +17,8 @@ class TimeoutHTTPAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def send(self, request, **kwargs):
-        #timeout = kwargs.get("timeout")
-        #if timeout is None:
+        # timeout = kwargs.get("timeout")
+        # if timeout is None:
         kwargs["timeout"] = self.timeout
         print(kwargs)
         return super().send(request, **kwargs)
@@ -36,13 +34,21 @@ def get_requests_session() -> Session:
     session.mount(
         "http://",
         TimeoutHTTPAdapter(
-            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1, timeout = 30
+            pool_connections=25,
+            pool_maxsize=25,
+            pool_block=True,
+            max_retries=1,
+            timeout=30,
         ),
     )
     session.mount(
         "https://",
         TimeoutHTTPAdapter(
-            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1, timeout = 30
+            pool_connections=25,
+            pool_maxsize=25,
+            pool_block=True,
+            max_retries=1,
+            timeout=30,
         ),
     )
     return session

--- a/ocean_lib/http_requests/requests_session.py
+++ b/ocean_lib/http_requests/requests_session.py
@@ -8,6 +8,23 @@ from requests.sessions import Session
 
 
 @enforce_types
+
+
+class TimeoutHTTPAdapter(HTTPAdapter):
+    def __init__(self, *args, **kwargs):
+        self.timeout = DEFAULT_TIMEOUT
+        if "timeout" in kwargs:
+            self.timeout = kwargs["timeout"]
+            del kwargs["timeout"]
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        timeout = kwargs.get("timeout")
+        if timeout is None:
+            kwargs["timeout"] = self.timeout
+        return super().send(request, **kwargs)
+
+
 def get_requests_session() -> Session:
     """
     Set connection pool maxsize and block value to avoid `connection pool full` warnings.
@@ -17,14 +34,14 @@ def get_requests_session() -> Session:
     session = Session()
     session.mount(
         "http://",
-        HTTPAdapter(
-            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1
+        TimeoutHTTPAdapter(
+            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1, timeout=30
         ),
     )
     session.mount(
         "https://",
-        HTTPAdapter(
-            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1
+        TimeoutHTTPAdapter(
+            pool_connections=25, pool_maxsize=25, pool_block=True, max_retries=1, timeout=30
         ),
     )
     return session

--- a/ocean_lib/http_requests/requests_session.py
+++ b/ocean_lib/http_requests/requests_session.py
@@ -20,7 +20,6 @@ class TimeoutHTTPAdapter(HTTPAdapter):
         # timeout = kwargs.get("timeout")
         # if timeout is None:
         kwargs["timeout"] = self.timeout
-        print(kwargs)
         return super().send(request, **kwargs)
 
 

--- a/tests/integration/ganache/test_issue981_consume.py
+++ b/tests/integration/ganache/test_issue981_consume.py
@@ -1,0 +1,68 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import csv
+import glob
+import os
+import shutil
+
+import pytest
+from web3 import Web3
+
+from ocean_lib.models.datatoken import Datatoken
+from ocean_lib.ocean.ocean import Ocean
+from ocean_lib.web3_internal.wallet import Wallet
+
+
+@pytest.mark.integration
+def test1(
+    web3: Web3,
+    config: dict,
+    publisher_wallet: Wallet,
+    consumer_wallet: Wallet,
+    tmp_path,
+):
+    ocean = Ocean(config)
+    
+    url = "https://cexa.oceanprotocol.io/ohlc?exchange=binance&pair=ETH/USDT"
+    name = "CEXA ETH-USDT"
+    asset = ocean.assets.create_url_asset(name, url, publisher_wallet)
+    datatoken_address = asset.datatokens[0]["address"]
+    datatoken = Datatoken(ocean.web3, datatoken_address)
+
+    to_address = consumer_wallet.address
+    datatoken.mint(to_address, ocean.to_wei(10), publisher_wallet)
+    
+    order_tx_id = ocean.assets.pay_for_access_service(asset, consumer_wallet)
+
+    #Commented out, we shouldn't need this
+    # Initialize service
+    #response = data_provider.initialize(
+    #    did=asset.did, service=service, consumer_address=consumer_wallet.address
+    #)
+
+    # consumer now has access. He downloads the asset.
+    # If the connection breaks, consumer can request again by showing order_tx_id.
+    file_path = ocean.assets.download_asset(
+        asset=asset, consumer_wallet=consumer_wallet, destination=str(tmp_path), order_tx_id=order_tx_id)
+    file_name = glob.glob(file_path + "/*")[0]
+    print(f"file_path: '{file_path}'")  # e.g. datafile.0xAf07...48,0
+    print(f"file_name: '{file_name}'")  # e.g. datafile.0xAf07...48,0/klines?symbol=ETHUSDT?int..22300
+    
+    #verify that file exists
+    assert os.path.exists(file_name), "couldn't find file"
+
+    #load from file into memory
+    with open(file_name, "r") as file:
+        #data_str is a string holding a list of lists '[[1663113600000,"1574.40000000", ..]]'
+        data_str = file.read().rstrip().replace('"', '')
+    data = eval(data_str)
+
+    #data is a list of lists
+    # -Outer list has one 6 entries; one entry per day.
+    # -Inner lists have 12 entries each: Kline open time, Open price, High price, Low price, close Price,  ..
+    # -It looks like: [[1662998400000,1706.38,1717.87,1693,1713.56],[1663002000000,1713.56,1729.84,1703.21,1729.08],[1663005600000,1729.08,1733.76,1718.09,1728.83],...
+
+    #Example: get close prices. These can serve as an approximation to spot price
+    close_prices = [float(data_at_day[4]) for data_at_day in data]


### PR DESCRIPTION
Fixes #981

For some reason, the default http adapter had a default of 2.5 or 3 s. That's too low. So a new adapter was added - TimeoutHTTPAdapter. With timeout hardcoded to 30 s.

Includes new integration test.