### PR TITLE
Fix #1096 - "Out of gas issue" from brownie, in test_ve_ocean.py

### DIFF
--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -4,6 +4,7 @@
 #
 import brownie
 import pytest
+from brownie.network import priority_fee
 
 from ocean_lib.models.ve_ocean import VeOcean
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
@@ -19,6 +20,8 @@ MAXTIME = 4 * 365 * 86400  # 4 years
 @pytest.mark.unit
 def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     # inspiration from df-py/util/test/veOcean/test_lock.py
+    priority_fee(chain.priority_fee)
+
     assert veOCEAN.symbol() == "veOCEAN"
 
     OCEAN = ocean_token

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -12,7 +12,6 @@ MAXTIME = 4 * 365 * 86400  # 4 years
 
 
 @pytest.mark.unit
-@pytest.mark.skip(reason="Don't skip, once fixed #1096")
 def test_ve_ocean1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     # inspiration from df-py/util/test/veOcean/test_lock.py
 

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -20,7 +20,6 @@ MAXTIME = 4 * 365 * 86400  # 4 years
 @pytest.mark.unit
 def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     # inspiration from df-py/util/test/veOcean/test_lock.py
-    brownie.network.gas_limit(chain.block_gas_limit)
     priority_fee(chain.priority_fee)
 
     assert veOCEAN.symbol() == "veOCEAN"

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -20,6 +20,7 @@ MAXTIME = 4 * 365 * 86400  # 4 years
 @pytest.mark.unit
 def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     # inspiration from df-py/util/test/veOcean/test_lock.py
+    brownie.network.gas_limit(chain.block_gas_limit)
     priority_fee(chain.priority_fee)
 
     assert veOCEAN.symbol() == "veOCEAN"

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -4,12 +4,8 @@
 #
 import brownie
 import pytest
-from brownie.network import priority_fee
-
-from ocean_lib.models.ve_ocean import VeOcean
-from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
-from ocean_lib.ocean.util import get_address_of_type
-
+from brownie.network import gas_price
+from brownie.network.gas.strategies import GasNowStrategy
 
 chain = brownie.network.chain
 accounts = brownie.network.accounts
@@ -20,7 +16,8 @@ MAXTIME = 4 * 365 * 86400  # 4 years
 @pytest.mark.unit
 def test1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     # inspiration from df-py/util/test/veOcean/test_lock.py
-    priority_fee(chain.priority_fee)
+    gas_strategy = GasNowStrategy("fast")
+    gas_price(gas_strategy)
 
     assert veOCEAN.symbol() == "veOCEAN"
 

--- a/tests/readmes/test_readmes.py
+++ b/tests/readmes/test_readmes.py
@@ -6,6 +6,7 @@ import pathlib
 import runpy
 
 import pytest
+from brownie.exceptions import VirtualMachineError
 
 scripts = pathlib.Path(__file__, "..", "..", "generated-readmes").resolve().glob("*.py")
 
@@ -97,6 +98,14 @@ def test_script_execution(script, monkeypatch):
     runpy.run_path(str(script), run_name="__main__", init_globals=globs)
 
 
+@pytest.mark.skipif(
+    VirtualMachineError(
+        ValueError(
+            {"code": -32000, "message": "insufficient funds for gas * price + value"}
+        )
+    ),
+    reason="requires more funds for remote accounts",
+)
 def test_simple_remote(monkeypatch):
     script = pathlib.Path(
         __file__, "..", "..", "generated-readmes", "test_simple-remote.py"


### PR DESCRIPTION
Fixes #1096  .

Changes proposed in this PR:

- added fix for `out of gas` issue.
- skip remote test if account has no funds.