### PR TITLE
remove version constrain on cryptography. obove of the current versio…

### DIFF
--- a/READMEs/data-nfts-and-datatokens-flow.md
+++ b/READMEs/data-nfts-and-datatokens-flow.md
@@ -35,8 +35,6 @@ pip3 install ocean-lib
 
 #### ⚠️ Known issues
 
-- for M1 processors, `coincurve` and `cryptography` installation may fail due to dependency/compilation issues. It is recommended to install them individually, e.g. `pip3 install coincurve && pip3 install cryptography`
-
 - Mac users: if you encounter an "Unsupported Architecture" issue, then install including ARCHFLAGS: `ARCHFLAGS="-arch x86_64" pip install ocean-lib`. [[Details](https://github.com/oceanprotocol/ocean.py/issues/486).]
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requirements = [
     "pycryptodomex",
     "tqdm",
     "pytz",
-    "cryptography==3.3.2",
+    "cryptography",
     "scipy",
     "enforce-typing==1.0.0.post1",
     "json-sempai==0.4.0",


### PR DESCRIPTION
…n the library runs without problems in mac with M1 processors

Fixes #1034 .
Installing ocean.py in Mac with M1 processor fail due to issues with Cryptography #1034

Changes proposed in this PR:

- upgrade to a newer version of Cryptography
- 
- 