### PR TITLE
Fixes #1185 test_data_nft.py call to create_exchange() has wrongly-named argument "publish_market_fee_amount" 

### DIFF
--- a/ocean_lib/models/test/test_data_nft.py
+++ b/ocean_lib/models/test/test_data_nft.py
@@ -748,7 +748,7 @@ def test_nft_transfer_with_fre(
     (exchange, tx) = datatoken.create_exchange(
         rate=to_wei(1),
         base_token_addr=OCEAN.address,
-        publish_market_fee_amount=to_wei(0.01),
+        publish_market_fee=to_wei(0.01),
         with_mint=True,
         tx_dict={"from": consumer_wallet},
     )


### PR DESCRIPTION
Fixes #1185 