### PR TITLE
Publish algos with default metadata including docker

### DIFF
--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -107,40 +107,11 @@ In the same Python console:
 ALGO_url = "https://raw.githubusercontent.com/oceanprotocol/c2d-examples/main/branin_and_gpr/gpr.py"
 
 name = "grp"
-(ALGO_data_nft, ALGO_datatoken, ALGO_ddo) = ocean.assets.create_url_asset(name, ALGO_url, alice_wallet, wait_for_aqua=True)
+ALGO_container = "python"
+(ALGO_data_nft, ALGO_datatoken, ALGO_asset) = ocean.assets.create_url_algo(name, ALGO_url, alice_wallet, ALGO_container)
 
 print(f"ALGO_data_nft address = '{ALGO_data_nft.address}'")
 print(f"ALGO_datatoken address = '{ALGO_datatoken.address}'")
-
-# Specify metadata and services, using the Branin test dataset
-ALGO_date_created = "2021-12-28T10:55:11Z"
-ALGO_metadata = {
-    "created": ALGO_date_created,
-    "updated": ALGO_date_created,
-    "description": "gpr",
-    "name": "gpr",
-    "type": "algorithm",
-    "author": "Trent",
-    "license": "CC0: PublicDomain",
-    "algorithm": {
-        "language": "python",
-        "format": "docker-image",
-        "version": "0.1",
-        "container": {
-            "entrypoint": "python $ALGO",
-            "image": "oceanprotocol/algo_dockers",
-            "tag": "python-branin",
-            "checksum": "sha256:8221d20c1c16491d7d56b9657ea09082c0ee4a8ab1a6621fa720da58b09580e4",
-        },
-    }
-}
-
-# update ALGO_Asset metadata
-ALGO_ddo.metadata.update(ALGO_metadata)
-ALGO_ddo = ocean.assets.update(
-    asset=ALGO_ddo, publisher_wallet=alice_wallet, provider_uri=config["PROVIDER_URL"])
-    
-
 print(f"ALGO_ddo did = '{ALGO_ddo.did}'")
 ```
 

--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -105,9 +105,9 @@ In the same Python console:
 ```python
 # Publish data NFT & datatoken for algorithm
 ALGO_url = "https://raw.githubusercontent.com/oceanprotocol/c2d-examples/main/branin_and_gpr/gpr.py"
-
 name = "grp"
 ALGO_container = "python"
+
 (ALGO_data_nft, ALGO_datatoken, ALGO_asset) = ocean.assets.create_url_algo(name, ALGO_url, alice_wallet, ALGO_container)
 
 print(f"ALGO_data_nft address = '{ALGO_data_nft.address}'")

--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -112,7 +112,7 @@ ALGO_container = "python"
 
 print(f"ALGO_data_nft address = '{ALGO_data_nft.address}'")
 print(f"ALGO_datatoken address = '{ALGO_datatoken.address}'")
-print(f"ALGO_ddo did = '{ALGO_ddo.did}'")
+print(f"ALGO_asset did = '{ALGO_asset.did}'")
 ```
 
 ## 4. Alice allows the algorithm for C2D for that data asset

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -330,8 +330,8 @@ class OceanAssets:
             "license": "CC0: PublicDomain",
         }
         if container == 'python':
-            metadata['type']: "algorithm"
-            metadata['algorithm'] = {
+            metadata["type"] = "algorithm"
+            metadata["algorithm"] = {
                 "language": "python",
                 "format": "docker-image",
                 "version": "0.1",

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -295,7 +295,15 @@ class OceanAssets:
         onchain_data = SmartContractCall(contract_address, chain_id, contract_abi)
         files = [onchain_data]
         return self._create1(name, files, publisher_wallet, wait_for_aqua)
-
+    
+    @enforce_types
+    def create_url_algo(
+        self, name: str, url: str, publisher_wallet, container: str, wait_for_aqua: bool = True
+    ) -> tuple:
+        """Create an algo of type "UrlFile", with good defaults"""
+        files = [UrlFile(url)]
+        return self._create1(name, files, publisher_wallet, wait_for_aqua, container)
+    
     @enforce_types
     def _create1(
         self,
@@ -303,6 +311,7 @@ class OceanAssets:
         files: list,
         publisher_wallet,
         wait_for_aqua: bool = True,
+        container: str = '',
     ) -> tuple:
         """Thin wrapper for create(). Creates 1 datatoken, with good defaults.
 
@@ -319,6 +328,19 @@ class OceanAssets:
             "type": "dataset",
             "author": publisher_wallet.address[:7],
             "license": "CC0: PublicDomain",
+        }
+        if container == 'python':
+            metadata['type']: "algorithm"
+            metadata['algorithm'] = {
+                "language": "python",
+                "format": "docker-image",
+                "version": "0.1",
+                "container": {
+                "entrypoint": "python $ALGO",
+                "image": "oceanprotocol/algo_dockers",
+                "tag": "python-branin",
+                "checksum": "sha256:8221d20c1c16491d7d56b9657ea09082c0ee4a8ab1a6621fa720da58b09580e4",
+                },
         }
 
         OCEAN_address = get_ocean_token_address(self._config_dict)


### PR DESCRIPTION
Fixes #1108 .

Changes proposed in this PR:

- There are different types of algos and different types of containers - leave a structure that can be expanded later on
- The start of a new group of functions. The first one of these is "create_url_algo". It is similar to create_url_asset but includes an argument named "container" that in this first case the parameter is set to "python". Other param values can be added later in the future
- the "create_url_algo" parameter is subsequently added to the create1 wrapper to account for additional metadata defaults (this also can be easily expanded later)