### PR TITLE
Updated version for eth-brownie.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requirements = [
     "enforce-typing==1.0.0.post1",
     "json-sempai==0.4.0",
     "eciespy",
-    "eth-brownie==1.19.1",
+    "eth-brownie==1.19.2",
     # web3 requires eth-abi, requests, and more,
     # so those will be installed too.
     # See https://github.com/ethereum/web3.py/blob/master/setup.py

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requirements = [
     "enforce-typing==1.0.0.post1",
     "json-sempai==0.4.0",
     "eciespy",
-    "eth-brownie==1.19.2",
+    "eth-brownie",
     # web3 requires eth-abi, requests, and more,
     # so those will be installed too.
     # See https://github.com/ethereum/web3.py/blob/master/setup.py
@@ -63,7 +63,7 @@ dev_requirements = [
     "watchdog",
     "flake8==5.0.4",
     "isort==5.10.1",
-    "black==22.10.0",  # need to keep this up to date to brownie
+    "black",  # need to keep this up to date to brownie
     "pre-commit",
     # for the following: maybe needed, maybe not
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ dev_requirements = [
     "watchdog",
     "flake8==5.0.4",
     "isort==5.10.1",
-    "black==22.6.0",  # need to keep this up to date to brownie
+    "black==22.10.0",  # need to keep this up to date to brownie
     "pre-commit",
     # for the following: maybe needed, maybe not
     "pytest",

--- a/tests/integration/remote/test_polygon.py
+++ b/tests/integration/remote/test_polygon.py
@@ -20,9 +20,8 @@ def test_ocean_tx__create_data_nft(tmp_path, monkeypatch):
     monkeypatch.delenv("ADDRESS_FILE")
     # setup
     connect_to_network("polygon")
+    brownie.web3.middleware_stack.inject(geth_poa_middleware, layer=0)
     util.set_aggressive_gas_fees()
-    brownie.web3._custom_middleware.add(geth_poa_middleware)
-    brownie.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     config = get_config_dict("polygon")
     ocean = Ocean(config)

--- a/tests/integration/remote/test_polygon.py
+++ b/tests/integration/remote/test_polygon.py
@@ -2,8 +2,10 @@
 # Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
+import brownie
 import pytest
 from brownie.network import accounts
+from web3.middleware import geth_poa_middleware
 
 from ocean_lib.example_config import get_config_dict
 from ocean_lib.ocean.ocean import Ocean
@@ -19,6 +21,8 @@ def test_ocean_tx__create_data_nft(tmp_path, monkeypatch):
     # setup
     connect_to_network("polygon")
     util.set_aggressive_gas_fees()
+    brownie.web3._custom_middleware.add(geth_poa_middleware)
+    brownie.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     config = get_config_dict("polygon")
     ocean = Ocean(config)

--- a/tests/integration/remote/test_polygon.py
+++ b/tests/integration/remote/test_polygon.py
@@ -2,10 +2,8 @@
 # Copyright 2022 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-import brownie
 import pytest
 from brownie.network import accounts
-from web3.middleware import geth_poa_middleware
 
 from ocean_lib.example_config import get_config_dict
 from ocean_lib.ocean.ocean import Ocean
@@ -20,7 +18,6 @@ def test_ocean_tx__create_data_nft(tmp_path, monkeypatch):
     monkeypatch.delenv("ADDRESS_FILE")
     # setup
     connect_to_network("polygon")
-    brownie.web3.middleware_stack.inject(geth_poa_middleware, layer=0)
     util.set_aggressive_gas_fees()
 
     config = get_config_dict("polygon")


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- updated brownie to 1.19.2
- inject POA middleware for polygon test