### PR TITLE
Towards #1108:In C2D README, show how to submit an algorithm for use by C2D *including docker container*

### DIFF
--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -107,40 +107,10 @@ In the same Python console:
 ALGO_url = "https://raw.githubusercontent.com/oceanprotocol/c2d-examples/main/branin_and_gpr/gpr.py"
 
 name = "grp"
-(ALGO_data_nft, ALGO_datatoken, ALGO_ddo) = ocean.assets.create_url_asset(name, ALGO_url, alice_wallet, wait_for_aqua=True)
+(ALGO_data_nft, ALGO_datatoken, ALGO_ddo) = ocean.assets.create_url_algorithm(name, ALGO_url, alice_wallet, wait_for_aqua=True)
 
 print(f"ALGO_data_nft address = '{ALGO_data_nft.address}'")
 print(f"ALGO_datatoken address = '{ALGO_datatoken.address}'")
-
-# Specify metadata and services, using the Branin test dataset
-ALGO_date_created = "2021-12-28T10:55:11Z"
-ALGO_metadata = {
-    "created": ALGO_date_created,
-    "updated": ALGO_date_created,
-    "description": "gpr",
-    "name": "gpr",
-    "type": "algorithm",
-    "author": "Trent",
-    "license": "CC0: PublicDomain",
-    "algorithm": {
-        "language": "python",
-        "format": "docker-image",
-        "version": "0.1",
-        "container": {
-            "entrypoint": "python $ALGO",
-            "image": "oceanprotocol/algo_dockers",
-            "tag": "python-branin",
-            "checksum": "sha256:8221d20c1c16491d7d56b9657ea09082c0ee4a8ab1a6621fa720da58b09580e4",
-        },
-    }
-}
-
-# update ALGO_Asset metadata
-ALGO_ddo.metadata.update(ALGO_metadata)
-ALGO_ddo = ocean.assets.update(
-    asset=ALGO_ddo, publisher_wallet=alice_wallet, provider_uri=config["PROVIDER_URL"])
-    
-
 print(f"ALGO_ddo did = '{ALGO_ddo.did}'")
 ```
 

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -227,6 +227,29 @@ class OceanAssets:
         assert "name" in metadata, "Must have name in metadata."
 
     @enforce_types
+    def create_url_algorithm(
+        self, name: str, url: str, publisher_wallet, wait_for_aqua: bool = True, algo_info: dict = None,
+    ) -> tuple:
+        """Create an asset of type "algorithm", with good defaults"""
+        if not algo_info:
+            algo_info = {
+                "algorithm": {
+                    "language": "python",
+                    "format": "docker-image",
+                    "version": "0.1",
+                    "container": {
+                        "entrypoint": "python $ALGO",
+                        "image": "oceanprotocol/algo_dockers",
+                        "tag": "python-branin",
+                        "checksum": "sha256:8221d20c1c16491d7d56b9657ea09082c0ee4a8ab1a6621fa720da58b09580e4",
+                    },
+                }
+            }
+
+        files = [UrlFile(url)]
+        return self._create1(name, files, publisher_wallet, wait_for_aqua, algo_info)
+
+    @enforce_types
     def create_url_asset(
         self, name: str, url: str, publisher_wallet, wait_for_aqua: bool = True
     ) -> tuple:
@@ -269,6 +292,7 @@ class OceanAssets:
         files: list,
         publisher_wallet,
         wait_for_aqua: bool = True,
+        algo_info: dict = None
     ) -> tuple:
         """Thin wrapper for create(). Creates 1 datatoken, with good defaults.
 
@@ -286,6 +310,10 @@ class OceanAssets:
             "author": publisher_wallet.address[:7],
             "license": "CC0: PublicDomain",
         }
+
+        if algo_info:
+            metadata["type"] = "algorithm"
+            metadata["algorithm"] = algo_info["algorithm"]
 
         OCEAN_address = get_ocean_token_address(self._config_dict)
         (data_nft, datatokens, ddo) = self.create(


### PR DESCRIPTION
Towards #1108.

Changes proposed in this PR:

- Uses `create_url_algo` to cerate assets that are algorithms. Set one of the ocean docker-images as default if the user does not provides `algo_info` which is a dictionary that contains all the required parameters for the algorithm. The default algo info is: 

```
         "algorithm": {
                    "language": "python",
                    "format": "docker-image",
                    "version": "0.1",
                    "container": {
                        "entrypoint": "python $ALGO",
                        "image": "oceanprotocol/algo_dockers",
                        "tag": "python-branin",
                        "checksum": "sha256:8221d20c1c16491d7d56b9657ea09082c0ee4a8ab1a6621fa720da58b09580e4",
                    },
                }

```
-  The default image contains the libraries listed [here](https://github.com/oceanprotocol/algo_dockers/blob/main/python-branin/requirements.txt)
- 