### PR TITLE
Remove duplicate create_erc20 and deploy_datatoken functions.

### DIFF
--- a/READMEs/data-nfts-and-datatokens-flow.md
+++ b/READMEs/data-nfts-and-datatokens-flow.md
@@ -64,7 +64,7 @@ In the same Python console:
 ```python
 # Create datatoken related to the above NFT.
 
-datatoken = data_nft.create_datatoken("Datatoken 1", "DT1", from_wallet=alice_wallet)
+datatoken = data_nft.create_datatoken("Datatoken 1", "DT1", {"from": alice_wallet})
 print(f"Created datatoken. Its address is {datatoken.address}")
 ```
 

--- a/conftest_ganache.py
+++ b/conftest_ganache.py
@@ -10,7 +10,6 @@ from ocean_lib.aquarius.aquarius import Aquarius
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
 from ocean_lib.models.datatoken import Datatoken
-from ocean_lib.models.datatoken_enterprise import DatatokenEnterprise
 from ocean_lib.models.factory_router import FactoryRouter
 from ocean_lib.ocean.util import get_address_of_type
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
@@ -166,7 +165,7 @@ def data_nft(config, publisher_wallet, data_nft_factory):
 
 @pytest.fixture
 def datatoken(config, data_nft, publisher_wallet, data_nft_factory):
