### PR TITLE
Add escaping to search.

### DIFF
--- a/ocean_lib/assets/asset.py
+++ b/ocean_lib/assets/asset.py
@@ -97,11 +97,12 @@ class Asset(AddressCredential):
             if "services" not in values
             else [Service.from_dict(value) for value in values.pop("services")]
         )
-        return cls(
-            values.pop("id"),
-            values.pop("@context"),
-            values.pop("chainId"),
-            values.pop("nftAddress"),
+
+        args = [
+            values.pop("id", None),
+            values.pop("@context", None),
+            values.pop("chainId", None),
+            values.pop("nftAddress", None),
             values.pop("metadata", None),
             services,
             values.pop("credentials", None),
@@ -109,7 +110,12 @@ class Asset(AddressCredential):
             values.pop("datatokens", None),
             values.pop("event", None),
             values.pop("stats", None),
-        )
+        ]
+
+        if args[0] is None:
+            return UnavailableAsset(*args)
+
+        return cls(*args)
 
     @enforce_types
     def as_dictionary(self) -> dict:
@@ -202,3 +208,7 @@ class Asset(AddressCredential):
     @property
     def is_disabled(self) -> bool:
         return not self.metadata or (self.nft and self.nft["state"] != 0)
+
+
+class UnavailableAsset(Asset):
+    pass

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -694,6 +694,7 @@ class OceanAssets:
         :return: List of assets that match with the query
         """
         logger.info(f"Searching asset containing: {text}")
+        text = text.replace(":", "\\:").replace("\\\\:", "\\:")
         return [
             Asset.from_dict(ddo_dict["_source"])
             for ddo_dict in self._aquarius.query_search(


### PR DESCRIPTION
Closes #1037. Fixes:

- issue with search string encoding
- unavailable asset (metadata not active) messing up an entire search: introduced an Unavailable Asset class s.t. it appears as a result, however it's unusable in the consumable checks and the different class name makes it more transparent to the user that it's not an actual Asset