### PR TITLE
Fix #916 - Expose VE & DF functionality into ocean.py; democratize wash consume

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ Here are flows to try out, from simple to specific detailed variants.
 - [Key-value database](READMEs/key-value-flow.md) - use data NFTs to store arbitrary key-value pairs on-chain.
 - [Profile NFTs](READMEs/profile-nfts-flow.md) - enable "login with Web3" where Dapp can access private user profile data.
 
-### Data Challenge flows
+### Use-case flows
 
-- [Predict-eth repo](https://github.com/oceanprotocol/predict-eth) - data challanges with $ to predict future ETH price.
+- [Predict-eth](https://github.com/oceanprotocol/predict-eth) - data challenges with $ to predict future ETH price.
+- [Data Farming](READMEs/df.md) - curate data assets, earn rewards
 
 ### Learn more
 

--- a/READMEs/df.md
+++ b/READMEs/df.md
@@ -174,5 +174,9 @@ print(f"Just claimed {bal_after-bal_before} OCEAN rewards")
 
 ## 7. Repeat steps 1-6, for Eth mainnet
 
-FIXME
+We leave this as an exercise to the reader:)
+
+Here's a hint to get started: initial setup is like the [simple-remote flow](simple-remote.md).
+
+Happy Data Farming!
 

--- a/READMEs/df.md
+++ b/READMEs/df.md
@@ -104,8 +104,8 @@ from web3 import Web3
 exchange_id = ocean.create_fixed_rate(
     datatoken=datatoken,
     base_token=OCEAN,
-    amount=Web3.toWei(num_consumes, "ether"),
-    fixed_rate=Web3.toWei(datatoken_price_OCEAN, "ether"),
+    amount=to_wei(num_consumes),
+    fixed_rate=to_wei(datatoken_price_OCEAN),
     from_wallet=alice_wallet,
 )
 ```
@@ -134,15 +134,15 @@ OCEAN.approve(ocean.fixed_rate_exchange.address, to_wei(OCEAN_bal), {"from": ali
 fees_info = ocean.fixed_rate_exchange.get_fees_info(exchange_id)
 for i in range(num_consumes):
     print(f"Purchase #{i+1}/{num_consumes}...")
-    txid = ocean.fixed_rate_exchange.buy_dt(
-        exchange_id=exchange_id,
-    	datatoken_amount=to_wei(num_consumes),
-    	max_base_token_amount=to_wei(OCEAN_bal),
-    	consume_market_swap_fee_address=fees_info[1],
-    	consume_market_swap_fee_amount=fees_info[0],
-    	from_wallet=alice_wallet,
+    tx = ocean.fixed_rate_exchange.buyDT(
+        exchange_id,
+        to_wei(num_consumes), # datatokenAmount
+        to_wei(OCEAN_bal),    # maxBaseTokenAmount
+        fees_info[1], # consumeMarketAddress
+        fees_info[0], # consumeMarketSwapFeeAmount
+        {"from": alice_wallet},
     )
-    assert txid, "buying datatokens failed"
+    assert tx, "buying datatokens failed"
 DT_bal = from_wei(datatoken.balanceOf(alice_wallet.address))
 assert DT_bal >= num_consumes, f"Have just {DT_bal} datatokens"
 

--- a/READMEs/df.md
+++ b/READMEs/df.md
@@ -49,19 +49,13 @@ amt_OCEAN_lock = 10.0
 We'll use these a lot. So import once, here. 
 In the same Python console:
 ```python
-# OCEAN
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
 mint_fake_OCEAN(config) #Alice gets some
-OCEAN = ocean.OCEAN_token
 
-# veOCEAN
-from ocean_lib.models.ve_ocean import VeOcean
-from ocean_lib.models.ve_allocate import VeAllocate
-from ocean_lib.models.ve_fee_distributor import VeFeeDistributor
-from ocean_lib.ocean.util import get_address_of_type
-veOCEAN = VeOcean(config, get_address_of_type(config, "veOCEAN"))
-ve_allocate = VeAllocate(config, get_address_of_type(config, "veAllocate"))
-ve_fee_distributor = VeFeeDistributor(config, get_address_of_type(config, "veFeeDistributor"))
+OCEAN = ocean.OCEAN_token
+veOCEAN = ocean.ve_ocean
+ve_allocate = ocean.ve_allocate
+ve_fee_distributor = ocean.ve_fee_distributor
 
 #helper functions
 def to_wei(amt_eth) -> int:

--- a/READMEs/df.md
+++ b/READMEs/df.md
@@ -36,6 +36,7 @@ In the same Python console:
 # Your asset gets rewards pro-rata for its DCV compared to other assets' DCVs. 
 datatoken_price_OCEAN = 100.0
 num_consumes = 3
+
 # This is how much OCEAN to lock into veOCEAN. It can be small if you're
 # the only staker on your asset. If others stake on your asset, your
 # rewards are pro-rate compared to others' stake in your asset.
@@ -52,6 +53,7 @@ In the same Python console:
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
 mint_fake_OCEAN(config) #Alice gets some
 OCEAN = ocean.OCEAN_token
+
 # veOCEAN
 from ocean_lib.models.ve_ocean import VeOcean
 from ocean_lib.models.ve_allocate import VeAllocate
@@ -60,9 +62,11 @@ from ocean_lib.ocean.util import get_address_of_type
 veOCEAN = VeOcean(config, get_address_of_type(config, "veOCEAN"))
 ve_allocate = VeAllocate(config, get_address_of_type(config, "veAllocate"))
 ve_fee_distributor = VeFeeDistributor(config, get_address_of_type(config, "veFeeDistributor"))
+
 #helper functions
 def to_wei(amt_eth) -> int:
     return int(amt_eth * 1e18)
+
 def from_wei(amt_wei: int) -> float:
     return float(amt_wei / 1e18)
 ```
@@ -80,6 +84,7 @@ t1 = t0 // WEEK * WEEK + WEEK #this is a Thursday, because Jan 1 1970 was
 t2 = t1 + WEEK
 chain.sleep(t1 - t0) 
 chain.mine()
+
 #we're now at the beginning of the week. So, lock
 OCEAN.approve(veOCEAN.address, to_wei(amt_OCEAN_lock), alice_wallet)
 veOCEAN.withdraw({"from": alice_wallet}) #withdraw old tokens first
@@ -94,9 +99,11 @@ In the same Python console:
 #data info
 name = "Branin dataset"
 url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
+
 #create data asset
 (data_NFT, datatoken, asset) = ocean.assets.create_url_asset(name, url, alice_wallet, wait_for_aqua=False)
 print(f"Just published asset, with data_NFT.address={data_NFT.address}")
+
 # create fixed-rate exchange (FRE)
 from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
 fixedPrice = FixedRateExchange(config, get_address_of_type(config, "FixedPrice"))
@@ -155,6 +162,7 @@ for i in range(num_consumes):
     assert txid, "buying datatokens failed"
 DT_bal = from_wei(datatoken.balanceOf(alice_wallet.address))
 assert DT_bal >= num_consumes, f"Have just {DT_bal} datatokens"
+
 # Alice sends datatokens to the service, to get access. This is the "consume".
 for i in range(num_consumes):
     print(f"Consume #{i+1}/{num_consumes}...")
@@ -174,6 +182,7 @@ t1 = t0 // WEEK * WEEK + WEEK
 t2 = t1 + WEEK
 chain.sleep(t1 - t0) 
 chain.mine()
+
 #Rewards can be claimed via code or webapp, at your leisure. Let's do it now.
 bal_before = from_wei(OCEAN.balanceOf(alice_wallet.address))
 ve_fee_distributor.claim({"from": alice_wallet})

--- a/READMEs/df.md
+++ b/READMEs/df.md
@@ -50,6 +50,7 @@ We'll use these a lot. So import once, here.
 In the same Python console:
 ```python
 # Set factory envvar. Stay in Python to retain state from before.
+import os
 os.environ['FACTORY_DEPLOYER_PRIVATE_KEY'] = '0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58'
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
 mint_fake_OCEAN(config) #Alice gets some

--- a/READMEs/df.md
+++ b/READMEs/df.md
@@ -1,0 +1,187 @@
+# Quickstart: Data Farming Flow
+
+This README shows how to do steps in Ocean Data Farming (DF), where you curate data assets to earn rewards. It also helps to democratize "wash consume" until it becomes unprofitable.
+
+Here are the steps:
+
+1. Setup, in Ganache
+2. Lock OCEAN for veOCEAN
+3. Publish dataset & FRE
+4. Allocate veOCEAN to dataset
+5. Fake-consume data
+6. Collect OCEAN rewards
+7. Repeat steps 1-6, for Eth mainnet
+
+Let's go through each step.
+
+## 1. Setup
+
+### 1.1 Basic setup
+
+From [data-nfts-and-datatokens-flow](data-nfts-and-datatokens-flow.md), do:
+- [x] Setup : Prerequisites
+- [x] Setup : Download barge and run services
+- [x] Setup : Install the library
+- [x] Setup : Set envvars
+- [x] Setup : Setup in Python, including `ocean` and `alice_wallet`
+
+
+### 1.2 Setup key parameters
+
+In Ganache, you can use these parameters as-is. But on Eth mainnet, you need to choose these for yourself.
+
+In the same Python console:
+```python
+# On your asset, your DCV = datatoken_price_OCEAN * num_consumes.
+# Your asset gets rewards pro-rata for its DCV compared to other assets' DCVs. 
+datatoken_price_OCEAN = 100.0
+num_consumes = 3
+# This is how much OCEAN to lock into veOCEAN. It can be small if you're
+# the only staker on your asset. If others stake on your asset, your
+# rewards are pro-rate compared to others' stake in your asset.
+amt_OCEAN_lock = 10.0
+```
+
+
+### 1.3 Setup OCEAN and veOCEAN
+
+We'll use these a lot. So import once, here. 
+In the same Python console:
+```python
+# OCEAN
+from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
+mint_fake_OCEAN(config) #Alice gets some
+OCEAN = ocean.OCEAN_token
+# veOCEAN
+from ocean_lib.models.ve_ocean import VeOcean
+from ocean_lib.models.ve_allocate import VeAllocate
+from ocean_lib.models.ve_fee_distributor import VeFeeDistributor
+from ocean_lib.ocean.util import get_address_of_type
+veOCEAN = VeOcean(config, get_address_of_type(config, "veOCEAN"))
+ve_allocate = VeAllocate(config, get_address_of_type(config, "veAllocate"))
+ve_fee_distributor = VeFeeDistributor(config, get_address_of_type(config, "veFeeDistributor"))
+#helper functions
+def to_wei(amt_eth) -> int:
+    return int(amt_eth * 1e18)
+def from_wei(amt_wei: int) -> float:
+    return float(amt_wei / 1e18)
+```
+
+
+## 2. Lock OCEAN for veOCEAN
+
+In the same Python console:
+```python
+#simulate passage of time, until next Thursday, the start of DF(X)
+from brownie.network import chain
+WEEK = 7 * 86400 # seconds in a week
+t0 = chain.time()
+t1 = t0 // WEEK * WEEK + WEEK #this is a Thursday, because Jan 1 1970 was
+t2 = t1 + WEEK
+chain.sleep(t1 - t0) 
+chain.mine()
+#we're now at the beginning of the week. So, lock
+OCEAN.approve(veOCEAN.address, to_wei(amt_OCEAN_lock), alice_wallet)
+veOCEAN.withdraw({"from": alice_wallet}) #withdraw old tokens first
+veOCEAN.create_lock(to_wei(amt_OCEAN_lock), t2, {"from": alice_wallet})
+```
+
+
+## 3. Publish Dataset & FRE
+
+In the same Python console:
+```python
+#data info
+name = "Branin dataset"
+url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
+#create data asset
+(data_NFT, datatoken, asset) = ocean.assets.create_url_asset(name, url, alice_wallet, wait_for_aqua=False)
+print(f"Just published asset, with data_NFT.address={data_NFT.address}")
+# create fixed-rate exchange (FRE)
+from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
+fixedPrice = FixedRateExchange(config, get_address_of_type(config, "FixedPrice"))
+datatoken.approve(fixedPrice.address, to_wei(num_consumes), alice_wallet)
+from ocean_lib.web3_internal.constants import ZERO_ADDRESS
+txid = datatoken.create_fixed_rate(
+    fixed_price_address = fixedPrice.address,
+    base_token_address = OCEAN.address,
+    owner = alice_wallet.address,
+    publish_market_swap_fee_collector = alice_wallet.address,
+    allowed_swapper = ZERO_ADDRESS,
+    base_token_decimals = OCEAN.decimals(),
+    datatoken_decimals = datatoken.decimals(),
+    fixed_rate = to_wei(datatoken_price_OCEAN),
+    publish_market_swap_fee_amount = 0,
+    with_mint = 1,
+    from_wallet = alice_wallet
+)
+from brownie.network.transaction import TransactionReceipt
+tx = TransactionReceipt(txid)
+exchange_id = tx.events["NewFixedRate"]["exchangeId"]
+```
+
+
+## 4. Stake on dataset
+
+To stake, you allocate veOCEAN to dataset. In the same Python console:
+```python
+amt_allocate = 100 #total allocation must be <= 10000 (wei)
+ve_allocate.setAllocation(amt_allocate, data_NFT.address, chain.id, {"from": alice_wallet})
+```
+
+## 5. Fake-consume data
+
+"Wash consuming" is when the publisher fake-consumes data to drive data consume volume (DCV) to get more rewards. Not healthy for the ecosystem long-term. Good news: if consume fee > weekly rewards, then wash consume becomes unprofitable. DF is set up to make this happen by DF29 (if not sooner). [Details](https://twitter.com/trentmc0/status/1587527525529358336).
+
+In the meantime, this README helps level the playing field around wash consume. This step shows how to do fake-consume.
+
+```python
+# Alice buys datatokens from herself
+amt_pay = datatoken_price_OCEAN * num_consumes
+OCEAN_bal = from_wei(OCEAN.balanceOf(alice_wallet.address))
+assert OCEAN_bal >= amt_pay, f"Have just {OCEAN_bal} OCEAN"
+OCEAN.approve(fixedPrice.address, to_wei(OCEAN_bal), alice_wallet)
+fees_info = fixedPrice.get_fees_info(exchange_id)
+for i in range(num_consumes):
+    print(f"Purchase #{i+1}/{num_consumes}...")
+    txid = fixedPrice.buy_dt(
+        exchange_id=exchange_id,
+    	datatoken_amount=to_wei(num_consumes),
+    	max_base_token_amount=to_wei(OCEAN_bal),
+    	consume_market_swap_fee_address=fees_info[1],
+    	consume_market_swap_fee_amount=fees_info[0],
+    	from_wallet=alice_wallet,
+    )
+    assert txid, "buying datatokens failed"
+DT_bal = from_wei(datatoken.balanceOf(alice_wallet.address))
+assert DT_bal >= num_consumes, f"Have just {DT_bal} datatokens"
+# Alice sends datatokens to the service, to get access. This is the "consume".
+for i in range(num_consumes):
+    print(f"Consume #{i+1}/{num_consumes}...")
+    ocean.assets.pay_for_access_service(asset, alice_wallet)
+    #don't need to call e.g. ocean.assets.download_asset() since wash-consuming
+```
+
+## 6. Collect OCEAN rewards
+
+In the same Python console:
+
+```python
+#simulate passage of time, until next Thursday, which is the start of DF(X+1)
+WEEK = 7 * 86400 # seconds in a week
+t0 = chain.time()
+t1 = t0 // WEEK * WEEK + WEEK
+t2 = t1 + WEEK
+chain.sleep(t1 - t0) 
+chain.mine()
+#Rewards can be claimed via code or webapp, at your leisure. Let's do it now.
+bal_before = from_wei(OCEAN.balanceOf(alice_wallet.address))
+ve_fee_distributor.claim({"from": alice_wallet})
+bal_after = from_wei(OCEAN.balanceOf(alice_wallet.address))
+print(f"Just claimed {bal_after-bal_before} OCEAN rewards") 
+```
+
+## 7. Repeat steps 1-6, for Eth mainnet
+
+FIXME
+

--- a/ocean_lib/models/ve_allocate.py
+++ b/ocean_lib/models/ve_allocate.py
@@ -1,0 +1,9 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+from ocean_lib.web3_internal.contract_base import ContractBase
+
+
+class VeAllocate(ContractBase):
+    CONTRACT_NAME = "veAllocate"

--- a/ocean_lib/models/ve_fee_distributor.py
+++ b/ocean_lib/models/ve_fee_distributor.py
@@ -1,0 +1,9 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+from ocean_lib.web3_internal.contract_base import ContractBase
+
+
+class VeFeeDistributor(ContractBase):
+    CONTRACT_NAME = "veFeeDistributor"

--- a/ocean_lib/models/ve_ocean.py
+++ b/ocean_lib/models/ve_ocean.py
@@ -1,0 +1,9 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+from ocean_lib.web3_internal.contract_base import ContractBase
+
+
+class VeOcean(ContractBase):
+    CONTRACT_NAME = "veOCEAN"

--- a/ocean_lib/models/vetest/conftest.py
+++ b/ocean_lib/models/vetest/conftest.py
@@ -25,10 +25,3 @@ def ve_allocate(config):
 def ve_fee_distributor(config):
     return VeFeeDistributor(config, get_address_of_type(config, "veFeeDistributor"))
 
-
-def to_wei(amt_eth) -> int:
-    return int(amt_eth * 1e18)
-
-
-def from_wei(amt_wei: int) -> float:
-    return float(amt_wei / 1e18)

--- a/ocean_lib/models/vetest/conftest.py
+++ b/ocean_lib/models/vetest/conftest.py
@@ -24,3 +24,11 @@ def ve_allocate(config):
 @pytest.fixture
 def ve_fee_distributor(config):
     return VeFeeDistributor(config, get_address_of_type(config, "veFeeDistributor"))
+
+
+def to_wei(amt_eth) -> int:
+    return int(amt_eth * 1e18)
+
+
+def from_wei(amt_wei: int) -> float:
+    return float(amt_wei / 1e18)

--- a/ocean_lib/models/vetest/conftest.py
+++ b/ocean_lib/models/vetest/conftest.py
@@ -24,4 +24,3 @@ def ve_allocate(config):
 @pytest.fixture
 def ve_fee_distributor(config):
     return VeFeeDistributor(config, get_address_of_type(config, "veFeeDistributor"))
-

--- a/ocean_lib/models/vetest/conftest.py
+++ b/ocean_lib/models/vetest/conftest.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import pytest
+
+from conftest_ganache import *
+from ocean_lib.models.ve_allocate import VeAllocate
+from ocean_lib.models.ve_fee_distributor import VeFeeDistributor
+from ocean_lib.models.ve_ocean import VeOcean
+from ocean_lib.ocean.util import get_address_of_type
+
+
+@pytest.fixture
+def veOCEAN(config):
+    return VeOcean(config, get_address_of_type(config, "veOCEAN"))
+
+
+@pytest.fixture
+def ve_allocate(config):
+    return VeAllocate(config, get_address_of_type(config, "veAllocate"))
+
+
+@pytest.fixture
+def ve_fee_distributor(config):
+    return VeFeeDistributor(config, get_address_of_type(config, "veFeeDistributor"))
+

--- a/ocean_lib/models/vetest/test_fake_ocean.py
+++ b/ocean_lib/models/vetest/test_fake_ocean.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import os
+
+import pytest
+from brownie.network import accounts
+
+from ocean_lib.models.datatoken import Datatoken
+from ocean_lib.ocean.util import get_ocean_token_address
+from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
+from ocean_lib.web3_internal.currency import to_wei, from_wei
+
+
+@pytest.mark.unit
+def test_direct_call(config, consumer_wallet, factory_deployer_wallet, ocean_token):
+    bal_before = ocean_token.balanceOf(consumer_wallet.address)
+    amt_distribute = to_wei(1000)
+    ocean_token.mint(
+        consumer_wallet.address, amt_distribute, from_wallet=factory_deployer_wallet
+    )
+    bal_after = ocean_token.balanceOf(consumer_wallet.address)
+    assert bal_after == (bal_before + amt_distribute)
+
+
+@pytest.mark.unit
+def test_use_mint_fake_ocean(config, factory_deployer_wallet, ocean_token):
+    expected_amt_distribute = to_wei("2000")
+
+    mint_fake_OCEAN(config)
+
+    for key_label in ["TEST_PRIVATE_KEY1", "TEST_PRIVATE_KEY2", "TEST_PRIVATE_KEY3"]:
+        key = os.environ.get(key_label)
+        if not key:
+            continue
+
+        w = accounts.add(key)
+        assert ocean_token.balanceOf(w.address) >= expected_amt_distribute

--- a/ocean_lib/models/vetest/test_fake_ocean.py
+++ b/ocean_lib/models/vetest/test_fake_ocean.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from brownie.network import accounts
 
-from conftest import to_wei
+
 from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.ocean.util import get_ocean_token_address
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
@@ -37,3 +37,7 @@ def test_use_mint_fake_ocean(config, factory_deployer_wallet, ocean_token):
 
         w = accounts.add(key)
         assert ocean_token.balanceOf(w.address) >= expected_amt_distribute
+
+
+def to_wei(amt_eth) -> int:
+    return int(amt_eth * 1e18)

--- a/ocean_lib/models/vetest/test_fake_ocean.py
+++ b/ocean_lib/models/vetest/test_fake_ocean.py
@@ -7,10 +7,10 @@ import os
 import pytest
 from brownie.network import accounts
 
+from conftest import to_wei
 from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.ocean.util import get_ocean_token_address
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
-from ocean_lib.web3_internal.currency import to_wei, from_wei
 
 
 @pytest.mark.unit
@@ -18,7 +18,7 @@ def test_direct_call(config, consumer_wallet, factory_deployer_wallet, ocean_tok
     bal_before = ocean_token.balanceOf(consumer_wallet.address)
     amt_distribute = to_wei(1000)
     ocean_token.mint(
-        consumer_wallet.address, amt_distribute, from_wallet=factory_deployer_wallet
+        consumer_wallet.address, amt_distribute, {"from": factory_deployer_wallet}
     )
     bal_after = ocean_token.balanceOf(consumer_wallet.address)
     assert bal_after == (bal_before + amt_distribute)
@@ -26,7 +26,7 @@ def test_direct_call(config, consumer_wallet, factory_deployer_wallet, ocean_tok
 
 @pytest.mark.unit
 def test_use_mint_fake_ocean(config, factory_deployer_wallet, ocean_token):
-    expected_amt_distribute = to_wei("2000")
+    expected_amt_distribute = to_wei(2000)
 
     mint_fake_OCEAN(config)
 

--- a/ocean_lib/models/vetest/test_ve_allocate.py
+++ b/ocean_lib/models/vetest/test_ve_allocate.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import os
+
+import brownie
+import pytest
+
+
+accounts = None
+
+
+@pytest.mark.unit
+def test_single_allocation(ve_allocate):
+    """getveAllocation should return the correct allocation."""
+    nftaddr1 = accounts[0].address
+    nftaddr2 = accounts[1].address
+    nftaddr3 = accounts[2].address
+
+    ve_allocate.setAllocation(100, nftaddr1, 1, {"from": accounts[0]})
+    assert ve_allocate.getveAllocation(accounts[0], nftaddr1, 1) == 100
+
+    ve_allocate.setAllocation(25, nftaddr2, 1, {"from": accounts[0]})
+    assert ve_allocate.getveAllocation(accounts[0], nftaddr2, 1) == 25
+
+    ve_allocate.setAllocation(50, nftaddr3, 1, {"from": accounts[0]})
+    assert ve_allocate.getveAllocation(accounts[0], nftaddr3, 1) == 50
+
+    ve_allocate.setAllocation(0, nftaddr2, 1, {"from": accounts[0]})
+    assert ve_allocate.getveAllocation(accounts[0], nftaddr2, 1) == 0
+
+
+@pytest.mark.unit
+def test_single_events(ve_allocate):
+    """Test emitted events."""
+    nftaddr1 = accounts[1].address
+    tx = ve_allocate.setAllocation(100, nftaddr1, 1, {"from": accounts[0]})
+    assert tx.events["AllocationSet"].values() == [
+        accounts[0].address,
+        accounts[1].address,
+        1,
+        100,
+    ]
+
+
+@pytest.mark.unit
+def test_batch_allocation(ve_allocate):
+    """getveAllocation should return the correct allocation."""
+    nftaddr1 = accounts[0].address
+    nftaddr2 = accounts[1].address
+
+    tx = ve_allocate.setBatchAllocation(
+        [50, 50], [nftaddr1, nftaddr2], [1, 1], {"from": accounts[0]}
+    )
+    assert ve_allocate.getveAllocation(accounts[0], nftaddr1, 1) == 50
+
+
+@pytest.mark.unit
+def test_batch_events(ve_allocate):
+    """Test emitted events."""
+    nftaddr1 = accounts[1].address
+    nftaddr2 = accounts[1].address
+    tx = ve_allocate.setBatchAllocation(
+        [25, 75], [nftaddr1, nftaddr2], [1, 1], {"from": accounts[0]}
+    )
+    assert tx.events["AllocationSetMultiple"].values() == [
+        accounts[0].address,
+        [nftaddr1, nftaddr2],
+        [1, 1],
+        [25, 75],
+    ]
+
+
+def setup_function():
+    global accounts
+    accounts = brownie.network.accounts
+

--- a/ocean_lib/models/vetest/test_ve_allocate.py
+++ b/ocean_lib/models/vetest/test_ve_allocate.py
@@ -75,4 +75,3 @@ def test_batch_events(ve_allocate):
 def setup_function():
     global accounts
     accounts = brownie.network.accounts
-

--- a/ocean_lib/models/vetest/test_ve_fee_distributor.py
+++ b/ocean_lib/models/vetest/test_ve_fee_distributor.py
@@ -1,0 +1,19 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import pytest
+
+
+@pytest.mark.unit
+def test1(config, ve_fee_distributor, consumer_wallet):
+    # df-py/util/test/veOcean/test_estimateClaim.py has thorough tests
+    # therefore, we keep it super-simple here
+    assert ve_fee_distributor.address is not None
+
+    ve_fee_distributor.user_epoch_of(consumer_wallet)
+    ve_fee_distributor.time_cursor_of(consumer_wallet)
+
+    # this is the most important call from a user standpoint. $$ :)
+    ve_fee_distributor.claim({"from": consumer_wallet})
+

--- a/ocean_lib/models/vetest/test_ve_fee_distributor.py
+++ b/ocean_lib/models/vetest/test_ve_fee_distributor.py
@@ -16,4 +16,3 @@ def test1(config, ve_fee_distributor, consumer_wallet):
 
     # this is the most important call from a user standpoint. $$ :)
     ve_fee_distributor.claim({"from": consumer_wallet})
-

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -25,7 +25,7 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     alice_wallet = accounts.add()  # new account avoids "withdraw old tokens first"
     factory_deployer_wallet.transfer(alice_wallet, "0.001 ether")
-    
+
     TA = to_wei(0.0001)
     OCEAN.mint(alice_wallet.address, TA, {"from": factory_deployer_wallet})
 

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -1,0 +1,64 @@
+#
+# Copyright 2022 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import brownie
+import pytest
+
+from ocean_lib.models.ve_ocean import VeOcean
+from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
+from ocean_lib.ocean.util import get_address_of_type
+from ocean_lib.web3_internal.currency import to_wei
+
+
+def from_wei(amt_wei: int) -> float:
+    return float(amt_wei / 1e18)
+
+
+chain = brownie.network.chain
+accounts = brownie.network.accounts
+WEEK = 7 * 86400
+MAXTIME = 4 * 365 * 86400  # 4 years
+
+
+@pytest.mark.unit
+def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
+    # inspiration from df-py/util/test/veOcean/test_lock.py
+    assert veOCEAN.symbol() == "veOCEAN"
+
+    OCEAN = ocean_token
+
+    alice_wallet = accounts.add()  # new account avoids "withdraw old tokens first"
+    TA = to_wei(10)
+    OCEAN.mint(alice_wallet.address, TA, from_wallet=factory_deployer_wallet)
+
+    veOCEAN.checkpoint({"from": factory_deployer_wallet})
+    OCEAN.approve(veOCEAN.address, TA, alice_wallet)
+
+    t0 = chain.time()
+    t1 = t0 // WEEK * WEEK + WEEK  # this is a Thursday, because Jan 1 1970 was
+    t2 = t1 + WEEK
+    chain.sleep(t1 - t0)
+
+    assert OCEAN.balanceOf(alice_wallet.address) != 0
+
+    veOCEAN.create_lock(TA, t2, {"from": alice_wallet})
+
+    assert OCEAN.balanceOf(alice_wallet.address) == 0
+
+    epoch = veOCEAN.user_point_epoch(alice_wallet)
+    assert epoch != 0
+
+    assert veOCEAN.get_last_user_slope(alice_wallet) != 0
+    alice_vote_power = from_wei(veOCEAN.balanceOf(alice_wallet, chain.time()))
+    expected_vote_power = from_wei(TA) * WEEK / MAXTIME
+    assert alice_vote_power == pytest.approx(expected_vote_power, 0.5)
+
+    brownie.network.chain.sleep(t2)
+    chain.mine()
+
+    veOCEAN.withdraw({"from": alice_wallet})
+    assert OCEAN.balanceOf(alice_wallet.address) == TA
+
+    assert veOCEAN.get_last_user_slope(alice_wallet) == 0
+    assert veOCEAN.balanceOf(alice_wallet, chain.time()) == 0

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -24,7 +24,7 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     OCEAN = ocean_token
 
     alice_wallet = accounts.add()  # new account avoids "withdraw old tokens first"
-    TA = to_wei(10)
+    TA = to_wei(0.0001)
     OCEAN.mint(alice_wallet.address, TA, {"from": factory_deployer_wallet})
 
     veOCEAN.checkpoint({"from": factory_deployer_wallet})
@@ -48,7 +48,7 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     alice_vote_power = from_wei(veOCEAN.balanceOf(alice_wallet, chain.time()))
     expected_vote_power = from_wei(TA) * WEEK / MAXTIME
-    assert alice_vote_power == pytest.approx(expected_vote_power, 0.5)
+    assert alice_vote_power == pytest.approx(expected_vote_power, TA / 20.0)
 
     brownie.network.chain.sleep(t2)
     chain.mine()

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -24,6 +24,8 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     OCEAN = ocean_token
 
     alice_wallet = accounts.add()  # new account avoids "withdraw old tokens first"
+    factory_deployer_wallet.transfer(alice_wallet, "0.001 ether")
+    
     TA = to_wei(0.0001)
     OCEAN.mint(alice_wallet.address, TA, {"from": factory_deployer_wallet})
 

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -5,7 +5,6 @@
 import brownie
 import pytest
 
-from conftest import to_wei, from_wei
 from ocean_lib.models.ve_ocean import VeOcean
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
 from ocean_lib.ocean.util import get_address_of_type
@@ -59,3 +58,11 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     assert veOCEAN.get_last_user_slope(alice_wallet) == 0
     assert veOCEAN.balanceOf(alice_wallet, chain.time()) == 0
+
+
+def to_wei(amt_eth) -> int:
+    return int(amt_eth * 1e18)
+
+
+def from_wei(amt_wei: int) -> float:
+    return float(amt_wei / 1e18)

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -8,11 +8,6 @@ import pytest
 from ocean_lib.models.ve_ocean import VeOcean
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
 from ocean_lib.ocean.util import get_address_of_type
-from ocean_lib.web3_internal.currency import to_wei
-
-
-def from_wei(amt_wei: int) -> float:
-    return float(amt_wei / 1e18)
 
 
 chain = brownie.network.chain
@@ -30,10 +25,10 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     alice_wallet = accounts.add()  # new account avoids "withdraw old tokens first"
     TA = to_wei(10)
-    OCEAN.mint(alice_wallet.address, TA, from_wallet=factory_deployer_wallet)
+    OCEAN.mint(alice_wallet.address, TA, {"from": factory_deployer_wallet})
 
     veOCEAN.checkpoint({"from": factory_deployer_wallet})
-    OCEAN.approve(veOCEAN.address, TA, alice_wallet)
+    OCEAN.approve(veOCEAN.address, TA, {"from": alice_wallet})
 
     t0 = chain.time()
     t1 = t0 // WEEK * WEEK + WEEK  # this is a Thursday, because Jan 1 1970 was
@@ -50,6 +45,7 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     assert epoch != 0
 
     assert veOCEAN.get_last_user_slope(alice_wallet) != 0
+
     alice_vote_power = from_wei(veOCEAN.balanceOf(alice_wallet, chain.time()))
     expected_vote_power = from_wei(TA) * WEEK / MAXTIME
     assert alice_vote_power == pytest.approx(expected_vote_power, 0.5)
@@ -62,3 +58,11 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     assert veOCEAN.get_last_user_slope(alice_wallet) == 0
     assert veOCEAN.balanceOf(alice_wallet, chain.time()) == 0
+
+
+def to_wei(amt_eth) -> int:
+    return int(amt_eth * 1e18)
+
+
+def from_wei(amt_wei: int) -> float:
+    return float(amt_wei / 1e18)

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -24,7 +24,7 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     OCEAN = ocean_token
 
     alice_wallet = accounts.add()  # new account avoids "withdraw old tokens first"
-    factory_deployer_wallet.transfer(alice_wallet, "0.001 ether")
+    factory_deployer_wallet.transfer(alice_wallet, "0.1 ether")
 
     TA = to_wei(0.0001)
     OCEAN.mint(alice_wallet.address, TA, {"from": factory_deployer_wallet})

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -24,7 +24,7 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     OCEAN = ocean_token
 
     alice_wallet = accounts.add()  # new account avoids "withdraw old tokens first"
-    factory_deployer_wallet.transfer(alice_wallet, "0.1 ether")
+    factory_deployer_wallet.transfer(alice_wallet, "1 ether")
 
     TA = to_wei(0.0001)
     OCEAN.mint(alice_wallet.address, TA, {"from": factory_deployer_wallet})

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -5,6 +5,7 @@
 import brownie
 import pytest
 
+from conftest import to_wei, from_wei
 from ocean_lib.models.ve_ocean import VeOcean
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
 from ocean_lib.ocean.util import get_address_of_type
@@ -58,11 +59,3 @@ def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     assert veOCEAN.get_last_user_slope(alice_wallet) == 0
     assert veOCEAN.balanceOf(alice_wallet, chain.time()) == 0
-
-
-def to_wei(amt_eth) -> int:
-    return int(amt_eth * 1e18)
-
-
-def from_wei(amt_wei: int) -> float:
-    return float(amt_wei / 1e18)

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -21,6 +21,9 @@ from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.models.dispenser import Dispenser
 from ocean_lib.models.factory_router import FactoryRouter
 from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
+from ocean_lib.models.ve_ocean import VeOcean
+from ocean_lib.models.ve_allocate import VeAllocate
+from ocean_lib.models.ve_fee_distributor import VeFeeDistributor
 from ocean_lib.ocean.ocean_assets import OceanAssets
 from ocean_lib.ocean.ocean_compute import OceanCompute
 from ocean_lib.ocean.util import get_address_of_type, get_ocean_token_address
@@ -299,3 +302,25 @@ class Ocean:
         )
 
         return initialize_compute_response.json()
+
+
+    @property
+    @enforce_types
+    def ve_ocean(self):
+        return VeOcean(
+            self.config_dict, get_address_of_type(self.config_dict, "veOCEAN")
+        )
+
+    @property
+    @enforce_types
+    def ve_allocate(self):
+        return VeAllocate(
+            self.config_dict, get_address_of_type(self.config_dict, "veAllocate")
+        )
+
+    @property
+    @enforce_types
+    def ve_fee_distributor(self):
+        return VeFeeDistributor(
+            self.config_dict, get_address_of_type(self.config_dict, "veFeeDistributor")
+        )

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -303,7 +303,6 @@ class Ocean:
 
         return initialize_compute_response.json()
 
-
     @property
     @enforce_types
     def ve_ocean(self):

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -266,7 +266,7 @@ class OceanAssets:
     ) -> tuple:
         """Create an asset of type "UrlFile", with good defaults"""
         files = [UrlFile(url)]
-        return self._create1(name, files, publisher_wallet)
+        return self._create1(name, files, publisher_wallet, wait_for_aqua)
 
     @enforce_types
     def create_graphql_asset(
@@ -279,7 +279,7 @@ class OceanAssets:
     ) -> tuple:
         """Create an asset of type "GraphqlQuery", with good defaults"""
         files = [GraphqlQuery(url, query)]
-        return self._create1(name, files, publisher_wallet)
+        return self._create1(name, files, publisher_wallet, wait_for_aqua)
 
     @enforce_types
     def create_onchain_asset(
@@ -294,7 +294,7 @@ class OceanAssets:
         chain_id = self._chain_id
         onchain_data = SmartContractCall(contract_address, chain_id, contract_abi)
         files = [onchain_data]
-        return self._create1(name, files, publisher_wallet)
+        return self._create1(name, files, publisher_wallet, wait_for_aqua)
 
     @enforce_types
     def _create1(

--- a/ocean_lib/ocean/test/test_ocean.py
+++ b/ocean_lib/ocean/test/test_ocean.py
@@ -35,20 +35,19 @@ def test_nft_factory(data_nft, datatoken, publisher_ocean_instance, publisher_wa
     assert created_nft.address
     assert created_nft.tokenURI(1) == "http://oceanprotocol.com/nft"
 
-    
+
 @pytest.mark.unit
 def test_contract_objects(publisher_ocean_instance):
     ocn = publisher_ocean_instance
-    
+
     assert ocn.OCEAN_address[:2] == "0x"
     assert isinstance(ocn.OCEAN_token, Datatoken)
     assert isinstance(ocn.get_nft_factory(), DataNFTFactoryContract)
-        
+
     assert isinstance(ocn.dispenser, Dispenser)
     assert isinstance(ocn.fixed_rate_exchange, FixedRateExchange)
     assert isinstance(ocn.factory_router, FactoryRouter)
-    
+
     assert isinstance(ocn.ve_ocean, VeOcean)
     assert isinstance(ocn.ve_allocate, VeAllocate)
     assert isinstance(ocn.ve_fee_distributor, VeFeeDistributor)
-    

--- a/ocean_lib/ocean/test/test_ocean.py
+++ b/ocean_lib/ocean/test/test_ocean.py
@@ -5,6 +5,14 @@
 import pytest
 
 from ocean_lib.models.data_nft import DataNFT
+from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
+from ocean_lib.models.datatoken import Datatoken
+from ocean_lib.models.dispenser import Dispenser
+from ocean_lib.models.factory_router import FactoryRouter
+from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
+from ocean_lib.models.ve_ocean import VeOcean
+from ocean_lib.models.ve_allocate import VeAllocate
+from ocean_lib.models.ve_fee_distributor import VeFeeDistributor
 
 
 @pytest.mark.unit
@@ -26,3 +34,21 @@ def test_nft_factory(data_nft, datatoken, publisher_ocean_instance, publisher_wa
     assert created_nft.symbol() == "TEST2"
     assert created_nft.address
     assert created_nft.tokenURI(1) == "http://oceanprotocol.com/nft"
+
+    
+@pytest.mark.unit
+def test_contract_objects(publisher_ocean_instance):
+    ocn = publisher_ocean_instance
+    
+    assert ocn.OCEAN_address[:2] == "0x"
+    assert isinstance(ocn.OCEAN_token, Datatoken)
+    assert isinstance(ocn.get_nft_factory(), DataNFTFactoryContract)
+        
+    assert isinstance(ocn.dispenser, Dispenser)
+    assert isinstance(ocn.fixed_rate_exchange, FixedRateExchange)
+    assert isinstance(ocn.factory_router, FactoryRouter)
+    
+    assert isinstance(ocn.ve_ocean, VeOcean)
+    assert isinstance(ocn.ve_allocate, VeAllocate)
+    assert isinstance(ocn.ve_fee_distributor, VeFeeDistributor)
+    

--- a/tests/readmes/test_readmes.py
+++ b/tests/readmes/test_readmes.py
@@ -17,12 +17,14 @@ def test_script_execution(script, monkeypatch):
 
     if (
         "developers" in script.name
+        or "df" in script.name
         or "publish-flow" in script.name
         or "data-nfts-and-datatokens-flow" in script.name
         or "c2d-flow-more-examples" in script.name
         or "parameters" in script.name
     ):
         # developers.md skipped because it does not have end-to-end Python snippets, just console
+        # df.md -- ditto
         # data-nfts-and-datatokens-flow.md and publish-flow skipped because it they run as prerequisites for the others, so they are tested implicitly
         # c2d-flow-more-examples skipped because it can not be parsed separately from c2d-flow
         return


### PR DESCRIPTION
Fixes:
- [ocean.py#916](https://github.com/oceanprotocol/ocean.py/issues/916) "Expose VE & DF functionality into ocean.py"
- [df-private#27](https://github.com/oceanprotocol/df-private/issues/27) "Democratize wash consume"

