### PR TITLE
Fix #996 - Streamline download in predict-eth.md

### DIFF
--- a/READMEs/consume-flow.md
+++ b/READMEs/consume-flow.md
@@ -27,13 +27,6 @@ From [data-nfts-and-datatokens-flow](data-nfts-and-datatokens-flow.md), do:
 - [x] Setup : Set envvars
 - [x] Setup : Setup in Python
 
-"Setup in Python" set up Alice's wallet. Let's set up Bob's wallet too. In the same Python console:
-```python
-bob_private_key = os.getenv('TEST_PRIVATE_KEY2')
-bob_wallet = Wallet(ocean.web3, bob_private_key, config["BLOCK_CONFIRMATIONS"], config["TRANSACTION_TIMEOUT"])
-print(f"bob_wallet.address = '{bob_wallet.address}'")
-```
-
 ## 2. Alice publishes dataset
 
 Now, you're Alice. From [publish-flow](publish-flow.md), do:
@@ -56,6 +49,7 @@ datatoken.mint(to_address, amt_tokens, alice_wallet)
 
 In the same Python console:
 ```python
+# Bob sends a datatoken to the service to get access; then downloads
 file_name = ocean.assets.download_file(asset.did, bob_wallet)
 ```
 
@@ -71,7 +65,13 @@ Congrats to Bob for buying and consuming a data asset!
 
 ## Appendix. Further Flexibility
 
-We can un-bundle step 4's `download_file()` into two pieces, as follows.
+Step 4's `download_file()` did three things:
+
+- Checked if Bob has access tokens. Bob did, so nothing else needed
+- Sent a datatoken to the service to get access
+- Downloaded the file
+
+Here are the last two steps, un-bundled.
 
 In the same Python console:
 ```python

--- a/READMEs/consume-flow.md
+++ b/READMEs/consume-flow.md
@@ -37,7 +37,7 @@ print(f"bob_wallet.address = '{bob_wallet.address}'")
 ## 2. Alice publishes dataset
 
 Now, you're Alice. From [publish-flow](publish-flow.md), do:
-- [x] 2. Publish Dataset. (This includes publishing a data NFT & datatoken)
+- [x] 2. Publish Dataset
 
 ## 3. Alice gives Bob access
 
@@ -45,34 +45,18 @@ Bob wants to consume the dataset that Alice just published. The first step is fo
 
 This README uses (d) - minting. Specifically, Alice mints a datatoken into Bob's wallet. In the same Python console:
 ```python
-datatoken = ocean.get_datatoken(asset.datatokens[0]["address"])
-datatoken.mint(
-    account_address=bob_wallet.address,
-    value=ocean.to_wei("1"),
-    from_wallet=alice_wallet,
-)
+datatoken_address = asset.datatokens[0]["address"]
+datatoken = ocean.get_datatoken(datatoken_address)
+to_address = bob_wallet.address
+amt_tokens = ocean.to_wei(10) #just need 1, send more for spare
+datatoken.mint(to_address, amt_tokens, alice_wallet)
 ```
 
 ## 4. Bob downloads the dataset
 
 In the same Python console:
 ```python
