### PR TITLE
Fix #1094: Improve asset creation

### DIFF
--- a/READMEs/publish-flow.md
+++ b/READMEs/publish-flow.md
@@ -68,7 +68,7 @@ url_file = UrlFile(
 
 # Publish data asset
 from ocean_lib.ocean.ocean_assets import DatatokenArguments
-ddo = ocean.assets.create(
+_, _, ddo = ocean.assets.create(
     metadata,
     alice_wallet,
     datatoken_arguments=[

--- a/READMEs/publish-flow.md
+++ b/READMEs/publish-flow.md
@@ -67,20 +67,15 @@ url_file = UrlFile(
 )
 
 # Publish data asset
-from ocean_lib.web3_internal.constants import ZERO_ADDRESS
+from ocean_lib.ocean.ocean_assets import DatatokenArguments
 ddo = ocean.assets.create(
     metadata,
     alice_wallet,
-    [url_file],
-    datatoken_templates=[1],
-    datatoken_names=["Datatoken 1"],
-    datatoken_symbols=["DT1"],
-    datatoken_minters=[alice_wallet.address],
-    datatoken_fee_managers=[alice_wallet.address],
-    datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-    datatoken_publish_market_order_fee_tokens=[ocean.OCEAN_address],
-    datatoken_publish_market_order_fee_amounts=[0],
-    datatoken_bytess=[[b""]],
+    datatoken_arguments=[
+        DatatokenArguments(
+            name="Datatoken 1", symbol="DT1", files=[url_file]
+        )
+    ],
 )
 print(f"Just published asset, with did={ddo.did}")
 ```

--- a/READMEs/publish-flow.md
+++ b/READMEs/publish-flow.md
@@ -71,11 +71,7 @@ from ocean_lib.ocean.ocean_assets import DatatokenArguments
 _, _, ddo = ocean.assets.create(
     metadata,
     alice_wallet,
-    datatoken_arguments=[
-        DatatokenArguments(
-            name="Datatoken 1", symbol="DT1", files=[url_file]
-        )
-    ],
+    datatoken_args=[DatatokenArguments(files=[url_file])],
 )
 print(f"Just published asset, with did={ddo.did}")
 ```

--- a/ocean_lib/aquarius/test/test_aquarius.py
+++ b/ocean_lib/aquarius/test/test_aquarius.py
@@ -20,7 +20,7 @@ def test_aqua_functions_for_single_ddo(
     publisher_ocean_instance, aquarius_instance, publisher_wallet, config, file1
 ):
     """Tests against single-ddo functions of Aquarius."""
-    ddo1 = publisher_ocean_instance.assets.create_url_asset(
+    _, _, ddo1 = publisher_ocean_instance.assets.create_url_asset(
         "Sample asset", file1.url, publisher_wallet
     )
     metadata1 = ddo1.metadata

--- a/ocean_lib/aquarius/test/test_aquarius.py
+++ b/ocean_lib/aquarius/test/test_aquarius.py
@@ -6,7 +6,6 @@ import pytest
 
 from ocean_lib.aquarius.aquarius import Aquarius
 from ocean_lib.assets.ddo import DDO
-from ocean_lib.ocean.ocean_assets import DatatokenArguments
 
 
 @pytest.mark.unit
@@ -21,23 +20,10 @@ def test_aqua_functions_for_single_ddo(
     publisher_ocean_instance, aquarius_instance, publisher_wallet, config, file1
 ):
     """Tests against single-ddo functions of Aquarius."""
-    metadata1 = {
-        "created": "2020-11-15T12:27:48Z",
-        "updated": "2021-05-17T21:58:02Z",
-        "description": "Sample description",
-        "name": "Sample asset",
-        "type": "dataset",
-        "author": "OPF",
-        "license": "https://market.oceanprotocol.com/terms",
-    }
-
-    ddo1 = publisher_ocean_instance.assets.create(
-        metadata=metadata1,
-        publisher_wallet=publisher_wallet,
-        datatoken_arguments=[
-            DatatokenArguments(name="Datatoken 1", symbol="DT1", files=[file1])
-        ],
+    ddo1 = publisher_ocean_instance.assets.create_url_asset(
+        "Sample asset", file1.url, publisher_wallet
     )
+    metadata1 = ddo1.metadata
 
     ddo2 = aquarius_instance.wait_for_ddo(ddo1.did)
     assert ddo2.metadata == ddo1.metadata

--- a/ocean_lib/aquarius/test/test_aquarius.py
+++ b/ocean_lib/aquarius/test/test_aquarius.py
@@ -35,9 +35,7 @@ def test_aqua_functions_for_single_ddo(
         metadata=metadata1,
         publisher_wallet=publisher_wallet,
         datatoken_arguments=[
-            DatatokenArguments(
-                template_index=1, name="Datatoken 1", symbol="DT1", files=[file1]
-            )
+            DatatokenArguments(name="Datatoken 1", symbol="DT1", files=[file1])
         ],
     )
 

--- a/ocean_lib/aquarius/test/test_aquarius.py
+++ b/ocean_lib/aquarius/test/test_aquarius.py
@@ -6,7 +6,7 @@ import pytest
 
 from ocean_lib.aquarius.aquarius import Aquarius
 from ocean_lib.assets.ddo import DDO
-from ocean_lib.web3_internal.constants import ZERO_ADDRESS
+from ocean_lib.ocean.ocean_assets import DatatokenArguments
 
 
 @pytest.mark.unit
@@ -31,20 +31,14 @@ def test_aqua_functions_for_single_ddo(
         "license": "https://market.oceanprotocol.com/terms",
     }
 
-    OCEAN_addr = publisher_ocean_instance.OCEAN_address
     ddo1 = publisher_ocean_instance.assets.create(
         metadata=metadata1,
         publisher_wallet=publisher_wallet,
-        files=[file1],
-        datatoken_templates=[1],
-        datatoken_names=["Datatoken 1"],
-        datatoken_symbols=["DT1"],
-        datatoken_minters=[publisher_wallet.address],
-        datatoken_fee_managers=[publisher_wallet.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[OCEAN_addr],
-        datatoken_publish_market_order_fee_amounts=[0],
-        datatoken_bytess=[[b""]],
+        datatoken_arguments=[
+            DatatokenArguments(
+                template_index=1, name="Datatoken 1", symbol="DT1", files=[file1]
+            )
+        ],
     )
 
     ddo2 = aquarius_instance.wait_for_ddo(ddo1.did)

--- a/ocean_lib/assets/test/test_asset_downloader.py
+++ b/ocean_lib/assets/test/test_asset_downloader.py
@@ -147,8 +147,6 @@ def test_ocean_assets_download_destination_file(
     tmpdir,
     publisher_wallet,
     publisher_ocean_instance,
-    data_nft,
-    datatoken,
 ):
     """Convert tmpdir: py._path.local.LocalPath to str, satisfy enforce-typing."""
     ocean_assets_download_destination_file_helper(
@@ -156,8 +154,6 @@ def test_ocean_assets_download_destination_file(
         str(tmpdir),
         publisher_wallet,
         publisher_ocean_instance,
-        data_nft,
-        datatoken,
     )
 
 
@@ -166,16 +162,14 @@ def ocean_assets_download_destination_file_helper(
     tmpdir,
     publisher_wallet,
     publisher_ocean_instance,
-    data_nft,
-    datatoken,
 ):
     """Downloading to an existing directory."""
     data_provider = DataServiceProvider
     data_nft, datatoken, ddo = get_registered_asset_with_access_service(
-        publisher_ocean_instance, publisher_wallet
+        publisher_ocean_instance, publisher_wallet, return_ddo=False
     )
 
-    access_service = datatoken.get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
+    access_service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
 
     datatoken.mint(
         publisher_wallet.address,

--- a/ocean_lib/assets/test/test_asset_downloader.py
+++ b/ocean_lib/assets/test/test_asset_downloader.py
@@ -16,8 +16,8 @@ from ocean_lib.assets.ddo import DDO
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.services.service import Service
 from tests.resources.ddo_helpers import (
-    create_basics,
     get_first_service_by_type,
+    get_registered_asset_with_access_service,
     get_sample_ddo,
 )
 
@@ -171,21 +171,10 @@ def ocean_assets_download_destination_file_helper(
 ):
     """Downloading to an existing directory."""
     data_provider = DataServiceProvider
-
-    _, metadata, files = create_basics(config, data_provider)
-    access_service = datatoken.build_access_service(
-        service_id="0",
-        service_endpoint=config.get("PROVIDER_URL"),
-        files=files,
+    data_nft, datatoken, ddo = get_registered_asset_with_access_service(
+        publisher_ocean_instance, publisher_wallet
     )
 
-    ddo = publisher_ocean_instance.assets.create(
-        metadata=metadata,
-        publisher_wallet=publisher_wallet,
-        services=[access_service],
-        data_nft_address=data_nft.address,
-        deployed_datatokens=[datatoken],
-    )
     access_service = datatoken.get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
 
     datatoken.mint(

--- a/ocean_lib/assets/test/test_asset_downloader.py
+++ b/ocean_lib/assets/test/test_asset_downloader.py
@@ -166,7 +166,7 @@ def ocean_assets_download_destination_file_helper(
     """Downloading to an existing directory."""
     data_provider = DataServiceProvider
     data_nft, datatoken, ddo = get_registered_asset_with_access_service(
-        publisher_ocean_instance, publisher_wallet, return_ddo=False
+        publisher_ocean_instance, publisher_wallet
     )
 
     access_service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)

--- a/ocean_lib/assets/test/test_asset_downloader.py
+++ b/ocean_lib/assets/test/test_asset_downloader.py
@@ -11,8 +11,8 @@ from web3.main import Web3
 
 from ocean_lib.agreements.consumable import AssetNotConsumable, ConsumableCodes
 from ocean_lib.agreements.service_types import ServiceTypes
-from ocean_lib.assets.ddo import DDO
 from ocean_lib.assets.asset_downloader import download_asset_files, is_consumable
+from ocean_lib.assets.ddo import DDO
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.services.service import Service
 from tests.resources.ddo_helpers import (
@@ -173,14 +173,20 @@ def ocean_assets_download_destination_file_helper(
     data_provider = DataServiceProvider
 
     _, metadata, files = create_basics(config, data_provider)
+    access_service = datatoken.build_access_service(
+        service_id="0",
+        service_endpoint=config.get("PROVIDER_URL"),
+        files=files,
+    )
+
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=files,
+        services=[access_service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
     )
-    access_service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
+    access_service = datatoken.get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
 
     datatoken.mint(
         publisher_wallet.address,

--- a/ocean_lib/data_provider/test/test_data_service_provider.py
+++ b/ocean_lib/data_provider/test/test_data_service_provider.py
@@ -235,7 +235,7 @@ def test_fileinfo(
         files=files,
     )
 
-    ddo = publisher_ocean_instance.assets.create(
+    _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         services=[access_service],
@@ -274,7 +274,7 @@ def test_initialize(
         files=files,
     )
 
-    ddo = publisher_ocean_instance.assets.create(
+    _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         services=[access_service],

--- a/ocean_lib/data_provider/test/test_data_service_provider.py
+++ b/ocean_lib/data_provider/test/test_data_service_provider.py
@@ -229,11 +229,16 @@ def test_fileinfo(
     config, publisher_wallet, publisher_ocean_instance, data_nft, datatoken
 ):
     _, metadata, files = create_basics(config, DataSP)
+    access_service = datatoken.build_access_service(
+        service_id="0",
+        service_endpoint=config.get("PROVIDER_URL"),
+        files=files,
+    )
 
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=files,
+        services=[access_service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
     )
@@ -263,10 +268,16 @@ def test_initialize(
     datatoken,
 ):
     _, metadata, files = create_basics(config, DataSP)
+    access_service = datatoken.build_access_service(
+        service_id="0",
+        service_endpoint=config.get("PROVIDER_URL"),
+        files=files,
+    )
+
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=files,
+        services=[access_service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
     )

--- a/ocean_lib/data_provider/test/test_data_service_provider.py
+++ b/ocean_lib/data_provider/test/test_data_service_provider.py
@@ -24,7 +24,10 @@ from ocean_lib.http_requests.requests_session import get_requests_session
 from ocean_lib.models.compute_input import ComputeInput
 from ocean_lib.ocean.util import get_ocean_token_address
 from ocean_lib.services.service import Service
-from tests.resources.ddo_helpers import create_basics, get_first_service_by_type
+from tests.resources.ddo_helpers import (
+    get_first_service_by_type,
+    get_registered_asset_with_access_service,
+)
 from tests.resources.helper_functions import get_publisher_ocean_instance
 from tests.resources.mocks.http_client_mock import (
     TEST_SERVICE_ENDPOINTS,
@@ -225,23 +228,11 @@ def test_encrypt(config, provider_wallet, file1, file2):
 
 
 @pytest.mark.integration
-def test_fileinfo(
-    config, publisher_wallet, publisher_ocean_instance, data_nft, datatoken
-):
-    _, metadata, files = create_basics(config, DataSP)
-    access_service = datatoken.build_access_service(
-        service_id="0",
-        service_endpoint=config.get("PROVIDER_URL"),
-        files=files,
+def test_fileinfo(config, publisher_wallet, publisher_ocean_instance):
+    _, _, ddo = get_registered_asset_with_access_service(
+        publisher_ocean_instance, publisher_wallet, more_files=True
     )
 
-    _, _, ddo = publisher_ocean_instance.assets.create(
-        metadata=metadata,
-        publisher_wallet=publisher_wallet,
-        services=[access_service],
-        data_nft_address=data_nft.address,
-        deployed_datatokens=[datatoken],
-    )
     access_service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
 
     fileinfo_result = FileInfoProvider.fileinfo(
@@ -264,23 +255,11 @@ def test_initialize(
     publisher_wallet,
     publisher_ocean_instance,
     provider_wallet,
-    data_nft,
-    datatoken,
 ):
-    _, metadata, files = create_basics(config, DataSP)
-    access_service = datatoken.build_access_service(
-        service_id="0",
-        service_endpoint=config.get("PROVIDER_URL"),
-        files=files,
+    _, _, ddo = get_registered_asset_with_access_service(
+        publisher_ocean_instance, publisher_wallet
     )
 
-    _, _, ddo = publisher_ocean_instance.assets.create(
-        metadata=metadata,
-        publisher_wallet=publisher_wallet,
-        services=[access_service],
-        data_nft_address=data_nft.address,
-        deployed_datatokens=[datatoken],
-    )
     access_service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
 
     initialize_result = DataSP.initialize(

--- a/ocean_lib/models/datatoken.py
+++ b/ocean_lib/models/datatoken.py
@@ -3,14 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from enum import IntEnum
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from brownie.network.state import Chain
 from enforce_typing import enforce_types
 
+from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.ocean.util import get_address_of_type
-from ocean_lib.web3_internal.contract_base import ContractBase
+from ocean_lib.services.service import Service
+from ocean_lib.structures.file_objects import FilesType
 from ocean_lib.web3_internal.constants import MAX_UINT256, ZERO_ADDRESS
+from ocean_lib.web3_internal.contract_base import ContractBase
 
 
 class DatatokenRoles(IntEnum):
@@ -216,6 +219,25 @@ class Datatoken(ContractBase):
 
         dispenser_addr = get_address_of_type(self.config_dict, "Dispenser")
         return Dispenser(self.config_dict, dispenser_addr)
+
+    @enforce_types
+    def build_access_service(
+        self,
+        service_id: str,
+        service_endpoint: str,
+        files: List[FilesType],
+        timeout: Optional[int] = 3600,
+        consumer_parameters=None,
+    ) -> Service:
+        return Service(
+            service_id=service_id,
+            service_type=ServiceTypes.ASSET_ACCESS,
+            service_endpoint=service_endpoint,
+            datatoken=self.address,
+            files=files,
+            timeout=timeout,
+            consumer_parameters=consumer_parameters,
+        )
 
 
 class MockERC20(Datatoken):

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -751,7 +751,7 @@ class DataNFTArguments:
         self.transferable = transferable or True
         self.owner = owner
 
-    def deploy_contract(self, config_dict, wallet):
+    def deploy_contract(self, config_dict, wallet) -> DataNFT:
         address = get_address_of_type(config_dict, DataNFTFactoryContract.CONTRACT_NAME)
         data_nft_factory = DataNFTFactoryContract(config_dict, address)
 

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -158,7 +158,9 @@ class OceanAssets:
     ) -> tuple:
         """Create an asset of type "UrlFile", with good defaults"""
         files = [UrlFile(url)]
-        return self._create1(name, files, publisher_wallet, None, wait_for_aqua)
+        return self.create_with_default_metadata(
+            name, files, publisher_wallet, wait_for_aqua
+        )
 
     @enforce_types
     def create_graphql_asset(
@@ -171,7 +173,9 @@ class OceanAssets:
     ) -> tuple:
         """Create an asset of type "GraphqlQuery", with good defaults"""
         files = [GraphqlQuery(url, query)]
-        return self._create1(name, files, publisher_wallet, None, wait_for_aqua)
+        return self.create_with_default_metadata(
+            name, files, publisher_wallet, wait_for_aqua
+        )
 
     @enforce_types
     def create_onchain_asset(
@@ -186,15 +190,16 @@ class OceanAssets:
         chain_id = self._chain_id
         onchain_data = SmartContractCall(contract_address, chain_id, contract_abi)
         files = [onchain_data]
-        return self._create1(name, files, publisher_wallet, None, wait_for_aqua)
+        return self.create_with_default_metadata(
+            name, files, publisher_wallet, wait_for_aqua
+        )
 
     @enforce_types
-    def _create1(
+    def create_with_default_metadata(
         self,
         name: str,
         files: list,
         publisher_wallet,
-        metadata=None,
         wait_for_aqua: bool = True,
     ) -> tuple:
         """Thin wrapper for create(). Creates 1 datatoken, with good defaults.
@@ -204,16 +209,15 @@ class OceanAssets:
         Returns (data_nft, datatoken, ddo)
         """
         date_created = datetime.now().isoformat()
-        if not metadata:
-            metadata = {
-                "created": date_created,
-                "updated": date_created,
-                "description": name,
-                "name": name,
-                "type": "dataset",
-                "author": publisher_wallet.address[:7],
-                "license": "CC0: PublicDomain",
-            }
+        metadata = {
+            "created": date_created,
+            "updated": date_created,
+            "description": name,
+            "name": name,
+            "type": "dataset",
+            "author": publisher_wallet.address[:7],
+            "license": "CC0: PublicDomain",
+        }
 
         (data_nft, datatokens, ddo) = self.create(
             metadata,

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -313,32 +313,26 @@ class OceanAssets:
 
         ddo.credentials = credentials if credentials else {"allow": [], "deny": []}
 
+        ddo.nft_address = data_nft.address
         datatokens = []
 
         if not deployed_datatokens:
+            services = []
             for datatoken_argument in datatoken_arguments:
                 datatokens.append(
                     datatoken_argument.create_from_arguments(
                         self._config_dict, data_nft, publisher_wallet
                     )
                 )
+
+                services.extend(datatoken_argument.services)
+
+            for service in services:
+                ddo.add_service(service)
         else:
             datatokens = deployed_datatokens
 
-        ddo.nft_address = data_nft_address
-        ddo.datatokens = [
-            {
-                "address": datatoken.address,
-                "name": datatoken.contract.name(),
-                "symbol": datatoken.symbol(),
-                # "serviceId": service.id, TODO
-            }
-            for datatoken in datatokens
-        ]
-
-        # TODO fix
-        # for service in services:
-        #    ddo.add_service(service)
+        # TODO: custom services
 
         # Validation by Aquarius
         _, proof = self.validate(ddo)
@@ -372,9 +366,6 @@ class OceanAssets:
         if return_ddo:
             return ddo
         else:
-            datatokens = [
-                Datatoken(self._config_dict, d["address"]) for d in datatokens
-            ]
             return (data_nft, datatokens, ddo)
 
     @enforce_types
@@ -842,13 +833,15 @@ class DatatokenArguments:
         )
 
         if not self.services:
-            self.services = self.build_access_service(
-                service_id="0",
-                service_endpoint=config_dict.get("PROVIDER_URL"),
-                datatoken=temp_dt.address,
-                files=self.files,
-                consumer_parameters=self.consumer_parameters,
-            )
+            self.services = [
+                self.build_access_service(
+                    service_id="0",
+                    service_endpoint=config_dict.get("PROVIDER_URL"),
+                    datatoken=temp_dt.address,
+                    files=self.files,
+                    consumer_parameters=self.consumer_parameters,
+                )
+            ]
 
         return temp_dt
 

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -850,5 +850,8 @@ class DatatokenArguments:
                     consumer_parameters=self.consumer_parameters,
                 )
             ]
+        else:
+            for service in self.services:
+                service.datatoken = temp_dt.address
 
         return temp_dt

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -213,7 +213,7 @@ class OceanAssets:
             publisher_wallet,
             datatoken_arguments=[
                 DatatokenArguments(
-                    name=[name + ": DT1"],
+                    name=f"{name}: DT1",
                     symbol="DT1",
                     files=files,
                 )

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -37,12 +37,7 @@ from ocean_lib.ocean.util import (
 )
 from ocean_lib.services.service import Service
 from ocean_lib.structures.algorithm_metadata import AlgorithmMetadata
-from ocean_lib.structures.file_objects import (
-    FilesType,
-    GraphqlQuery,
-    SmartContractCall,
-    UrlFile,
-)
+from ocean_lib.structures.file_objects import GraphqlQuery, SmartContractCall, UrlFile
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.utils import check_network
 
@@ -248,6 +243,7 @@ class OceanAssets:
         data_nft_address: Optional[str] = None,
         data_nft_arguments: Optional["DataNFTArguments"] = None,
         deployed_datatokens: Optional[List[Datatoken]] = None,
+        services: Optional[list] = None,
         datatoken_arguments: Optional[List["DatatokenArguments"]] = None,
         encrypt_flag: Optional[bool] = True,
         compress_flag: Optional[bool] = True,
@@ -330,9 +326,13 @@ class OceanAssets:
             for service in services:
                 ddo.add_service(service)
         else:
+            # TODO: check that all deployed datatokens belong to our data nft
             datatokens = deployed_datatokens
 
-        # TODO: custom services
+            # TODo: check all services belong to one of the deployed datatokens
+            # TODO: require services with deployed datatokens
+            for service in services:
+                ddo.add_service(service)
 
         # Validation by Aquarius
         _, proof = self.validate(ddo)
@@ -832,35 +832,15 @@ class DatatokenArguments:
             f"Successfully created datatoken with address " f"{temp_dt.address}."
         )
 
+        # TODO: check all services are of this dt
         if not self.services:
             self.services = [
-                self.build_access_service(
+                temp_dt.build_access_service(
                     service_id="0",
                     service_endpoint=config_dict.get("PROVIDER_URL"),
-                    datatoken=temp_dt.address,
                     files=self.files,
                     consumer_parameters=self.consumer_parameters,
                 )
             ]
 
         return temp_dt
-
-    @enforce_types
-    def build_access_service(
-        self,
-        service_id: str,
-        service_endpoint: str,
-        datatoken: str,
-        files: List[FilesType],
-        timeout: Optional[int] = 3600,
-        consumer_parameters=None,
-    ) -> Service:
-        return Service(
-            service_id=service_id,
-            service_type=ServiceTypes.ASSET_ACCESS,
-            service_endpoint=service_endpoint,
-            datatoken=datatoken,
-            files=files,
-            timeout=timeout,
-            consumer_parameters=consumer_parameters,
-        )

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -11,7 +11,7 @@ import lzma
 import os
 import warnings
 from datetime import datetime
-from typing import List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from brownie import network
 from enforce_typing import enforce_types
@@ -37,7 +37,12 @@ from ocean_lib.ocean.util import (
 )
 from ocean_lib.services.service import Service
 from ocean_lib.structures.algorithm_metadata import AlgorithmMetadata
-from ocean_lib.structures.file_objects import GraphqlQuery, SmartContractCall, UrlFile
+from ocean_lib.structures.file_objects import (
+    FilesType,
+    GraphqlQuery,
+    SmartContractCall,
+    UrlFile,
+)
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.utils import check_network
 
@@ -323,7 +328,12 @@ class OceanAssets:
             datatokens = deployed_datatokens
             dt_addresses = []
             for datatoken in datatokens:
-                # TODO: check that all deployed datatokens belong to our data nft
+                if deployed_datatokens[0].address not in data_nft.getTokensList():
+                    logger.warning(
+                        "some deployed_datatokens do not belong to the data nft given."
+                    )
+                    return None, None, None
+
                 dt_addresses.append(datatoken.address)
 
             for service in services:
@@ -789,9 +799,9 @@ class DatatokenArguments:
         publish_market_order_fee_token: Optional[str] = None,
         publish_market_order_fee_amount: Optional[int] = 0,
         bytess: Optional[List[bytes]] = None,
-        services=None,  # TODO: typing
-        files=None,  # TODO: typing
-        consumer_parameters=None,  # TODO: typing
+        services: Optional[list] = None,
+        files: Optional[List[FilesType]] = None,
+        consumer_parameters: Optional[List[Dict[str, Any]]] = None,
     ):
         self.name = name
         self.symbol = symbol

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -221,7 +221,6 @@ class OceanAssets:
                 )
             ],
             wait_for_aqua=wait_for_aqua,
-            return_ddo=False,
         )
         datatoken = None if datatokens is None else datatokens[0]
         return (data_nft, datatoken, ddo)
@@ -242,7 +241,6 @@ class OceanAssets:
         encrypt_flag: Optional[bool] = True,
         compress_flag: Optional[bool] = True,
         wait_for_aqua: bool = True,
-        return_ddo: bool = True,
     ) -> Optional[DDO]:
         """Register an asset on-chain. Asset = {data_NFT, >=0 datatokens, DDO}
 
@@ -260,8 +258,7 @@ class OceanAssets:
         :param encrypt_flag: bool for encryption of the DDO.
         :param compress_flag: bool for compression of the DDO.
         :param wait_for_aqua: wait to ensure ddo's updated in aquarius?
-        :param return_ddo: return ddo, vs tuple?
-        :return: ddo [if return_ddo == True], otherwise tuple of (data_nft, datatokens, ddo)
+        :return: otherwise tuple of (data_nft, datatokens, ddo)
         """
         self._assert_ddo_metadata(metadata)
 
@@ -279,7 +276,7 @@ class OceanAssets:
             # register on-chain
             if not data_nft:
                 logger.warning("Creating new NFT failed.")
-                return None if return_ddo else (None, None, None)
+                return None, None, None
             logger.info(
                 f"Successfully created NFT with address " f"{data_nft.address}."
             )
@@ -364,11 +361,7 @@ class OceanAssets:
         if wait_for_aqua:
             ddo = self._aquarius.wait_for_ddo(did)
 
-        # Return
-        if return_ddo:
-            return ddo
-        else:
-            return (data_nft, datatokens, ddo)
+        return (data_nft, datatokens, ddo)
 
     @enforce_types
     def update(

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -189,6 +189,7 @@ class OceanAssets:
         name: str,
         files: list,
         publisher_wallet,
+        metadata=None,
         wait_for_aqua: bool = True,
     ) -> tuple:
         """Thin wrapper for create(). Creates 1 datatoken, with good defaults.
@@ -198,15 +199,16 @@ class OceanAssets:
         Returns (data_nft, datatoken, ddo)
         """
         date_created = datetime.now().isoformat()
-        metadata = {
-            "created": date_created,
-            "updated": date_created,
-            "description": name,
-            "name": name,
-            "type": "dataset",
-            "author": publisher_wallet.address[:7],
-            "license": "CC0: PublicDomain",
-        }
+        if not metadata:
+            metadata = {
+                "created": date_created,
+                "updated": date_created,
+                "description": name,
+                "name": name,
+                "type": "dataset",
+                "author": publisher_wallet.address[:7],
+                "license": "CC0: PublicDomain",
+            }
 
         (data_nft, datatokens, ddo) = self.create(
             metadata,

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -11,7 +11,7 @@ import lzma
 import os
 import warnings
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import List, Optional, Tuple, Type, Union
 
 from brownie import network
 from enforce_typing import enforce_types
@@ -208,21 +208,13 @@ class OceanAssets:
             "license": "CC0: PublicDomain",
         }
 
-        OCEAN_address = get_ocean_token_address(self._config_dict)
         (data_nft, datatokens, ddo) = self.create(
             metadata,
             publisher_wallet,
             datatoken_arguments=[
                 DatatokenArguments(
-                    template_index=1,
                     name=[name + ": DT1"],
                     symbol="DT1",
-                    minter=publisher_wallet.address,
-                    fee_manager=publisher_wallet.address,
-                    publish_market_order_fee_address=ZERO_ADDRESS,
-                    publish_market_order_fee_token=OCEAN_address,
-                    publish_market_order_fee_amount=0,
-                    bytess=[b""],
                     files=files,
                 )
             ],
@@ -247,7 +239,6 @@ class OceanAssets:
         datatoken_arguments: Optional[List["DatatokenArguments"]] = None,
         encrypt_flag: Optional[bool] = True,
         compress_flag: Optional[bool] = True,
-        consumer_parameters: Optional[List[Dict[str, Any]]] = None,
         wait_for_aqua: bool = True,
         return_ddo: bool = True,
     ) -> Optional[DDO]:

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -24,6 +24,7 @@ from ocean_lib.services.service import Service
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from tests.resources.ddo_helpers import (
     build_credentials_dict,
+    build_default_services,
     get_default_files,
     get_default_metadata,
     get_first_service_by_type,
@@ -403,9 +404,7 @@ def test_plain_asset_with_one_datatoken(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         data_nft_address=data_nft_address,
-        datatoken_arguments=[
-            DatatokenArguments(name="Datatoken 1", symbol="DT1", files=files)
-        ],
+        datatoken_args=[DatatokenArguments(files=files)],
     )
     assert ddo, "The ddo is not created."
     assert ddo.nft["name"] == "NFT1"
@@ -448,17 +447,9 @@ def test_plain_asset_multiple_datatokens(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         data_nft_address=data_nft_address2,
-        datatoken_arguments=[
-            DatatokenArguments(
-                name="Datatoken 2",
-                symbol="DT2",
-                files=files,
-            ),
-            DatatokenArguments(
-                name="Datatoken 3",
-                symbol="DT3",
-                files=files,
-            ),
+        datatoken_args=[
+            DatatokenArguments("Datatoken 2", "DT2", files=files),
+            DatatokenArguments("Datatoken 3", "DT3", files=files),
         ],
     )
     assert ddo, "The ddo is not created."
@@ -543,15 +534,7 @@ def test_encrypted_asset(
     publisher_ocean_instance, publisher_wallet, config, data_nft, datatoken
 ):
     metadata = get_default_metadata()
-    files = get_default_files()
-
-    services = [
-        datatoken.build_access_service(
-            service_id="0",
-            service_endpoint=config.get("PROVIDER_URL"),
-            files=files,
-        )
-    ]
+    services = build_default_services(config, datatoken)
 
     _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
@@ -576,15 +559,7 @@ def test_compressed_asset(
     publisher_ocean_instance, publisher_wallet, config, data_nft, datatoken
 ):
     metadata = get_default_metadata()
-    files = get_default_files()
-
-    services = [
-        datatoken.build_access_service(
-            service_id="0",
-            service_endpoint=config.get("PROVIDER_URL"),
-            files=files,
-        )
-    ]
+    services = build_default_services(config, datatoken)
 
     _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
@@ -609,15 +584,7 @@ def test_compressed_and_encrypted_asset(
     publisher_ocean_instance, publisher_wallet, config, data_nft, datatoken
 ):
     metadata = get_default_metadata()
-    files = get_default_files()
-
-    services = [
-        datatoken.build_access_service(
-            service_id="0",
-            service_endpoint=config.get("PROVIDER_URL"),
-            files=files,
-        )
-    ]
+    services = build_default_services(config, datatoken)
 
     _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -18,6 +18,7 @@ from ocean_lib.assets.ddo import DDO
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.exceptions import AquariusError, InsufficientBalance
 from ocean_lib.models.data_nft import DataNFT
+from ocean_lib.ocean.ocean_assets import DatatokenArguments
 from ocean_lib.ocean.util import get_address_of_type
 from ocean_lib.services.service import Service
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
@@ -428,19 +429,10 @@ def test_plain_asset_with_one_datatoken(
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=files,
         data_nft_address=data_nft_address,
-        datatoken_templates=[1],
-        datatoken_names=["Datatoken 1"],
-        datatoken_symbols=["DT1"],
-        datatoken_minters=[publisher_wallet.address],
-        datatoken_fee_managers=[publisher_wallet.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[
-            publisher_ocean_instance.OCEAN_address
+        datatoken_arguments=[
+            DatatokenArguments(name="Datatoken 1", symbol="DT1", files=files)
         ],
-        datatoken_publish_market_order_fee_amounts=[0],
-        datatoken_bytess=[[b""]],
     )
     assert ddo, "The ddo is not created."
     assert ddo.nft["name"] == "NFT1"
@@ -478,20 +470,19 @@ def test_plain_asset_multiple_datatokens(
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=[files, files],
         data_nft_address=data_nft_address2,
-        datatoken_templates=[1, 1],
-        datatoken_names=["Datatoken 2", "Datatoken 3"],
-        datatoken_symbols=["DT2", "DT3"],
-        datatoken_minters=[publisher_wallet.address, publisher_wallet.address],
-        datatoken_fee_managers=[publisher_wallet.address, publisher_wallet.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS, ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[
-            publisher_ocean_instance.OCEAN_address,
-            publisher_ocean_instance.OCEAN_address,
+        datatoken_arguments=[
+            DatatokenArguments(
+                name="Datatoken 2",
+                symbol="DT2",
+                files=files,
+            ),
+            DatatokenArguments(
+                name="Datatoken 3",
+                symbol="DT3",
+                files=files,
+            ),
         ],
-        datatoken_publish_market_order_fee_amounts=[0, 0],
-        datatoken_bytess=[[b""], [b""]],
     )
     assert ddo, "The ddo is not created."
     assert ddo.nft["name"] == "NFT2"

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -544,7 +544,6 @@ def test_plain_asset_multiple_services(
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=files,
         services=[access_service, compute_service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -568,11 +567,20 @@ def test_encrypted_asset(
     data_provider = DataServiceProvider
     _, metadata, files = create_basics(config, data_provider)
 
+    services = [
+        datatoken.build_access_service(
+            service_id="0",
+            service_endpoint=config.get("PROVIDER_URL"),
+            files=files,
+        )
+    ]
+
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
+        services=services,
         encrypt_flag=True,
     )
     assert ddo, "The ddo is not created."
@@ -592,10 +600,18 @@ def test_compressed_asset(
     data_provider = DataServiceProvider
     _, metadata, files = create_basics(config, data_provider)
 
+    services = [
+        datatoken.build_access_service(
+            service_id="0",
+            service_endpoint=config.get("PROVIDER_URL"),
+            files=files,
+        )
+    ]
+
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=files,
+        services=services,
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
         compress_flag=True,
@@ -617,10 +633,18 @@ def test_compressed_and_encrypted_asset(
     data_provider = DataServiceProvider
     _, metadata, files = create_basics(config, data_provider)
 
+    services = [
+        datatoken.build_access_service(
+            service_id="0",
+            service_endpoint=config.get("PROVIDER_URL"),
+            files=files,
+        )
+    ]
+
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=files,
+        services=services,
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
         encrypt_flag=True,
@@ -647,7 +671,7 @@ def test_asset_creation_errors(
         publisher_ocean_instance.assets.create(
             metadata=metadata,
             publisher_wallet=publisher_wallet,
-            files=files,
+            services=[],
             data_nft_address=some_random_address,
             deployed_datatokens=[datatoken],
             encrypt_flag=True,
@@ -659,7 +683,7 @@ def test_asset_creation_errors(
             publisher_ocean_instance.assets.create(
                 metadata=metadata,
                 publisher_wallet=publisher_wallet,
-                files=files,
+                services=[],
                 data_nft_address=data_nft.address,
                 deployed_datatokens=[datatoken],
                 encrypt_flag=True,

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -17,7 +17,6 @@ from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.assets.ddo import DDO
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.exceptions import AquariusError, InsufficientBalance
-from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.ocean.ocean_assets import DatatokenArguments
 from ocean_lib.services.service import Service
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
@@ -40,7 +39,7 @@ def test_register_asset(publisher_ocean_instance, publisher_wallet, consumer_wal
 
 @pytest.mark.integration
 def test_update_metadata(publisher_ocean_instance, publisher_wallet):
-    ddo = get_registered_asset_with_access_service(
+    _, _, ddo = get_registered_asset_with_access_service(
         publisher_ocean_instance, publisher_wallet
     )
 
@@ -64,7 +63,7 @@ def test_update_metadata(publisher_ocean_instance, publisher_wallet):
 
 @pytest.mark.integration
 def test_update_credentials(publisher_ocean_instance, publisher_wallet):
-    ddo = get_registered_asset_with_access_service(
+    _, _, ddo = get_registered_asset_with_access_service(
         publisher_ocean_instance, publisher_wallet
     )
 
@@ -85,7 +84,7 @@ def test_update_credentials(publisher_ocean_instance, publisher_wallet):
 def test_update_datatokens(
     publisher_ocean_instance, publisher_wallet, config, datatoken, file2
 ):
-    ddo = get_registered_asset_with_access_service(
+    _, _, ddo = get_registered_asset_with_access_service(
         publisher_ocean_instance, publisher_wallet
     )
     data_provider = DataServiceProvider
@@ -162,12 +161,9 @@ def test_update_datatokens(
 
 @pytest.mark.integration
 def test_update_flags(publisher_ocean_instance, publisher_wallet):
-    ddo = get_registered_asset_with_access_service(
+    data_nft, _, ddo = get_registered_asset_with_access_service(
         publisher_ocean_instance, publisher_wallet
     )
-
-    # Test compress & update flags
-    data_nft = DataNFT(publisher_ocean_instance.config_dict, ddo.nft_address)
 
     ddo2 = publisher_ocean_instance.assets.update(
         ddo,
@@ -283,7 +279,7 @@ def test_ocean_assets_algorithm(publisher_ocean_instance, publisher_wallet):
         },
     }
 
-    ddo = get_registered_asset_with_access_service(
+    _, _, ddo = get_registered_asset_with_access_service(
         publisher_ocean_instance, publisher_wallet, metadata
     )
     assert ddo, "DDO None. The ddo is not cached after the creation."
@@ -397,7 +393,7 @@ def test_plain_asset_with_one_datatoken(
     assert registered_event["admin"] == publisher_wallet.address
     data_nft_address = registered_event["newTokenAddress"]
 
-    ddo = publisher_ocean_instance.assets.create(
+    _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         data_nft_address=data_nft_address,
@@ -438,7 +434,7 @@ def test_plain_asset_multiple_datatokens(
     assert registered_event["admin"] == publisher_wallet.address
     data_nft_address2 = registered_event["newTokenAddress"]
 
-    ddo = publisher_ocean_instance.assets.create(
+    _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         data_nft_address=data_nft_address2,
@@ -512,7 +508,7 @@ def test_plain_asset_multiple_services(
         compute_values=compute_values,
     )
 
-    ddo = publisher_ocean_instance.assets.create(
+    _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         services=[access_service, compute_service],
@@ -546,7 +542,7 @@ def test_encrypted_asset(
         )
     ]
 
-    ddo = publisher_ocean_instance.assets.create(
+    _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         data_nft_address=data_nft.address,
@@ -579,7 +575,7 @@ def test_compressed_asset(
         )
     ]
 
-    ddo = publisher_ocean_instance.assets.create(
+    _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         services=services,
@@ -612,7 +608,7 @@ def test_compressed_and_encrypted_asset(
         )
     ]
 
-    ddo = publisher_ocean_instance.assets.create(
+    _, _, ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         services=services,

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -17,12 +17,15 @@ from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.assets.ddo import DDO
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.exceptions import AquariusError, InsufficientBalance
+from ocean_lib.models.data_nft_factory import DataNFTFactoryContract
 from ocean_lib.ocean.ocean_assets import DatatokenArguments
+from ocean_lib.ocean.util import get_address_of_type
 from ocean_lib.services.service import Service
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from tests.resources.ddo_helpers import (
     build_credentials_dict,
-    create_basics,
+    get_default_files,
+    get_default_metadata,
     get_first_service_by_type,
     get_registered_asset_with_access_service,
     get_sample_ddo,
@@ -373,9 +376,12 @@ def test_create_url_asset(publisher_ocean_instance, publisher_wallet):
 def test_plain_asset_with_one_datatoken(
     publisher_ocean_instance, publisher_wallet, config
 ):
-    data_provider = DataServiceProvider
+    data_nft_factory = DataNFTFactoryContract(
+        config, get_address_of_type(config, "ERC721Factory")
+    )
 
-    data_nft_factory, metadata, files = create_basics(config, data_provider)
+    metadata = get_default_metadata()
+    files = get_default_files()
 
     # Publisher deploys NFT contract
     tx_receipt = data_nft_factory.deployERC721Contract(
@@ -415,8 +421,12 @@ def test_plain_asset_with_one_datatoken(
 def test_plain_asset_multiple_datatokens(
     publisher_ocean_instance, publisher_wallet, config
 ):
-    data_provider = DataServiceProvider
-    data_nft_factory, metadata, files = create_basics(config, data_provider)
+    data_nft_factory = DataNFTFactoryContract(
+        config, get_address_of_type(config, "ERC721Factory")
+    )
+
+    metadata = get_default_metadata()
+    files = get_default_files()
 
     tx_receipt = data_nft_factory.deployERC721Contract(
         "NFT2",
@@ -476,7 +486,8 @@ def test_plain_asset_multiple_services(
     publisher_ocean_instance, publisher_wallet, config, data_nft, datatoken
 ):
     data_provider = DataServiceProvider
-    _, metadata, files = create_basics(config, data_provider)
+    metadata = get_default_metadata()
+    files = get_default_files()
 
     access_service = Service(
         service_id="0",
@@ -531,8 +542,8 @@ def test_plain_asset_multiple_services(
 def test_encrypted_asset(
     publisher_ocean_instance, publisher_wallet, config, data_nft, datatoken
 ):
-    data_provider = DataServiceProvider
-    _, metadata, files = create_basics(config, data_provider)
+    metadata = get_default_metadata()
+    files = get_default_files()
 
     services = [
         datatoken.build_access_service(
@@ -564,8 +575,8 @@ def test_encrypted_asset(
 def test_compressed_asset(
     publisher_ocean_instance, publisher_wallet, config, data_nft, datatoken
 ):
-    data_provider = DataServiceProvider
-    _, metadata, files = create_basics(config, data_provider)
+    metadata = get_default_metadata()
+    files = get_default_files()
 
     services = [
         datatoken.build_access_service(
@@ -597,8 +608,8 @@ def test_compressed_asset(
 def test_compressed_and_encrypted_asset(
     publisher_ocean_instance, publisher_wallet, config, data_nft, datatoken
 ):
-    data_provider = DataServiceProvider
-    _, metadata, files = create_basics(config, data_provider)
+    metadata = get_default_metadata()
+    files = get_default_files()
 
     services = [
         datatoken.build_access_service(
@@ -630,8 +641,7 @@ def test_compressed_and_encrypted_asset(
 def test_asset_creation_errors(
     publisher_ocean_instance, publisher_wallet, config, data_nft, datatoken
 ):
-    data_provider = DataServiceProvider
-    _, metadata, files = create_basics(config, data_provider)
+    metadata = get_default_metadata()
 
     some_random_address = ZERO_ADDRESS
     with pytest.raises(brownie.exceptions.ContractNotFound):

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -571,7 +571,6 @@ def test_encrypted_asset(
     ddo = publisher_ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=files,
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
         encrypt_flag=True,

--- a/tests/flows/test_start_order_fees.py
+++ b/tests/flows/test_start_order_fees.py
@@ -265,7 +265,7 @@ def create_asset_with_order_fee_and_timeout(
     )
 
     # Publish asset
-    ddo = ocean_assets.create(
+    data_nft, dt, ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         services=[service],
@@ -274,6 +274,5 @@ def create_asset_with_order_fee_and_timeout(
     )
 
     service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
-    dt = Datatoken(config, ddo.datatokens[0]["address"])
 
     return ddo, service, dt

--- a/tests/flows/test_start_order_fees.py
+++ b/tests/flows/test_start_order_fees.py
@@ -265,7 +265,7 @@ def create_asset_with_order_fee_and_timeout(
     )
 
     # Publish asset
-    data_nft, dt, ddo = ocean_assets.create(
+    data_nft, datatokens, ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         services=[service],
@@ -275,4 +275,4 @@ def create_asset_with_order_fee_and_timeout(
 
     service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
 
-    return ddo, service, dt
+    return ddo, service, datatokens[0]

--- a/tests/integration/ganache/test_compute_flow.py
+++ b/tests/integration/ganache/test_compute_flow.py
@@ -71,7 +71,7 @@ def dataset_with_compute_service_and_trusted_algorithm(
     publisher_wallet, publisher_ocean_instance, algorithm
 ):
     # Setup algorithm meta to run raw algorithm
-    _, _, ddo = get_registered_asset_with_compute_service(
+    ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance, publisher_wallet, trusted_algorithms=[algorithm]
     )
     # verify the ddo is available in Aquarius
@@ -84,7 +84,7 @@ def dataset_with_compute_service_and_trusted_publisher(
     publisher_wallet, publisher_ocean_instance
 ):
     # Setup algorithm meta to run raw algorithm
-    _, _, ddo = get_registered_asset_with_compute_service(
+    ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance,
         publisher_wallet,
         trusted_algorithm_publishers=[publisher_wallet.address],

--- a/tests/integration/ganache/test_compute_flow.py
+++ b/tests/integration/ganache/test_compute_flow.py
@@ -32,7 +32,7 @@ def dataset_with_compute_service(publisher_wallet, publisher_ocean_instance):
     Fixture is registered on chain once and can be used multiple times.
     Reduces setup time."""
     # Dataset with compute service
-    ddo = get_registered_asset_with_compute_service(
+    _, _, ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance, publisher_wallet
     )
     # verify the ddo is available in Aquarius
@@ -45,7 +45,7 @@ def dataset_with_compute_service_generator(publisher_wallet, publisher_ocean_ins
     """Returns a new dataset each time fixture is used.
     Useful for tests that need to update the dataset"""
     # Dataset with compute service
-    ddo = get_registered_asset_with_compute_service(
+    _, _, ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance, publisher_wallet
     )
     # verify the ddo is available in Aquarius
@@ -58,7 +58,7 @@ def dataset_with_compute_service_allow_raw_algo(
     publisher_wallet, publisher_ocean_instance
 ):
     # Dataset with compute service
-    ddo = get_registered_asset_with_compute_service(
+    _, _, ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance, publisher_wallet, allow_raw_algorithms=True
     )
     # verify the ddo is available in Aquarius
@@ -71,7 +71,7 @@ def dataset_with_compute_service_and_trusted_algorithm(
     publisher_wallet, publisher_ocean_instance, algorithm
 ):
     # Setup algorithm meta to run raw algorithm
-    ddo = get_registered_asset_with_compute_service(
+    _, _, ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance, publisher_wallet, trusted_algorithms=[algorithm]
     )
     # verify the ddo is available in Aquarius
@@ -84,7 +84,7 @@ def dataset_with_compute_service_and_trusted_publisher(
     publisher_wallet, publisher_ocean_instance
 ):
     # Setup algorithm meta to run raw algorithm
-    ddo = get_registered_asset_with_compute_service(
+    _, _, ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance,
         publisher_wallet,
         trusted_algorithm_publishers=[publisher_wallet.address],
@@ -96,7 +96,7 @@ def dataset_with_compute_service_and_trusted_publisher(
 
 def get_algorithm(publisher_wallet, publisher_ocean_instance):
     # Setup algorithm meta to run raw algorithm
-    ddo = get_registered_algorithm_with_access_service(
+    _, _, ddo = get_registered_algorithm_with_access_service(
         publisher_ocean_instance, publisher_wallet
     )
     # verify the asset is available in Aquarius

--- a/tests/integration/ganache/test_compute_flow.py
+++ b/tests/integration/ganache/test_compute_flow.py
@@ -122,7 +122,7 @@ def raw_algorithm():
 @pytest.fixture
 def dataset_with_access_service(publisher_wallet, publisher_ocean_instance):
     # Dataset with access service
-    ddo = get_registered_asset_with_access_service(
+    _, _, ddo = get_registered_asset_with_access_service(
         publisher_ocean_instance, publisher_wallet
     )
     # verify the ddo is available in Aquarius

--- a/tests/integration/ganache/test_compute_flow.py
+++ b/tests/integration/ganache/test_compute_flow.py
@@ -71,7 +71,7 @@ def dataset_with_compute_service_and_trusted_algorithm(
     publisher_wallet, publisher_ocean_instance, algorithm
 ):
     # Setup algorithm meta to run raw algorithm
-    ddo = get_registered_asset_with_compute_service(
+    _, _, ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance, publisher_wallet, trusted_algorithms=[algorithm]
     )
     # verify the ddo is available in Aquarius
@@ -84,7 +84,7 @@ def dataset_with_compute_service_and_trusted_publisher(
     publisher_wallet, publisher_ocean_instance
 ):
     # Setup algorithm meta to run raw algorithm
-    ddo = get_registered_asset_with_compute_service(
+    _, _, ddo = get_registered_asset_with_compute_service(
         publisher_ocean_instance,
         publisher_wallet,
         trusted_algorithm_publishers=[publisher_wallet.address],
@@ -301,7 +301,7 @@ def run_compute_test(
         )
         print(f"got algo log file: {str(log_file)}")
 
-        result = ocean_instance.compute.result(
+        _ = ocean_instance.compute.result(
             dataset_and_userdata.ddo, service, job_id, 0, consumer_wallet
         )
 

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -10,11 +10,8 @@ from web3.main import Web3
 
 from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
-from ocean_lib.models.data_nft import DataNFT
-from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.ocean.ocean import Ocean
 from ocean_lib.ocean.ocean_assets import OceanAssets
-from ocean_lib.structures.file_objects import FilesType
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from tests.resources.ddo_helpers import (
     get_first_service_by_type,
@@ -27,19 +24,16 @@ def test_consume_flow(
     config: dict,
     publisher_wallet,
     consumer_wallet,
-    data_nft: DataNFT,
-    file1: FilesType,
 ):
     ocean = Ocean(config)
 
     # Publish a plain asset with one data token on chain
-    ddo = get_registered_asset_with_access_service(
+    data_nft, dt, ddo = get_registered_asset_with_access_service(
         ocean,
         publisher_wallet,
     )
 
     service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
-    dt = Datatoken(config, ddo.datatokens[0]["address"])
 
     # Mint 50 datatokens in consumer wallet from publisher. Max cap = 100
     dt.mint(

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -12,7 +12,7 @@ from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.datatoken import Datatoken
-from ocean_lib.ocean.ocean_assets import OceanAssets
+from ocean_lib.ocean.ocean_assets import DatatokenArguments, OceanAssets
 from ocean_lib.structures.file_objects import FilesType
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from tests.resources.ddo_helpers import get_first_service_by_type
@@ -46,15 +46,9 @@ def test_consume_flow(
         publisher_wallet=publisher_wallet,
         files=[file1],
         data_nft_address=data_nft.address,
-        datatoken_templates=[1],
-        datatoken_names=["Datatoken 1"],
-        datatoken_symbols=["DT1"],
-        datatoken_minters=[publisher_wallet.address],
-        datatoken_fee_managers=[publisher_wallet.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_amounts=[0],
-        datatoken_bytess=[[b""]],
+        datatoken_arguments=[
+            DatatokenArguments(name="Datatoken 1", symbol="DT1", files=[file1])
+        ],
     )
 
     assert ddo, "The ddo is not created."

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -12,10 +12,14 @@ from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.datatoken import Datatoken
-from ocean_lib.ocean.ocean_assets import DatatokenArguments, OceanAssets
+from ocean_lib.ocean.ocean import Ocean
+from ocean_lib.ocean.ocean_assets import OceanAssets
 from ocean_lib.structures.file_objects import FilesType
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
-from tests.resources.ddo_helpers import get_first_service_by_type
+from tests.resources.ddo_helpers import (
+    get_first_service_by_type,
+    get_registered_asset_with_access_service,
+)
 
 
 @pytest.mark.integration
@@ -26,38 +30,13 @@ def test_consume_flow(
     data_nft: DataNFT,
     file1: FilesType,
 ):
-    data_provider = DataServiceProvider
-    ocean_assets = OceanAssets(config, data_provider)
-    metadata = {
-        "created": "2020-11-15T12:27:48Z",
-        "updated": "2021-05-17T21:58:02Z",
-        "description": "Sample description",
-        "name": "Sample asset",
-        "type": "dataset",
-        "author": "OPF",
-        "license": "https://market.oceanprotocol.com/terms",
-    }
-
-    files = [file1]
+    ocean = Ocean(config)
 
     # Publish a plain asset with one data token on chain
-    ddo = ocean_assets.create(
-        metadata=metadata,
-        publisher_wallet=publisher_wallet,
-        files=[file1],
-        data_nft_address=data_nft.address,
-        datatoken_arguments=[
-            DatatokenArguments(name="Datatoken 1", symbol="DT1", files=[file1])
-        ],
+    ddo = get_registered_asset_with_access_service(
+        ocean,
+        publisher_wallet,
     )
-
-    assert ddo, "The ddo is not created."
-    assert ddo.nft["name"] == "NFT"
-    assert ddo.nft["symbol"] == "NFTSYMBOL"
-    assert ddo.nft["address"] == data_nft.address
-    assert ddo.nft["owner"] == publisher_wallet.address
-    assert ddo.datatokens[0]["name"] == "Datatoken 1"
-    assert ddo.datatokens[0]["symbol"] == "DT1"
 
     service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
     dt = Datatoken(config, ddo.datatokens[0]["address"])
@@ -114,13 +93,13 @@ def test_consume_flow(
 
     assert len(os.listdir(destination)) == 0
 
-    ocean_assets.download_asset(
+    ocean.assets.download_asset(
         ddo, consumer_wallet, destination, receipt.txid, service
     )
 
-    assert len(
-        os.listdir(os.path.join(destination, os.listdir(destination)[0]))
-    ) == len(files), "The asset folder is empty."
+    assert (
+        len(os.listdir(os.path.join(destination, os.listdir(destination)[0]))) == 1
+    ), "The asset folder is empty."
 
 
 @pytest.mark.integration

--- a/tests/integration/ganache/test_disconnecting_components.py
+++ b/tests/integration/ganache/test_disconnecting_components.py
@@ -13,8 +13,6 @@ from ocean_lib.data_provider.data_encryptor import DataEncryptor
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.example_config import DEFAULT_PROVIDER_URL
 from ocean_lib.ocean.ocean import Ocean
-from ocean_lib.structures.file_objects import FilesTypeFactory
-from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 
 exception_flag = 0
 
@@ -53,36 +51,9 @@ def test_with_wrong_aquarius(publisher_wallet, caplog, monkeypatch, config):
 
 def _create_ddo(ocean, publisher):
     global exception_flag
-    metadata = {
-        "created": "2020-11-15T12:27:48Z",
-        "updated": "2021-05-17T21:58:02Z",
-        "description": "Sample description",
-        "name": "Sample asset",
-        "type": "dataset",
-        "author": "OPF",
-        "license": "https://market.oceanprotocol.com/terms",
-    }
-
-    file_url = "https://foo.txt"
-    file_dict = {"type": "url", "url": file_url, "method": "GET"}
-    file = FilesTypeFactory(file_dict)
-    files = [file]
     time.sleep(5)
     try:
-        ocean.assets.create(
-            metadata,
-            publisher,
-            files,
-            datatoken_templates=[1],
-            datatoken_names=["Datatoken 1"],
-            datatoken_symbols=["DT1"],
-            datatoken_minters=[publisher.address],
-            datatoken_fee_managers=[publisher.address],
-            datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-            datatoken_publish_market_order_fee_tokens=[ocean.OCEAN_address],
-            datatoken_publish_market_order_fee_amounts=[0],
-            datatoken_bytess=[[b""]],
-        )
+        ocean.assets.create_url_asset("Sample asset", "https://foo.txt", publisher)
     except requests.exceptions.InvalidURL as err:
         exception_flag = 1
         assert err.args[0] == "InvalidURL http://foourl.com."

--- a/tests/integration/ganache/test_graphql.py
+++ b/tests/integration/ganache/test_graphql.py
@@ -12,7 +12,7 @@ from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.datatoken import Datatoken
-from ocean_lib.ocean.ocean_assets import OceanAssets
+from ocean_lib.ocean.ocean_assets import DatatokenArguments, OceanAssets
 from ocean_lib.structures.file_objects import FilesType, GraphqlQuery
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from tests.resources.ddo_helpers import get_first_service_by_type
@@ -56,17 +56,13 @@ def test_consume_simple_graphql_query(
     ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=[file1],
-        data_nft_address=data_nft.address,
-        datatoken_templates=[1],
-        datatoken_names=["Datatoken 1"],
-        datatoken_symbols=["DT1"],
-        datatoken_minters=[publisher_wallet.address],
-        datatoken_fee_managers=[publisher_wallet.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_amounts=[0],
-        datatoken_bytess=[[b""]],
+        datatoken_arguments=[
+            DatatokenArguments(
+                name="Datatoken 1",
+                symbol="DT1",
+                files=[file1],
+            )
+        ],
     )
 
     assert ddo, "The ddo is not created."
@@ -195,18 +191,14 @@ def test_consume_parametrized_graphql_query(
     ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=[file1],
-        data_nft_address=data_nft.address,
-        datatoken_templates=[1],
-        datatoken_names=["Datatoken 1"],
-        datatoken_symbols=["DT1"],
-        datatoken_minters=[publisher_wallet.address],
-        datatoken_fee_managers=[publisher_wallet.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_amounts=[0],
-        datatoken_bytess=[[b""]],
-        consumer_parameters=consumer_parameters,
+        datatoken_arguments=[
+            DatatokenArguments(
+                name="Datatoken 1",
+                symbol="DT1",
+                files=[file1],
+                consumer_parameters=consumer_parameters,
+            )
+        ],
     )
 
     assert ddo, "The ddo is not created."

--- a/tests/integration/ganache/test_graphql.py
+++ b/tests/integration/ganache/test_graphql.py
@@ -169,7 +169,6 @@ def test_consume_parametrized_graphql_query(
                 consumer_parameters=consumer_parameters,
             )
         ],
-        return_ddo=False,
     )
 
     assert ddo, "The ddo is not created."

--- a/tests/integration/ganache/test_graphql.py
+++ b/tests/integration/ganache/test_graphql.py
@@ -158,17 +158,14 @@ def test_consume_parametrized_graphql_query(
     ]
 
     # Publish a plain asset with one data token on chain
+    dt_arg = DatatokenArguments(
+        files=files,
+        consumer_parameters=consumer_parameters,
+    )
     data_nft, datatoken, ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        datatoken_arguments=[
-            DatatokenArguments(
-                name="Datatoken 1",
-                symbol="DT1",
-                files=files,
-                consumer_parameters=consumer_parameters,
-            )
-        ],
+        datatoken_args=[dt_arg],
     )
 
     assert ddo, "The ddo is not created."

--- a/tests/integration/ganache/test_graphql.py
+++ b/tests/integration/ganache/test_graphql.py
@@ -10,11 +10,10 @@ from web3.main import Web3
 
 from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
-from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.ocean.ocean import Ocean
 from ocean_lib.ocean.ocean_assets import DatatokenArguments, OceanAssets
-from ocean_lib.structures.file_objects import FilesType, GraphqlQuery
+from ocean_lib.structures.file_objects import GraphqlQuery
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from tests.resources.ddo_helpers import get_first_service_by_type
 
@@ -24,8 +23,6 @@ def test_consume_simple_graphql_query(
     config: dict,
     publisher_wallet,
     consumer_wallet,
-    data_nft: DataNFT,
-    file1: FilesType,
 ):
     data_provider = DataServiceProvider
     ocean = Ocean(config)
@@ -45,11 +42,9 @@ def test_consume_simple_graphql_query(
     )
 
     assert ddo, "The ddo is not created."
-    assert ddo.nft["name"] == "Data NFTs in Ocean"
     assert ddo.nft["address"] == data_nft.address
     assert ddo.nft["owner"] == publisher_wallet.address
-    assert ddo.datatokens[0]["name"] == "Datatoken 1"
-    assert ddo.datatokens[0]["symbol"] == "DT1"
+    assert ddo.datatokens[0]["name"] == "Data NFTs in Ocean: DT1"
 
     service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
 
@@ -123,8 +118,6 @@ def test_consume_parametrized_graphql_query(
     config: dict,
     publisher_wallet,
     consumer_wallet,
-    data_nft: DataNFT,
-    file1: FilesType,
 ):
     data_provider = DataServiceProvider
     ocean_assets = OceanAssets(config, data_provider)
@@ -165,22 +158,22 @@ def test_consume_parametrized_graphql_query(
     ]
 
     # Publish a plain asset with one data token on chain
-    ddo = ocean_assets.create(
+    data_nft, datatoken, ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
         datatoken_arguments=[
             DatatokenArguments(
                 name="Datatoken 1",
                 symbol="DT1",
-                files=[file1],
+                files=files,
                 consumer_parameters=consumer_parameters,
             )
         ],
+        return_ddo=False,
     )
 
     assert ddo, "The ddo is not created."
-    assert ddo.nft["name"] == "NFT"
-    assert ddo.nft["symbol"] == "NFTSYMBOL"
+    assert ddo.nft["name"] == "Sample asset"
     assert ddo.nft["address"] == data_nft.address
     assert ddo.nft["owner"] == publisher_wallet.address
     assert ddo.datatokens[0]["name"] == "Datatoken 1"

--- a/tests/integration/ganache/test_market_flow.py
+++ b/tests/integration/ganache/test_market_flow.py
@@ -30,9 +30,10 @@ def test_market_flow(
     consumer_ocean = consumer_ocean_instance
     another_consumer_ocean = get_another_consumer_ocean_instance(use_provider_mock=True)
 
-    ddo = get_registered_asset_with_access_service(publisher_ocean, publisher_wallet)
+    data_nft, datatoken, ddo = get_registered_asset_with_access_service(
+        publisher_ocean, publisher_wallet
+    )
     service = ddo.services[0]
-    datatoken = publisher_ocean.get_datatoken(service.datatoken)
 
     # Mint data tokens and assign to publisher
     datatoken.mint(
@@ -106,9 +107,10 @@ def test_pay_for_access_service_good_default(
 ):
     publisher_ocean, consumer_ocean = publisher_ocean_instance, consumer_ocean_instance
 
-    ddo = get_registered_asset_with_access_service(publisher_ocean, publisher_wallet)
+    data_nft, datatoken, ddo = get_registered_asset_with_access_service(
+        publisher_ocean, publisher_wallet
+    )
     service = ddo.services[0]
-    datatoken = publisher_ocean.get_datatoken(service.datatoken)
 
     # Mint datatokens to consumer
     datatoken.mint(

--- a/tests/integration/ganache/test_onchain.py
+++ b/tests/integration/ganache/test_onchain.py
@@ -13,7 +13,7 @@ from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
 from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.datatoken import Datatoken
-from ocean_lib.ocean.ocean_assets import OceanAssets
+from ocean_lib.ocean.ocean_assets import DatatokenArguments, OceanAssets
 from ocean_lib.ocean.util import get_address_of_type
 from ocean_lib.structures.file_objects import FilesType, SmartContractCall
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
@@ -57,17 +57,14 @@ def test_consume_simple_onchain_data(
     ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=[file1],
         data_nft_address=data_nft.address,
-        datatoken_templates=[1],
-        datatoken_names=["Datatoken 1"],
-        datatoken_symbols=["DT1"],
-        datatoken_minters=[publisher_wallet.address],
-        datatoken_fee_managers=[publisher_wallet.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_amounts=[0],
-        datatoken_bytess=[[b""]],
+        datatoken_arguments=[
+            DatatokenArguments(
+                name="Datatoken 1",
+                symbol="DT1",
+                files=[file1],
+            )
+        ],
     )
 
     assert ddo, "The ddo is not created."
@@ -195,18 +192,15 @@ def test_consume_parametrized_onchain_data(
     ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        files=[file1],
         data_nft_address=data_nft.address,
-        datatoken_templates=[1],
-        datatoken_names=["Datatoken 1"],
-        datatoken_symbols=["DT1"],
-        datatoken_minters=[publisher_wallet.address],
-        datatoken_fee_managers=[publisher_wallet.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_amounts=[0],
-        datatoken_bytess=[[b""]],
-        consumer_parameters=consumer_parameters,
+        datatoken_arguments=[
+            DatatokenArguments(
+                name="Datatoken 1",
+                symbol="DT1",
+                files=[file1],
+                consumer_parameters=consumer_parameters,
+            )
+        ],
     )
 
     assert ddo, "The ddo is not created."

--- a/tests/integration/ganache/test_onchain.py
+++ b/tests/integration/ganache/test_onchain.py
@@ -110,9 +110,8 @@ def test_consume_simple_onchain_data(
         service,
     )
 
-    assert (
-        len(os.listdir(os.path.join(destination, os.listdir(destination)[0]))) == 1
-    ), "The asset folder is empty."
+    dir_files = os.listdir(os.path.join(destination, os.listdir(destination)[0]))
+    assert len(dir_files) == 1, "The asset folder is empty."
 
 
 @pytest.mark.integration
@@ -159,17 +158,11 @@ def test_consume_parametrized_onchain_data(
     ]
 
     # Publish a plain asset with one data token on chain
+    dt_arg = DatatokenArguments(files=files, consumer_parameters=consumer_parameters)
     data_nft, _, ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        datatoken_arguments=[
-            DatatokenArguments(
-                name="Datatoken 1",
-                symbol="DT1",
-                files=files,
-                consumer_parameters=consumer_parameters,
-            )
-        ],
+        datatoken_args=[dt_arg],
     )
 
     assert ddo, "The ddo is not created."
@@ -241,6 +234,5 @@ def test_consume_parametrized_onchain_data(
         ddo, consumer_wallet, destination, receipt.txid, service, userdata=userdata
     )
 
-    assert len(
-        os.listdir(os.path.join(destination, os.listdir(destination)[0]))
-    ) == len(files), "The asset folder is empty."
+    dir_files = os.listdir(os.path.join(destination, os.listdir(destination)[0]))
+    assert len(dir_files) == len(files), "The asset folder is empty."

--- a/tests/integration/ganache/test_onchain.py
+++ b/tests/integration/ganache/test_onchain.py
@@ -170,7 +170,6 @@ def test_consume_parametrized_onchain_data(
                 consumer_parameters=consumer_parameters,
             )
         ],
-        return_ddo=False,
     )
 
     assert ddo, "The ddo is not created."

--- a/tests/integration/ganache/test_onchain.py
+++ b/tests/integration/ganache/test_onchain.py
@@ -11,11 +11,10 @@ from web3.main import Web3
 
 from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.data_service_provider import DataServiceProvider
-from ocean_lib.models.data_nft import DataNFT
 from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.ocean.ocean_assets import DatatokenArguments, OceanAssets
 from ocean_lib.ocean.util import get_address_of_type
-from ocean_lib.structures.file_objects import FilesType, SmartContractCall
+from ocean_lib.structures.file_objects import SmartContractCall
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from tests.resources.ddo_helpers import get_first_service_by_type
 
@@ -25,8 +24,6 @@ def test_consume_simple_onchain_data(
     config: dict,
     publisher_wallet,
     consumer_wallet,
-    data_nft: DataNFT,
-    file1: FilesType,
 ):
     data_provider = DataServiceProvider
     ocean_assets = OceanAssets(config, data_provider)
@@ -47,7 +44,7 @@ def test_consume_simple_onchain_data(
     assert ddo.nft["name"] == "NFT"
     assert ddo.nft["address"] == data_nft.address
     assert ddo.nft["owner"] == publisher_wallet.address
-    assert ddo.datatokens[0]["name"] == "Datatoken 1"
+    assert ddo.datatokens[0]["name"] == "NFT: DT1"
     assert ddo.datatokens[0]["symbol"] == "DT1"
 
     service = get_first_service_by_type(ddo, ServiceTypes.ASSET_ACCESS)
@@ -123,8 +120,6 @@ def test_consume_parametrized_onchain_data(
     config: dict,
     publisher_wallet,
     consumer_wallet,
-    data_nft: DataNFT,
-    file1: FilesType,
 ):
     data_provider = DataServiceProvider
     ocean_assets = OceanAssets(config, data_provider)
@@ -164,23 +159,23 @@ def test_consume_parametrized_onchain_data(
     ]
 
     # Publish a plain asset with one data token on chain
-    ddo = ocean_assets.create(
+    data_nft, _, ddo = ocean_assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        data_nft_address=data_nft.address,
         datatoken_arguments=[
             DatatokenArguments(
                 name="Datatoken 1",
                 symbol="DT1",
-                files=[file1],
+                files=files,
                 consumer_parameters=consumer_parameters,
             )
         ],
+        return_ddo=False,
     )
 
     assert ddo, "The ddo is not created."
-    assert ddo.nft["name"] == "NFT"
-    assert ddo.nft["symbol"] == "NFTSYMBOL"
+    assert ddo.nft["name"] == "Sample asset"
+    assert ddo.nft["symbol"] == "Sample asset"
     assert ddo.nft["address"] == data_nft.address
     assert ddo.nft["owner"] == publisher_wallet.address
     assert ddo.datatokens[0]["name"] == "Datatoken 1"

--- a/tests/integration/ganache/test_onchain.py
+++ b/tests/integration/ganache/test_onchain.py
@@ -30,15 +30,6 @@ def test_consume_simple_onchain_data(
 ):
     data_provider = DataServiceProvider
     ocean_assets = OceanAssets(config, data_provider)
-    metadata = {
-        "created": "2020-11-15T12:27:48Z",
-        "updated": "2021-05-17T21:58:02Z",
-        "description": "Sample description",
-        "name": "Sample asset",
-        "type": "dataset",
-        "author": "OPF",
-        "license": "https://market.oceanprotocol.com/terms",
-    }
     abi = {
         "inputs": [],
         "name": "swapOceanFee",
@@ -47,29 +38,13 @@ def test_consume_simple_onchain_data(
         "type": "function",
     }
     router_address = get_address_of_type(config, "Router")
-    onchain_data = SmartContractCall(
-        address=router_address, chainId=network.chain[-1].number, abi=abi
-    )
 
-    files = [onchain_data]
-
-    # Publish a plain asset with one data token on chain
-    ddo = ocean_assets.create(
-        metadata=metadata,
-        publisher_wallet=publisher_wallet,
-        data_nft_address=data_nft.address,
-        datatoken_arguments=[
-            DatatokenArguments(
-                name="Datatoken 1",
-                symbol="DT1",
-                files=[file1],
-            )
-        ],
+    data_nft, dt, ddo = ocean_assets.create_onchain_asset(
+        "NFT", router_address, abi, publisher_wallet
     )
 
     assert ddo, "The ddo is not created."
     assert ddo.nft["name"] == "NFT"
-    assert ddo.nft["symbol"] == "NFTSYMBOL"
     assert ddo.nft["address"] == data_nft.address
     assert ddo.nft["owner"] == publisher_wallet.address
     assert ddo.datatokens[0]["name"] == "Datatoken 1"
@@ -138,9 +113,9 @@ def test_consume_simple_onchain_data(
         service,
     )
 
-    assert len(
-        os.listdir(os.path.join(destination, os.listdir(destination)[0]))
-    ) == len(files), "The asset folder is empty."
+    assert (
+        len(os.listdir(os.path.join(destination, os.listdir(destination)[0]))) == 1
+    ), "The asset folder is empty."
 
 
 @pytest.mark.integration

--- a/tests/readmes/test_readmes.py
+++ b/tests/readmes/test_readmes.py
@@ -88,8 +88,6 @@ def test_script_execution(script, monkeypatch):
             )
             for key in [
                 "ddo",
-                "ZERO_ADDRESS",
-                # "did",
                 "metadata",
                 "url_file",
             ]:

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -18,11 +18,11 @@ from ocean_lib.models.datatoken import Datatoken
 from ocean_lib.models.factory_router import FactoryRouter
 from ocean_lib.models.fixed_rate_exchange import FixedRateExchange
 from ocean_lib.ocean.ocean import Ocean
+from ocean_lib.ocean.ocean_assets import DatatokenArguments
 from ocean_lib.ocean.util import get_address_of_type
 from ocean_lib.services.service import Service
 from ocean_lib.structures.algorithm_metadata import AlgorithmMetadata
 from ocean_lib.structures.file_objects import FilesType, FilesTypeFactory, UrlFile
-from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from tests.resources.helper_functions import deploy_erc721_erc20, get_file1, get_file2
 
 
@@ -120,16 +120,9 @@ def create_asset(ocean, publisher, metadata=None, files=None):
     ddo = ocean.assets.create(
         metadata,
         publisher,
-        files,
-        datatoken_templates=[1],
-        datatoken_names=["Datatoken 1"],
-        datatoken_symbols=["DT1"],
-        datatoken_minters=[publisher.address],
-        datatoken_fee_managers=[publisher.address],
-        datatoken_publish_market_order_fee_addresses=[ZERO_ADDRESS],
-        datatoken_publish_market_order_fee_tokens=[ocean.OCEAN_address],
-        datatoken_publish_market_order_fee_amounts=[0],
-        datatoken_bytess=[[b""]],
+        datatoken_arguments=[
+            DatatokenArguments(name="Datatoken 1", symbol="DT1", files=files)
+        ],
     )
 
     return ddo

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -99,6 +99,19 @@ def get_default_files():
     return [get_file1(), get_file2()]
 
 
+def build_default_services(config, datatoken):
+    files = get_default_files()
+    services = [
+        datatoken.build_access_service(
+            service_id="0",
+            service_endpoint=config.get("PROVIDER_URL"),
+            files=files,
+        )
+    ]
+
+    return services
+
+
 def get_registered_asset_with_access_service(
     ocean_instance, publisher_wallet, metadata=None, more_files=False
 ):
@@ -111,13 +124,7 @@ def get_registered_asset_with_access_service(
     data_nft, dts, ddo = ocean_instance.assets.create(
         metadata,
         publisher_wallet,
-        datatoken_arguments=[
-            DatatokenArguments(
-                name="Branin: DT1",
-                symbol="DT1",
-                files=files,
-            )
-        ],
+        datatoken_args=[DatatokenArguments("Branin: DT1", "DT1", files=files)],
     )
 
     return data_nft, dts[0], ddo
@@ -212,13 +219,7 @@ def get_registered_algorithm_with_access_service(
     return ocean_instance.assets.create(
         metadata=metadata,
         publisher_wallet=publisher_wallet,
-        datatoken_arguments=[
-            DatatokenArguments(
-                name="Algo DT1",
-                symbol="DT1",
-                files=[algorithm_file],
-            )
-        ],
+        datatoken_args=[DatatokenArguments("Algo DT1", "DT1", files=[algorithm_file])],
     )
 
 

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -112,15 +112,18 @@ def create_basics(
 
 
 def get_registered_asset_with_access_service(
-    ocean_instance, publisher_wallet, metadata=None
+    ocean_instance, publisher_wallet, metadata=None, return_ddo=True
 ):
     url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
     files = [UrlFile(url)]
-    _, _, ddo = ocean_instance.assets._create1(
-        "Branin dataset", files, publisher_wallet
+    result = ocean_instance.assets._create1(
+        "Branin dataset", files, publisher_wallet, metadata=metadata
     )
 
-    return ddo
+    if return_ddo:
+        return result[2]
+    else:
+        return result
 
 
 def get_registered_asset_with_compute_service(

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -93,41 +93,6 @@ def get_access_service(
     )
 
 
-def create_asset(ocean, publisher, metadata=None, files=None):
-    """Helper function for asset creation based on ddo_sa_sample.json."""
-    if not metadata:
-        metadata = {
-            "created": "2020-11-15T12:27:48Z",
-            "updated": "2021-05-17T21:58:02Z",
-            "description": "Sample description",
-            "name": "Sample asset",
-            "type": "dataset",
-            "author": "OPF",
-            "license": "https://market.oceanprotocol.com/terms",
-        }
-
-    if not files:
-        file1_dict = {
-            "type": "url",
-            "url": "https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-abstract10.xml.gz-rss.xml",
-            "method": "GET",
-        }
-        file1 = FilesTypeFactory(file1_dict)
-        files = [file1]
-
-    # Publish asset with services on-chain.
-    # The download (access service) is automatically created
-    ddo = ocean.assets.create(
-        metadata,
-        publisher,
-        datatoken_arguments=[
-            DatatokenArguments(name="Datatoken 1", symbol="DT1", files=files)
-        ],
-    )
-
-    return ddo
-
-
 def create_basics(
     config,
     data_provider,
@@ -161,8 +126,16 @@ def create_basics(
     return data_nft_factory, metadata, files
 
 
-def get_registered_asset_with_access_service(ocean_instance, publisher_wallet):
-    return create_asset(ocean_instance, publisher_wallet)
+def get_registered_asset_with_access_service(
+    ocean_instance, publisher_wallet, metadata=None
+):
+    url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
+    files = [UrlFile(url)]
+    _, _, ddo = ocean_instance.assets._create1(
+        "Branin dataset", files, publisher_wallet
+    )
+
+    return ddo
 
 
 def get_registered_asset_with_compute_service(
@@ -251,11 +224,16 @@ def get_registered_algorithm_with_access_service(
         }
     )
 
-    return create_asset(
-        ocean_instance,
-        publisher_wallet,
+    return ocean_instance.assets.create(
         metadata=metadata,
-        files=[algorithm_file],
+        publisher_wallet=publisher_wallet,
+        datatoken_arguments=[
+            DatatokenArguments(
+                name="Algo DT1",
+                symbol="DT1",
+                files=[algorithm_file],
+            )
+        ],
     )
 
 

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -104,9 +104,23 @@ def get_registered_asset_with_access_service(
 ):
     url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
     files = [UrlFile(url)] if not more_files else [UrlFile(url), get_file2()]
-    return ocean_instance.assets._create1(
-        "Branin dataset", files, publisher_wallet, metadata=metadata
+
+    if not metadata:
+        metadata = get_default_metadata()
+
+    data_nft, dts, ddo = ocean_instance.assets.create(
+        metadata,
+        publisher_wallet,
+        datatoken_arguments=[
+            DatatokenArguments(
+                name="Branin: DT1",
+                symbol="DT1",
+                files=files,
+            )
+        ],
     )
+
+    return data_nft, dts[0], ddo
 
 
 def get_registered_asset_with_compute_service(

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -5,7 +5,6 @@
 import json
 import os
 import pathlib
-import time
 from typing import List, Optional
 
 import requests
@@ -78,21 +77,7 @@ def get_sample_algorithm_ddo(filename="ddo_algorithm.json") -> DDO:
     return DDO.from_dict(get_sample_algorithm_ddo_dict(filename))
 
 
-def get_access_service(
-    ocean_instance, address, date_created, provider_uri=None, timeout=3600
-):
-    if not provider_uri:
-        provider_uri = DataServiceProvider.get_url(ocean_instance.config_dict)
-
-    return ocean_instance.assets.build_access_service(
-        DataServiceProvider.build_download_endpoint(provider_uri)[1],
-        date_created,
-        1.0,
-        address,
-        timeout,
-    )
-
-
+# TODO: maybe remove
 def create_basics(
     config,
     data_provider,
@@ -266,24 +251,6 @@ def get_registered_algorithm_ddo_different_provider(ocean_instance, wallet):
 def build_credentials_dict() -> dict:
     """Build a credentials dict, used for testing."""
     return {"allow": [], "deny": []}
-
-
-def wait_for_asset(ocean, did, timeout=30):
-    start = time.time()
-    ddo = None
-    while not ddo:
-        try:
-            ddo = ocean.assets.resolve(did)
-        except ValueError:
-            pass
-
-        if not ddo:
-            time.sleep(0.2)
-
-        if time.time() - start > timeout:
-            break
-
-    return ddo
 
 
 def get_first_service_by_type(ddo, service_type: str) -> Service:

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -112,18 +112,13 @@ def create_basics(
 
 
 def get_registered_asset_with_access_service(
-    ocean_instance, publisher_wallet, metadata=None, return_ddo=True
+    ocean_instance, publisher_wallet, metadata=None
 ):
     url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
     files = [UrlFile(url)]
-    result = ocean_instance.assets._create1(
+    return ocean_instance.assets._create1(
         "Branin dataset", files, publisher_wallet, metadata=metadata
     )
-
-    if return_ddo:
-        return result[2]
-    else:
-        return result
 
 
 def get_registered_asset_with_compute_service(
@@ -242,12 +237,6 @@ def get_raw_algorithm() -> str:
                 "checksum": "sha256:8221d20c1c16491d7d56b9657ea09082c0ee4a8ab1a6621fa720da58b09580e4",
             },
         }
-    )
-
-
-def get_registered_algorithm_ddo_different_provider(ocean_instance, wallet):
-    return get_registered_algorithm_with_access_service(
-        ocean_instance, wallet, "http://172.15.0.7:8030"
     )
 
 


### PR DESCRIPTION
Closes #1094

Here's what I did:
### refactored the arguments for create() entirely and added defaults
- `data_nft_arguments` is a DataNFTArguments object and gets published using defaults from the publisher wallet
- `datatoken_arguments` is a list of DatatokenArguments objects which gets published using defaults from the publisher wallet, but can be customised with files, services etc. Each datatoken to be created has their own list of services, there is no more weird mapping and default adding boilerplate, removing confusion as to 1:n/1:1 service mapping etc.
- when using already `deployed_datatokens`, the user is required to provide the `services` already created. We do not add defaults on already created datatokens, because it assumes to much about the structure. If the user chooses such a customised flow, we assume they will also customise or create services. I think this is a fair tradeoff between providing good defaults and allowing for customisation
- removed the `return_ddo` parameter, now the function always returns a tuple
- removed the boilerplate that mapped lists of datatokens to lists of services

### others
- used utilitary functions and good defaults like `create_url_asset` in tests that don't particularly test asset creation. All customisations are tested inside ocean_assets and the special graphql and onchain tests, while tests for other functionalities use really basic assets to avoid complexity.
- removed some test boilerplate in support/preparation of #1155

### Open to discussion
I renamed `create1` as `create_with_default_metadata` but the following still stands.
- The main difference between create and create1 is that create1 returns just the first datatoken in the tuple. I kept it because of this simplification, but we can still remove it if necessary.
- Metadata requirement: metadata is now required on `create` but not on `create1`. Instead, `create1` requires a name, from where it derives some common sense metadata. I can add the same defaults in `create` but I'm not sure we should do that. This is related to the previous item, so I will wait on the answers for that first.