### PR TITLE
In test_ve_ocean.py: replace custom "to_wei", "from_wei" --> "Web3.toWei", "Web.fromWei"  

### DIFF
--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -18,6 +18,7 @@ MAXTIME = 4 * 365 * 86400  # 4 years
 
 
 @pytest.mark.unit
+@pytest.mark.skip(reason="Don't skip, once fixed #1096")
 def test_ve_ocean1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     # inspiration from df-py/util/test/veOcean/test_lock.py
     assert veOCEAN.symbol() == "veOCEAN"

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -4,6 +4,7 @@
 #
 import brownie
 import pytest
+from web3 import Web3
 
 from ocean_lib.models.ve_ocean import VeOcean
 from ocean_lib.ocean.mint_fake_ocean import mint_fake_OCEAN
@@ -17,7 +18,6 @@ MAXTIME = 4 * 365 * 86400  # 4 years
 
 
 @pytest.mark.unit
-@pytest.mark.skip(reason="Don't skip, once fixed #1096")
 def test_ve_ocean1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     # inspiration from df-py/util/test/veOcean/test_lock.py
     assert veOCEAN.symbol() == "veOCEAN"
@@ -27,7 +27,7 @@ def test_ve_ocean1(config, factory_deployer_wallet, ocean_token, veOCEAN):
     alice_wallet = accounts.add()  # new account avoids "withdraw old tokens first"
     factory_deployer_wallet.transfer(alice_wallet, "1 ether")
 
-    TA = to_wei(0.0001)
+    TA = Web3.toWei(0.0001, "ether")
     OCEAN.mint(alice_wallet.address, TA, {"from": factory_deployer_wallet})
 
     veOCEAN.checkpoint({"from": factory_deployer_wallet})
@@ -49,8 +49,8 @@ def test_ve_ocean1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     assert veOCEAN.get_last_user_slope(alice_wallet) != 0
 
-    alice_vote_power = from_wei(veOCEAN.balanceOf(alice_wallet, chain.time()))
-    expected_vote_power = from_wei(TA) * WEEK / MAXTIME
+    alice_vote_power = float(Web3.fromWei(veOCEAN.balanceOf(alice_wallet, chain.time()), "ether"))
+    expected_vote_power = float(Web3.fromWei(TA, "ether")) * WEEK / MAXTIME
     assert alice_vote_power == pytest.approx(expected_vote_power, TA / 20.0)
 
     brownie.network.chain.sleep(t2)
@@ -61,11 +61,3 @@ def test_ve_ocean1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     assert veOCEAN.get_last_user_slope(alice_wallet) == 0
     assert veOCEAN.balanceOf(alice_wallet, chain.time()) == 0
-
-
-def to_wei(amt_eth) -> int:
-    return int(amt_eth * 1e18)
-
-
-def from_wei(amt_wei: int) -> float:
-    return float(amt_wei / 1e18)

--- a/ocean_lib/models/vetest/test_ve_ocean.py
+++ b/ocean_lib/models/vetest/test_ve_ocean.py
@@ -49,7 +49,9 @@ def test_ve_ocean1(config, factory_deployer_wallet, ocean_token, veOCEAN):
 
     assert veOCEAN.get_last_user_slope(alice_wallet) != 0
 
-    alice_vote_power = float(Web3.fromWei(veOCEAN.balanceOf(alice_wallet, chain.time()), "ether"))
+    alice_vote_power = float(
+        Web3.fromWei(veOCEAN.balanceOf(alice_wallet, chain.time()), "ether")
+    )
     expected_vote_power = float(Web3.fromWei(TA, "ether")) * WEEK / MAXTIME
     assert alice_vote_power == pytest.approx(expected_vote_power, TA / 20.0)
 


### PR DESCRIPTION
This was an attempt to fix #1096 - brownie gas error on test_ve_ocean.py.

The approach: test a completely different hypothesis: 
- hypothesis: "the custom `to_wei()` and `from_wei()` have a bug, pushing some numbers the wrong direction and eating up tokens or gas"
- to test:  convert the custom implementation to using off-the-shelf `Web3.toWei()` and `Web3.fromWei()`

Results with local testing, in sequence:
1.test locally with changes (with toWei/fromWei): it passes
2. re-start barge: it fails
3. with same barge: it passes
4. with same barge, and changes reverted (with to_wei/from_wei): it fails with "ValueError: Gas estimation failed: 'VM Exception while processing transaction: revert Can only lock until time in the future'. This transaction will likely revert. If you wish to broadcast, you must set the gas limit manually."
5. with same barge, and changes reverted (with to_wei/from_wei): failure like previous
6. with same barge, back with changes (with toWei/fromWei): failure like previous

Summary: the change didn't help fix the test.

However, it _is_ better to avoid custom to_wei / from_wei. So I am propagating those changes back to main.