-# Verify that Bob has ganache ETH
-assert ocean.web3.eth.get_balance(bob_wallet.address) > 0, "need ganache ETH"
-
-# Bob sends 1.0 datatokens to the service, to get access
-order_tx_id = ocean.assets.pay_for_access_service(asset, bob_wallet)
-print(f"order_tx_id = '{order_tx_id}'")
-
-# Bob now has access! He downloads the asset. 
-# If the connection breaks, Bob can request again by showing order_tx_id.
-file_path = ocean.assets.download_asset(
-    asset=asset,
-    consumer_wallet=bob_wallet,
-    destination='./',
-    order_tx_id=order_tx_id
-)
-print(f"file_path = '{file_path}'")  # e.g. datafile.0xAf07...
+file_name = ocean.assets.download_file(asset.did, bob_wallet)
 ```
 
 Bob can verify that the file is downloaded. In a new console:
@@ -84,21 +68,42 @@ ls branin.arff
 
 Congrats to Bob for buying and consuming a data asset!
 
-## Appendix: Further Flexibility
 
-`pay_for_access_service()` fills in good defaults of using the 0th service (if >1 services available) and zero fees. Here's how it looks if we filled them explicitly.
+## Appendix. Further Flexibility
 
-And `download_asset()` fills in a good default for `service` too, as well as for `index` and `userdata` (not shown).
+We can un-bundle step 4's `download_file()` into two pieces, as follows.
+
+In the same Python console:
+```python
+# Bob sends a datatoken to the service, to get access
+order_tx_id = ocean.assets.pay_for_access_service(asset, bob_wallet)
+print(f"order_tx_id = '{order_tx_id}'")
+
+# Bob downloads the file
+# If the connection breaks, Bob can request again by showing order_tx_id.
+file_path = ocean.assets.download_asset(
+    asset=asset,
+    consumer_wallet=bob_wallet,
+    destination='./',
+    order_tx_id=order_tx_id
+)
+```
+
+
+## Appendix: Further Flexibility Yet
+
+We can un-bundle even further:
+- `pay_for_access_service()` fills in good defaults of using the 0th service (if >1 services available) and zero fees. 
+- And `download_asset()` fills in a good default for `service` too, as well as for `index` and `userdata` (not shown).
+
+Here's how it looks, fully un-bundled.
 
 In the same python console:
 ```python
-# Let's get more datatokens to Bob first
-datatoken.mint(bob_wallet.address, ocean.to_wei("1"), alice_wallet)
-
 # Bob retrieves the reference to the service object
 service = asset.services[0]
 