-    receipt = data_nft.create_erc20(
+    return data_nft.create_datatoken(
         template_index=1,
         name="DT1",
         symbol="DT1Symbol",
@@ -179,14 +178,10 @@ def datatoken(config, data_nft, publisher_wallet, data_nft_factory):
         transaction_parameters={"from": publisher_wallet},
     )
 
-    dt_address = receipt.events["TokenCreated"]["newTokenAddress"]
-
-    return Datatoken(config, dt_address)
-
 
 @pytest.fixture
 def datatoken_enterprise_token(config, data_nft, publisher_wallet, data_nft_factory):
-    receipt = data_nft.create_erc20(
+    return data_nft.create_datatoken(
         template_index=2,
         name="DT1",
         symbol="DT1Symbol",
@@ -199,10 +194,6 @@ def datatoken_enterprise_token(config, data_nft, publisher_wallet, data_nft_fact
         transaction_parameters={"from": publisher_wallet},
         datatoken_cap=Web3.toWei(100, "ether"),
     )
-
-    dt_address = receipt.events["TokenCreated"]["newTokenAddress"]
-
-    return DatatokenEnterprise(config, dt_address)
 
 
 @pytest.fixture

--- a/ocean_lib/models/test/test_data_nft_factory.py
+++ b/ocean_lib/models/test/test_data_nft_factory.py
@@ -72,7 +72,7 @@ def test_main(
 
     # Tests creating successfully an ERC20 token
     data_nft.addToCreateERC20List(consumer_wallet.address, {"from": publisher_wallet})
-    receipt = data_nft.create_erc20(
+    receipt = data_nft.create_datatoken(
         template_index=1,
         name="DT1",
         symbol="DT1Symbol",
@@ -83,6 +83,7 @@ def test_main(
         publish_market_order_fee_amount=0,
         bytess=[b""],
         transaction_parameters={"from": consumer_wallet},
+        wrap_as_object=False,
     )
     assert receipt, "Failed to create ERC20 token."
     registered_token_event = receipt.events["TokenCreated"]
@@ -148,7 +149,7 @@ def test_main(
     fixed_rate_address = get_address_of_type(config, "FixedPrice")
 
     # Create ERC20 data token for fees.
-    receipt = data_nft.create_erc20(
+    receipt = data_nft.create_datatoken(
         template_index=1,
         name="DT1P",
         symbol="DT1SymbolP",
@@ -159,6 +160,7 @@ def test_main(
         publish_market_order_fee_amount=Web3.toWei("0.0005", "ether"),
         bytess=[b""],
         transaction_parameters={"from": publisher_wallet},
+        wrap_as_object=False,
     )
     assert receipt, "Failed to create ERC20 token."
     registered_fee_token_event = receipt.events["TokenCreated"]
@@ -358,7 +360,7 @@ def test_start_multiple_order(
 
     # Tests creating successfully an ERC20 token
     data_nft.addToCreateERC20List(consumer_wallet.address, {"from": publisher_wallet})
-    receipt = data_nft.create_erc20(
+    receipt = data_nft.create_datatoken(
         template_index=1,
         name="DT1",
         symbol="DT1Symbol",
@@ -369,6 +371,7 @@ def test_start_multiple_order(
         publish_market_order_fee_amount=0,
         bytess=[b""],
         transaction_parameters={"from": consumer_wallet},
+        wrap_as_object=False,
     )
     assert receipt, "Failed to create ERC20 token."
     registered_token_event = receipt.events["TokenCreated"]
@@ -481,7 +484,7 @@ def test_fail_get_templates(config):
 
 
 @pytest.mark.unit
-def test_fail_create_erc20(
+def test_fail_create_datatoken(
     config, publisher_wallet, consumer_wallet, another_consumer_wallet
 ):
     """Tests multiple failures for creating ERC20 token."""
@@ -510,7 +513,7 @@ def test_fail_create_erc20(
 
     # Should fail to create a specific ERC20 Template if the index is ZERO
     with pytest.raises(Exception, match="Template index doesnt exist"):
-        data_nft.create_erc20(
+        data_nft.create_datatoken(
             template_index=0,
             name="DT1",
             symbol="DT1Symbol",
@@ -525,7 +528,7 @@ def test_fail_create_erc20(
 
     # Should fail to create a specific ERC20 Template if the index doesn't exist
     with pytest.raises(Exception, match="Template index doesnt exist"):
-        data_nft.create_erc20(
+        data_nft.create_datatoken(
             template_index=3,
             name="DT1",
             symbol="DT1Symbol",
@@ -541,7 +544,7 @@ def test_fail_create_erc20(
     # Should fail to create a specific ERC20 Template if the user is not added on the ERC20 deployers list
     assert data_nft.getPermissions(another_consumer_wallet.address)[1] is False
     with pytest.raises(Exception, match="NOT ERC20DEPLOYER_ROLE"):
-        data_nft.create_erc20(
+        data_nft.create_datatoken(
             template_index=1,
             name="DT1",
             symbol="DT1Symbol",

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -136,41 +136,6 @@ class OceanAssets:
         )
 
     @enforce_types
-    def deploy_datatoken(
-        self,
-        data_nft_factory: DataNFTFactoryContract,
-        data_nft: DataNFT,
-        template_index: int,
-        name: str,
-        symbol: str,
-        minter: str,
-        fee_manager: str,
-        publish_market_order_fee_address: str,
-        publish_market_order_fee_token: str,
-        publish_market_order_fee_amount: int,
-        bytess: List[bytes],
-        from_wallet,
-    ) -> str:
-        receipt = data_nft.create_erc20(
-            template_index=template_index,
-            name=name,
-            symbol=symbol,
-            minter=minter,
-            fee_manager=fee_manager,
-            publish_market_order_fee_address=publish_market_order_fee_address,
-            publish_market_order_fee_token=publish_market_order_fee_token,
-            publish_market_order_fee_amount=publish_market_order_fee_amount,
-            bytess=bytess,
-            transaction_parameters={"from": from_wallet},
-        )
-        assert receipt, "Failed to create ERC20 token."
-
-        registered_token_event = receipt.events["TokenCreated"]
-        assert registered_token_event, "Cannot find TokenCreated event."
-
-        return registered_token_event["newTokenAddress"]
-
-    @enforce_types
     def find_service_by_datatoken(self, datatoken: str, services: list) -> str:
         return next(
             (service.id for service in services if service.datatoken == datatoken), None
@@ -512,28 +477,24 @@ class OceanAssets:
 
         if not deployed_datatokens:
             for datatoken_data_counter in range(len(datatoken_templates)):
-                datatoken_addresses.append(
-                    self.deploy_datatoken(
-                        data_nft_factory=data_nft_factory,
-                        data_nft=data_nft,
-                        template_index=datatoken_templates[datatoken_data_counter],
-                        name=datatoken_names[datatoken_data_counter],
-                        symbol=datatoken_symbols[datatoken_data_counter],
-                        minter=datatoken_minters[datatoken_data_counter],
-                        fee_manager=datatoken_fee_managers[datatoken_data_counter],
-                        publish_market_order_fee_address=datatoken_publish_market_order_fee_addresses[
-                            datatoken_data_counter
-                        ],
-                        publish_market_order_fee_token=datatoken_publish_market_order_fee_tokens[
-                            datatoken_data_counter
-                        ],
-                        publish_market_order_fee_amount=datatoken_publish_market_order_fee_amounts[
-                            datatoken_data_counter
-                        ],
-                        bytess=datatoken_bytess[datatoken_data_counter],
-                        from_wallet=publisher_wallet,
-                    )
+                temp_dt = data_nft.create_datatoken(
+                    template_index=datatoken_templates[datatoken_data_counter],
+                    name=datatoken_names[datatoken_data_counter],
+                    symbol=datatoken_symbols[datatoken_data_counter],
+                    minter=datatoken_minters[datatoken_data_counter],
+                    fee_manager=datatoken_fee_managers[datatoken_data_counter],
+                    publish_market_order_fee_address=datatoken_publish_market_order_fee_addresses[
+                        datatoken_data_counter
+                    ],
+                    publish_market_order_fee_token=datatoken_publish_market_order_fee_tokens[
+                        datatoken_data_counter
+                    ],
+                    publish_market_order_fee_amount=datatoken_publish_market_order_fee_amounts[
+                        datatoken_data_counter
+                    ],
+                    transaction_parameters={"from": publisher_wallet},
                 )
+                datatoken_addresses.append(temp_dt.address)
                 logger.info(
                     f"Successfully created datatoken with address "
                     f"{datatoken_addresses[-1]}."

--- a/tests/flows/test_nft_creation.py
+++ b/tests/flows/test_nft_creation.py
@@ -216,7 +216,7 @@ def test_datatoken_creation(
     token_address = receipt.events["NFTCreated"]["newTokenAddress"]
     data_nft = DataNFT(config, token_address)
     data_nft.addToCreateERC20List(consumer_wallet.address, {"from": publisher_wallet})
-    tx_result = data_nft.create_erc20(
+    tx_result = data_nft.create_datatoken(
         template_index=1,
         name="DT1",
         symbol="DT1Symbol",
@@ -239,7 +239,7 @@ def test_datatoken_creation(
 
     # Tests failed creation of datatoken
     with pytest.raises(Exception, match="NOT ERC20DEPLOYER_ROLE"):
-        data_nft.create_erc20(
+        data_nft.create_datatoken(
             template_index=1,
             name="DT1",
             symbol="DT1Symbol",
@@ -325,7 +325,7 @@ def test_nft_owner_transfer(
     assert data_nft.ownerOf(1) == consumer_wallet.address
     # Owner is not NFT owner anymore, nor has any other role, neither older users
     with pytest.raises(Exception, match="NOT ERC20DEPLOYER_ROLE"):
-        data_nft.create_erc20(
+        data_nft.create_datatoken(
             template_index=1,
             name="DT1",
             symbol="DT1Symbol",
@@ -342,7 +342,7 @@ def test_nft_owner_transfer(
         datatoken.mint(publisher_wallet.address, 10, {"from": publisher_wallet})
 
     # NewOwner now owns the NFT, is already Manager by default and has all roles
-    data_nft.create_erc20(
+    data_nft.create_datatoken(
         template_index=1,
         name="DT1",
         symbol="DT1Symbol",
@@ -353,6 +353,7 @@ def test_nft_owner_transfer(
         publish_market_order_fee_amount=0,
         bytess=[b""],
         transaction_parameters={"from": consumer_wallet},
+        wrap_as_object=False,
     )
     datatoken.addMinter(consumer_wallet.address, {"from": consumer_wallet})
 

--- a/tests/flows/test_start_order_fees.py
+++ b/tests/flows/test_start_order_fees.py
@@ -237,7 +237,7 @@ def create_asset_with_order_fee_and_timeout(
         publish_market_order_fee_token=publish_market_order_fee_token,
         publish_market_order_fee_amount=publish_market_order_fee_amount,
         bytess=[b""],
-        from_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
     )
 
     data_provider = DataServiceProvider

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -188,7 +188,7 @@ def deploy_erc721_erc20(
     if not datatoken_minter:
         return data_nft
 
-    tx_receipt2 = data_nft.create_erc20(
+    datatoken = data_nft.create_datatoken(
         template_index=template_index,
         name="DT1",
         symbol="DT1Symbol",
@@ -200,11 +200,6 @@ def deploy_erc721_erc20(
         bytess=[b""],
         transaction_parameters={"from": data_nft_publisher},
     )
-
-    registered_event2 = tx_receipt2.events["TokenCreated"]
-    datatoken_address = registered_event2["newTokenAddress"]
-
-    datatoken = Datatoken(config_dict, datatoken_address)
 
     return data_nft, datatoken
 


### PR DESCRIPTION
Closes #1100

Explanations:
- removed create_erc20 entirely
- added a parameter to create_datatoken: `wrap_as_object`. When False, returns the contract call result. When True, returns the Datatoken/DatatokenEnterprise object. This was the essential difference between create_erc20 and create_datatoken,  so I replaced it with a parameter
- removed the `from_wallet` parameter from create_datatoken, replaced with `transaction_parameters` dictionary like it is for contract calls (more consistent)
- kept the defaults from create_datatoken
- removed the deploy_datatoken function in OceanAssets since it was easily repurposed as a call to `create_datatoken` instead