### PR TITLE
Increase waiting time for address file to 5 minutes.

### DIFF
--- a/.github/workflows/libcheck.yml
+++ b/.github/workflows/libcheck.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: ${{ github.workspace }}/barge
         run: |
           bash -x start_ocean.sh --no-dashboard 2>&1 --with-provider2 --with-rbac --with-c2d > start_ocean.log &
-          for i in $(seq 1 50); do
+          for i in $(seq 1 60); do
             sleep 5
             [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
             done

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ${{ github.workspace }}/barge
         run: |
           bash -x start_ocean.sh --no-dashboard 2>&1 --with-provider2 --with-rbac --with-c2d --with-thegraph > start_ocean.log &
-          for i in $(seq 1 50); do
+          for i in $(seq 1 60); do
             sleep 5
             [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
             done

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: ${{ github.workspace }}/barge
         run: |
           bash -x start_ocean.sh --no-dashboard 2>&1 --with-provider2 --with-rbac --with-c2d > start_ocean.log &
-          for i in $(seq 1 50); do
+          for i in $(seq 1 60); do
             sleep 5
             [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
             done


### PR DESCRIPTION
Closes #939.

I can not entirely verify this, but here is what I found: with 50 loops (as previously), the time was 250s (a little over 4 minutes). For the test failure mentioned in the original ticket, the barge run time was 4min:15sec and I remember empirically that the entire test suite was under 8mins for cases where the address file was missing. Based on these calculations, I increased the waiting time to 5 minutes (60 loops of 5 seconds), which I think is a reasonable increase.