-# Bob sends 1.0 datatokens to the service, to get access
+# Bob sends a datatoken to the service, to get access
 order_tx_id = ocean.assets.pay_for_access_service(
     asset,
     bob_wallet,
@@ -108,8 +113,7 @@ order_tx_id = ocean.assets.pay_for_access_service(
     consume_market_order_fee_amount=0,
 )
 
-# Bob now has access! He downloads the asset. 
-# If the connection breaks, Bob can request again by showing order_tx_id.
+# Bob now has access! He downloads the asset.
 file_path = ocean.assets.download_asset(
     asset=asset,
     consumer_wallet=bob_wallet,

--- a/READMEs/data-nfts-and-datatokens-flow.md
+++ b/READMEs/data-nfts-and-datatokens-flow.md
@@ -80,6 +80,11 @@ import os
 from ocean_lib.web3_internal.wallet import Wallet
 alice_private_key = os.getenv('TEST_PRIVATE_KEY1')
 alice_wallet = Wallet(ocean.web3, alice_private_key, config["BLOCK_CONFIRMATIONS"], config["TRANSACTION_TIMEOUT"])
+
+# Create Bob's wallet. While some flows just use Alice wallet, it's simpler to do all here.
+bob_private_key = os.getenv('TEST_PRIVATE_KEY2')
+bob_wallet = Wallet(ocean.web3, bob_private_key, config["BLOCK_CONFIRMATIONS"], config["TRANSACTION_TIMEOUT"])
+assert ocean.web3.eth.get_balance(bob_wallet.address) > 0, "Bob needs ganache ETH"
 ```
 
 ## 2. Publish Data NFT & Datatoken

--- a/READMEs/datatoken-enterprise.md
+++ b/READMEs/datatoken-enterprise.md
@@ -73,17 +73,6 @@ asset = ocean.assets.create(
 )
 access_service = asset.services[0]
 
-bob_private_key = os.getenv("TEST_PRIVATE_KEY2")
-bob_wallet = Wallet(
-    ocean.web3,
-    bob_private_key,
-    config["BLOCK_CONFIRMATIONS"],
-    config["TRANSACTION_TIMEOUT"],
-)
-
-# Verify that Bob has ganache ETH
-assert ocean.web3.eth.get_balance(bob_wallet.address) > 0, "need ganache ETH"
-
 # Create & activate dispenser
 dispenser = ocean.dispenser
 tx = datatoken_enterprise_token.create_dispenser(
@@ -181,17 +170,6 @@ asset = ocean.assets.create(
     deployed_datatokens=[datatoken_enterprise_token]
 )
 access_service = asset.services[0]
-
-bob_private_key = os.getenv("TEST_PRIVATE_KEY2")
-bob_wallet = Wallet(
-    ocean.web3,
-    bob_private_key,
-    config["BLOCK_CONFIRMATIONS"],
-    config["TRANSACTION_TIMEOUT"],
-)
-
-# Verify that Bob has ganache ETH
-assert ocean.web3.eth.get_balance(bob_wallet.address) > 0, "need ganache ETH"
 
 # Bob buys 1 DT from the FRE and then startsOrder, while burning that DT
 fixed_rate_exchange = ocean.fixed_rate_exchange

--- a/READMEs/get-test-MATIC.md
+++ b/READMEs/get-test-MATIC.md
@@ -14,7 +14,7 @@ The READMEs use one or two remote accounts, with keys `REMOTE_TEST_PRIVATE_KEY1`
 From [data-nfts-and-datatokens-flow](data-nfts-and-datatokens-flow.md), do:
 - [x] Setup : Prerequisites
 
-## 2. Create two new accounts
+## 2. Create two new accounts (one-time)
 
 In your console, run Python.
 ```console

--- a/READMEs/marketplace-flow.md
+++ b/READMEs/marketplace-flow.md
@@ -72,11 +72,6 @@ Instead of using OCEAN, Alice could have used H2O, the OCEAN-backed stable asset
 
 Now, you're Bob. In the same Python console:
 ```python
-# Bob sets up wallet
-bob_private_key = os.getenv('TEST_PRIVATE_KEY2')
-bob_wallet = Wallet(ocean.web3, bob_private_key, config["BLOCK_CONFIRMATIONS"], config["TRANSACTION_TIMEOUT"])
-print(f"bob_wallet.address = '{bob_wallet.address}'")
-
 # Bob verifies having enough funds
 assert ocean.web3.eth.get_balance(bob_wallet.address) > 0, "need ganache ETH"
 assert OCEAN_token.balanceOf(bob_wallet.address) > 0, "need OCEAN"

--- a/READMEs/predict-eth.md
+++ b/READMEs/predict-eth.md
@@ -93,33 +93,11 @@ Here, we grab Binance ETH/USDT price feed, which is published through Ocean as a
 In the same Python console:
 
 ```python
-# Retrieve the Asset and datatoken objects
-from ocean_lib.models.datatoken import Datatoken
+# Download file
 asset_did = "did:op:0dac5eb4965fb2b485181671adbf3a23b0133abf71d2775eda8043e8efc92d19"
-asset = ocean.assets.resolve(asset_did)
-datatoken_address = asset.datatokens[0]["address"]
-datatoken = Datatoken(ocean.web3, datatoken_address)
-print(f"Asset retrieved, with did={asset.did}, and datatoken_address={datatoken_address}")
-
-# Alice gets a datatoken from the dispenser
-amt_dispense_wei = ocean.to_wei(1)
-ocean.dispenser.dispense_tokens(datatoken, amt_dispense_wei, consumer_wallet=alice_wallet)
-bal = ocean.from_wei(datatoken.balanceOf(alice_wallet.address))
-print(f"Alice now holds {bal} datatokens to access the data asset.")
-
-# Alice sends datatoken to the service, to get access
-order_tx_id = ocean.assets.pay_for_access_service(asset, alice_wallet)
-print(f"order_tx_id = '{order_tx_id}'")
-
-# Alice now has access. She downloads the asset.
-# If the connection breaks, Alice can request again by showing order_tx_id.
-file_path = ocean.assets.download_asset(
-    asset, consumer_wallet=alice_wallet, destination='./', order_tx_id=order_tx_id)
+file_name = ocean.assets.download_file(asset_did, alice_wallet)
 
 # Load file
-import glob
-file_name = glob.glob(file_path + "/*")[0]
-print(f"file_name: '{file_name}'")
 with open(file_name, "r") as file:
     data_str = file.read().rstrip().replace('"', '')
 
@@ -240,18 +218,10 @@ datatoken.mint(to_address, ocean.to_wei(10), alice_wallet)
 This step and the next simulate what the judges ("Bob" here) will do with the predictions you shared: retrieve them, then calculate NMSE. You can use it to see how your predictions will be scored.
 
 ```python
-# Bob sends datatoken to the service, to get access
-order_tx_id = ocean.assets.pay_for_access_service(asset, bob_wallet)
-print(f"order_tx_id = '{order_tx_id}'")
-
-# Bob now has access. He downloads the asset.
-file_path = ocean.assets.download_asset(
-    asset, consumer_wallet=bob_wallet, destination='./', order_tx_id=order_tx_id)
+# Download file
+file_name = ocean.assets.download_file(asset.did, bob_wallet)
 
 # Load file
-import glob
-file_name = glob.glob(file_path + "/*")[0]
-print(f"file_name: '{file_name}'")
 import csv
 import numpy as np
 with open(file_name, "r") as f:

--- a/READMEs/predict-eth.md
+++ b/READMEs/predict-eth.md
@@ -28,6 +28,7 @@ From [simple-flow](data-nfts-and-datatokens-flow.md), do:
 
 ### 1.2 Create Polygon Account (One-Time)
 
+
 You'll be using Polygon to retrieve Ocean data assets, and publish your ETH predictions. So, you will need a Polygon account with a small amount of MATIC to pay for gas. If you have an account already (and its private key), you can skip this section.
 
 In your console, run Python.
@@ -182,14 +183,6 @@ From [simple-flow](data-nfts-and-datatokens-flow.md), do:
 - [x] Setup : Setup in Python
 
 In this flow, Alice is you -- the participant in the competition.
-
-"Setup in Python" set up Alice's wallet. Let's set up Bob's wallet too. In the same Python console:
-
-```python
-bob_private_key = os.getenv('TEST_PRIVATE_KEY2')
-bob_wallet = Wallet(ocean.web3, bob_private_key, config["BLOCK_CONFIRMATIONS"], config["TRANSACTION_TIMEOUT"])
-print(f"bob_wallet.address = '{bob_wallet.address}'")
-```
 
 ### 5.2 Publish the csv as an Ocean asset
 

--- a/READMEs/publish-flow-restapi.md
+++ b/READMEs/publish-flow-restapi.md
@@ -22,15 +22,10 @@ Let's go through each step.
 
 From [simple-flow](data-nfts-and-datatokens-flow.md), do:
 - [x] Setup : Prerequisites
+- [x] Setup : Download barge and run services
 - [x] Setup : Install the library
-
-### Setup for remote
-
-From [simple-remote](simple-remote.md), do:
-- [x] Create Mumbai Accounts (One-Time)
-- [x] Create Config File for Services
-- [x] Set envvars
-- [x] Setup in Python. Includes: Config, Alice's wallet, Bob's wallet
+- [x] Setup : Set envvars
+- [x] Setup : Setup in Python
 
 ## 2. Alice publishes the API asset
 
@@ -53,8 +48,8 @@ print(f"Just published asset, with did={asset.did}")
 
 In the same Python console:
 ```python
-from ocean_lib.models.datatoken import Datatoken
-datatoken = Datatoken(ocean.web3, datatoken_address)
+datatoken_address = asset.datatokens[0]["address"]
+datatoken = ocean.get_datatoken(datatoken_address)
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 datatoken.create_dispenser(
     dispenser_address=ocean.dispenser.address,
@@ -68,34 +63,65 @@ dispenser_status = ocean.dispenser.status(datatoken.address)
 assert dispenser_status[0:3] == [True, alice_wallet.address, True]
 ```
 
-### 4.  Bob consumes the API asset
+### 4. Bob consumes the API asset
 
-Now, you're Bob. All you have is the did of the data asset; you compute the rest.
+Now, you're Bob. First, download the file.
 
 In the same Python console:
 ```python
 # Set asset did. Practically, you'd get this from Ocean Market. _This_ example uses prior info.
 asset_did = asset.did
 
-# Retrieve the Asset and datatoken objects
+# Bob gets a datatoken from the dispenser; sends it to the service; downloads
+file_name = ocean.assets.download_file(asset_did, bob_wallet)
+```
+
+Now, load the file and use its data.
+
+The data follows the Binance docs specs for Kline/Candlestick Data, [here](https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-data).
+
+In the same Python console:
+```python
+
+#load from file into memory
+with open(file_name, "r") as file:
+    #data_str is a string holding a list of lists '[[1663113600000,"1574.40000000", ..]]'
+    data_str = file.read().rstrip().replace('"', '')
+
+
+data = eval(data_str) 
+
+#data is a list of lists
+# -Outer list has one 7 entries; one entry per day.
+# -Inner lists have 12 entries each: Kline open time, Open price, High price, Low price, close Price, Vol, ..
+
+#get close prices
+close_prices = [float(data_at_day[4]) for data_at_day in data]
+```
+
+## Appendix. Further Flexibility
+
+Step 4's `download_file()` did three things:
+
+- Checked if Bob has access tokens. He didn't, so the dispenser gave him some
+- Sent a datatoken to the service to get access
+- Downloaded the file
+
+Here are the three steps, un-bundled.
+
+In the same Python console:
+```python
+# Bob gets an access token from the dispenser
 asset = ocean.assets.resolve(asset_did)
 datatoken_address = asset.datatokens[0]["address"]
-print(f"Asset retrieved, with did={asset.did}, and datatoken_address={datatoken_address}")
+datatoken = ocean.get_datatoken(datatoken_address)
+amt_tokens = ocean.to_wei(1)
+ocean.dispenser.dispense_tokens(datatoken, amt_tokens, bob_wallet)
 
-# Bob gets an access token from the dispenser
-amt_dispense = 1
-datatoken = Datatoken(ocean.web3, datatoken_address)
-ocean.dispenser.dispense_tokens(
-    datatoken=datatoken, amount=ocean.to_wei(amt_dispense), consumer_wallet=bob_wallet
-)
-bal = ocean.from_wei(datatoken.balanceOf(bob_wallet.address))
-print(f"Bob now holds {bal} access tokens for the data asset.")
-
-# Bob sends 1.0 datatokens to the service, to get access
+# Bob sends a datatoken to the service to get access
 order_tx_id = ocean.assets.pay_for_access_service(asset, bob_wallet)
-print(f"order_tx_id = '{order_tx_id}'")
 
-# Bob now has access. He downloads the asset.
+# Bob downloads the dataset
 # If the connection breaks, Bob can request again by showing order_tx_id.
 file_path = ocean.assets.download_asset(
     asset=asset,
@@ -103,38 +129,9 @@ file_path = ocean.assets.download_asset(
     destination='./',
     order_tx_id=order_tx_id
 )
-
 import glob
 file_name = glob.glob(file_path + "/*")[0]
-print(f"file_path: '{file_path}'")  # e.g. datafile.0xAf07...48,0
-print(f"file_name: '{file_name}'")  # e.g. datafile.0xAf07...48,0/klines?symbol=ETHUSDT?int..22300
-
-#verify that file exists
-import os
-assert os.path.exists(file_name), "couldn't find file"
-
-# The file's data follows the Binance docs specs for Kline/Candlestick Data
-# https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-data
-
-#load from file into memory
-with open(file_name, "r") as file:
-    #data_str is a string holding a list of lists '[[1663113600000,"1574.40000000", ..]]'
-    data_str = file.read().rstrip().replace('"', '')
-
-#data is a list of lists
-# -Outer list has one 7 entries; one entry per day.
-# -Inner lists have 12 entries each: Kline open time, Open price, High price, Low price, close Price, Vol, ..
-data = eval(data_str) 
-
-#get close prices. These can serve as an approximation to spot price
-close_prices = [float(data_at_day[4]) for data_at_day in data]
-
-#or, we can put all data into a 2D array, to ease numerical processing
-import numpy
-D = numpy.asarray(data)
-print(D.shape)
-# returns:
-# (7,12) #7 days, 12 entries per day
+print(f"file_name: '{file_name}'")
 ```
 
 

--- a/conftest_ganache.py
+++ b/conftest_ganache.py
@@ -5,12 +5,14 @@
 import pytest
 
 from ocean_lib.aquarius.aquarius import Aquarius
+from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
 from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.models.datatoken_enterprise import DatatokenEnterprise
 from ocean_lib.models.factory_router import FactoryRouter
 from ocean_lib.models.side_staking import SideStaking
+from ocean_lib.ocean.ocean_assets import OceanAssets
 from ocean_lib.ocean.util import get_address_of_type
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.contract_utils import get_addresses_with_fallback
@@ -73,8 +75,26 @@ def setup_all(request, config, web3, ocean_token):
 
 
 @pytest.fixture
+def ocean_assets():
+    return OceanAssets(_config(), _web3(), DataServiceProvider)
+
+
+@pytest.fixture
 def config():
+    return _config()
+
+
+def _config():
     return get_example_config()
+
+
+@pytest.fixture
+def web3():
+    return _web3()
+
+
+def _web3():
+    return get_web3("http://127.0.0.1:8545")
 
 
 @pytest.fixture
@@ -85,11 +105,6 @@ def publisher_ocean_instance():
 @pytest.fixture
 def consumer_ocean_instance():
     return get_consumer_ocean_instance()
-
-
-@pytest.fixture
-def web3():
-    return get_web3("http://127.0.0.1:8545")
 
 
 @pytest.fixture

--- a/conftest_ganache.py
+++ b/conftest_ganache.py
@@ -5,14 +5,12 @@
 import pytest
 
 from ocean_lib.aquarius.aquarius import Aquarius
-from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
 from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.models.datatoken_enterprise import DatatokenEnterprise
 from ocean_lib.models.factory_router import FactoryRouter
 from ocean_lib.models.side_staking import SideStaking
-from ocean_lib.ocean.ocean_assets import OceanAssets
 from ocean_lib.ocean.util import get_address_of_type
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.contract_utils import get_addresses_with_fallback
@@ -75,26 +73,8 @@ def setup_all(request, config, web3, ocean_token):
 
 
 @pytest.fixture
-def ocean_assets():
-    return OceanAssets(_config(), _web3(), DataServiceProvider)
-
-
-@pytest.fixture
 def config():
-    return _config()
-
-
-def _config():
     return get_example_config()
-
-
-@pytest.fixture
-def web3():
-    return _web3()
-
-
-def _web3():
-    return get_web3("http://127.0.0.1:8545")
 
 
 @pytest.fixture
@@ -105,6 +85,11 @@ def publisher_ocean_instance():
 @pytest.fixture
 def consumer_ocean_instance():
     return get_consumer_ocean_instance()
+
+
+@pytest.fixture
+def web3():
+    return get_web3("http://127.0.0.1:8545")
 
 
 @pytest.fixture

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -4,6 +4,7 @@
 #
 
 """Ocean module."""
+import glob
 import json
 import logging
 import lzma
@@ -26,6 +27,7 @@ from ocean_lib.models.compute_input import ComputeInput
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
 from ocean_lib.models.datatoken import Datatoken
+from ocean_lib.models.dispenser import Dispenser
 from ocean_lib.ocean.util import get_address_of_type, get_ocean_token_address
 from ocean_lib.services.service import Service
 from ocean_lib.structures.algorithm_metadata import AlgorithmMetadata
@@ -37,7 +39,7 @@ from ocean_lib.structures.file_objects import (
 )
 from ocean_lib.utils.utilities import create_checksum
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
-from ocean_lib.web3_internal.currency import pretty_ether_and_wei, to_wei
+from ocean_lib.web3_internal.currency import pretty_ether_and_wei, to_wei, from_wei
 from ocean_lib.web3_internal.wallet import Wallet
 
 logger = logging.getLogger("ocean")
@@ -695,6 +697,45 @@ class OceanAssets:
             for ddo_dict in self._aquarius.query_search(query)
             if "_source" in ddo_dict
         ]
+
+    @enforce_types
+    def download_file(self, asset_did:str, wallet:Wallet) -> str:
+        """Helper method. Given a did, download file to "./". Returns filename.
+
+        Assumes that:
+        - wallet holds datatoken, or datatoken will freely dispense
+        - 0th datatoken of this did
+        - 0th service of the datatoken
+        - the service *is* a download service
+        """         
+        # Retrieve the Asset and datatoken objects
+        print("Resolve did...")
+        asset = self.resolve(asset_did)
+        datatoken_address = asset.datatokens[0]["address"]
+        datatoken = Datatoken(self._web3, datatoken_address)
+
+        # Ensure access token
+        bal = from_wei(datatoken.balanceOf(wallet.address))
+        if bal >= 1.0: #we're good
+            pass
+        else: #try to get freely-dispensed asset. If not free, it'll complain
+            print("Dispense access token...")
+            amt_dispense_wei = to_wei(1)
+            dispenser_addr = get_address_of_type(self._config_dict, "Dispenser")
+            dispenser = Dispenser(self._web3, dispenser_addr)
+            dispenser.dispense_tokens(datatoken, amt_dispense_wei, wallet)
+
+        # send datatoken to the service, to get access
+        print("Order access...")
+        order_tx_id = self.pay_for_access_service(asset, wallet)
+
+        # download the asset
+        print("Download file...")
+        file_path = self.download_asset(asset, wallet, './', order_tx_id)
+        file_name = glob.glob(file_path + "/*")[0]
+        print(f"Done. File: {file_name}")
+        
+        return file_name
 
     @enforce_types
     def download_asset(

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -699,7 +699,7 @@ class OceanAssets:
         ]
 
     @enforce_types
-    def download_file(self, asset_did:str, wallet:Wallet) -> str:
+    def download_file(self, asset_did: str, wallet: Wallet) -> str:
         """Helper method. Given a did, download file to "./". Returns filename.
 
         Assumes that:
@@ -707,7 +707,7 @@ class OceanAssets:
         - 0th datatoken of this did
         - 0th service of the datatoken
         - the service *is* a download service
-        """         
+        """
         # Retrieve the Asset and datatoken objects
         print("Resolve did...")
         asset = self.resolve(asset_did)
@@ -716,9 +716,9 @@ class OceanAssets:
 
         # Ensure access token
         bal = from_wei(datatoken.balanceOf(wallet.address))
-        if bal >= 1.0: #we're good
+        if bal >= 1.0:  # we're good
             pass
-        else: #try to get freely-dispensed asset. If not free, it'll complain
+        else:  # try to get freely-dispensed asset. If not free, it'll complain
             print("Dispense access token...")
             amt_dispense_wei = to_wei(1)
             dispenser_addr = get_address_of_type(self._config_dict, "Dispenser")
@@ -731,10 +731,10 @@ class OceanAssets:
 
         # download the asset
         print("Download file...")
-        file_path = self.download_asset(asset, wallet, './', order_tx_id)
+        file_path = self.download_asset(asset, wallet, "./", order_tx_id)
         file_name = glob.glob(file_path + "/*")[0]
         print(f"Done. File: {file_name}")
-        
+
         return file_name
 
     @enforce_types

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -145,7 +145,7 @@ def test_compact_publish_and_consume(
 ):
     data_provider = DataServiceProvider
     ocean_assets = OceanAssets(config, web3, data_provider)
-    
+
     # publish
     name = "CEXA"
     url = "https://cexa.oceanprotocol.io/ohlc?exchange=binance&pair=ETH/USDT"

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -133,24 +133,23 @@ def test_consume_flow(
         os.listdir(os.path.join(destination, os.listdir(destination)[0]))
     ) == len(files), "The asset folder is empty."
 
-    
+
 @pytest.mark.integration
 def test_compact_publish_and_consume(
     web3: Web3,
     ocean_assets,
     publisher_wallet: Wallet,
     consumer_wallet: Wallet,
-):    
-    #publish
+):
+    # publish
     name = "CEXA"
     url = "https://cexa.oceanprotocol.io/ohlc?exchange=binance&pair=ETH/USDT"
     asset = ocean_assets.create_url_asset(name, url, publisher_wallet)
 
-    #share access
+    # share access
     datatoken_address = asset.datatokens[0]["address"]
     datatoken = Datatoken(web3, datatoken_address)
     datatoken.mint(consumer_wallet.address, to_wei(1), publisher_wallet)
 
-    #consume
+    # consume
     file_name = ocean_assets.download_file(asset.did, consumer_wallet)
-    

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -12,6 +12,7 @@ from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.datatoken import Datatoken
+from ocean_lib.ocean.ocean_assets import OceanAssets
 from ocean_lib.structures.file_objects import FilesType
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.currency import to_wei
@@ -21,7 +22,6 @@ from tests.resources.ddo_helpers import get_first_service_by_type
 
 @pytest.mark.integration
 def test_consume_flow(
-    ocean_assets,
     web3: Web3,
     config: dict,
     publisher_wallet: Wallet,
@@ -29,6 +29,8 @@ def test_consume_flow(
     data_nft: DataNFT,
     file1: FilesType,
 ):
+    data_provider = DataServiceProvider
+    ocean_assets = OceanAssets(config, web3, data_provider)
     metadata = {
         "created": "2020-11-15T12:27:48Z",
         "updated": "2021-05-17T21:58:02Z",
@@ -137,10 +139,13 @@ def test_consume_flow(
 @pytest.mark.integration
 def test_compact_publish_and_consume(
     web3: Web3,
-    ocean_assets,
+    config: dict,
     publisher_wallet: Wallet,
     consumer_wallet: Wallet,
 ):
+    data_provider = DataServiceProvider
+    ocean_assets = OceanAssets(config, web3, data_provider)
+    
     # publish
     name = "CEXA"
     url = "https://cexa.oceanprotocol.io/ohlc?exchange=binance&pair=ETH/USDT"

--- a/tests/readmes/test_readmes.py
+++ b/tests/readmes/test_readmes.py
@@ -62,6 +62,7 @@ def test_script_execution(script, monkeypatch):
                 "config",
                 "ocean",
                 "alice_wallet",
+                "bob_wallet",
                 "data_nft",
                 "datatoken",
             ]:


### PR DESCRIPTION
Fixes #996

Changes:
- add `ocean_assets.py::download_file()` which bundles together dispensing (when applicable), ordering with a token, and finally downloading
- added new test for the above, into `test_consume_flow.py`
- updated all the READMEs accordingly: predict-eth.md (23 lines -> 1 line), consume-flow.md, publish-flow-restapi.md. 
- added creation of `bob_wallet` into simple flow; then removed it from simplified enterprise-flow.md, marketplace-flow.md, predict-eth.md.