### PR TITLE
Towards #1161 part 1. Approach here: deprecate download_file()

### DIFF
--- a/READMEs/consume-flow.md
+++ b/READMEs/consume-flow.md
@@ -52,8 +52,11 @@ datatoken.mint(to_address, amt_tokens, {"from": alice_wallet})
 
 In the same Python console:
 ```python
-# Bob sends a datatoken to the service to get access; then downloads
-file_name = ocean.assets.download_file(ddo.did, bob_wallet)
+# Bob sends a datatoken to the service to get access
+order_tx_id = ocean.assets.pay_for_access_service(ddo, bob_wallet)
+
+# Bob downloads the file. If the connection breaks, Bob can try again
+file_name = ocean.assets.download_asset(ddo, bob_wallet, './', order_tx_id)
 ```
 
 Bob can verify that the file is downloaded. In a new console:
@@ -68,33 +71,7 @@ Congrats to Bob for buying and consuming a data asset!
 
 ## Appendix. Further Flexibility
 
-Step 4's `download_file()` did three things:
-
-- Checked if Bob has access tokens. Bob did, so nothing else needed
-- Sent a datatoken to the service to get access
-- Downloaded the file
-
-Here are the last two steps, un-bundled.
-
-In the same Python console:
-```python
-# Bob sends a datatoken to the service, to get access
-order_tx_id = ocean.assets.pay_for_access_service(ddo, bob_wallet)
-print(f"order_tx_id = '{order_tx_id}'")
-
-# Bob downloads the file
-# If the connection breaks, Bob can request again by showing order_tx_id.
-consumer_wallet = bob_wallet
-destination = './'
-file_path = ocean.assets.download_asset(
-    ddo, consumer_wallet, destination, order_tx_id
-)
-```
-
-
-## Appendix: Further Flexibility Yet
-
-We can un-bundle even further:
+We can un-bundle the steps further:
 - `pay_for_access_service()` fills in good defaults of using the 0th service (if >1 services available) and zero fees.
 - And `download_asset()` fills in a good default for `service` too, as well as for `index` and `userdata` (not shown).
 

--- a/READMEs/publish-flow-restapi.md
+++ b/READMEs/publish-flow-restapi.md
@@ -63,7 +63,7 @@ In the same Python console:
 ddo_did = ddo.did
 
 # Bob gets a free datatoken, sends it to the service, and downloads
-datatoken.dispense(to_wei(1), {"from": bob_wallet})
+datatoken.dispense("1 ether", {"from": bob_wallet})
 order_tx_id = ocean.assets.pay_for_access_service(ddo, bob_wallet)
 file_name = ocean.assets.download_asset(ddo, bob_wallet, './', order_tx_id)
 ```

--- a/READMEs/publish-flow-restapi.md
+++ b/READMEs/publish-flow-restapi.md
@@ -63,7 +63,9 @@ In the same Python console:
 ddo_did = ddo.did
 
 # Bob gets a free datatoken, sends it to the service, and downloads
-file_name = ocean.assets.download_file(ddo_did, bob_wallet)
+datatoken.dispense(to_wei(1), {"from": bob_wallet})
+order_tx_id = ocean.assets.pay_for_access_service(ddo, bob_wallet)
+file_name = ocean.assets.download_asset(ddo, bob_wallet, './', order_tx_id)
 ```
 
 Now, load the file and use its data.
@@ -89,35 +91,3 @@ data = eval(data_str)
 close_prices = [float(data_at_day[4]) for data_at_day in data]
 ```
 
-## Appendix. Further Flexibility
-
-Step 4's `download_file()` did three things:
-
-- Checked if Bob has access tokens. He didn't, so the dispenser gave him some
-- Sent a datatoken to the service to get access
-- Downloaded the file
-
-Here are the three steps, un-bundled.
-
-In the same Python console:
-```python
-# Bob gets an access token from the faucet dispenser
-ddo = ocean.assets.resolve(ddo_did)
-datatoken_address = ddo.datatokens[0]["address"]
-datatoken = ocean.get_datatoken(datatoken_address)
-datatoken.dispense("1 ether", {"from": bob_wallet})
-
-# Bob sends a datatoken to the service to get access
-order_tx_id = ocean.assets.pay_for_access_service(ddo, bob_wallet)
-
-# Bob downloads the dataset
-# If the connection breaks, Bob can request again by showing order_tx_id.
-consumer_wallet = bob_wallet
-destination = './'
-file_path = ocean.assets.download_asset(
-    ddo, consumer_wallet, destination, order_tx_id
-)
-import glob
-file_name = glob.glob(file_path + "/*")[0]
-print(f"file_name: '{file_name}'")
-```

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -94,28 +94,3 @@ def test_consume_flow(
     assert (
         len(os.listdir(os.path.join(destination, os.listdir(destination)[0]))) == 1
     ), "The asset folder is empty."
-
-
-@pytest.mark.integration
-def test_compact_publish_and_consume(
-    config: dict,
-    publisher_wallet,
-    consumer_wallet,
-):
-    data_provider = DataServiceProvider
-    ocean_assets = OceanAssets(config, data_provider)
-
-    # publish
-    name = "My asset"
-    url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
-    (data_nft, datatoken, ddo) = ocean_assets.create_url_asset(
-        name, url, publisher_wallet
-    )
-
-    # share access
-    datatoken.mint(
-        consumer_wallet.address, Web3.toWei(1, "ether"), {"from": publisher_wallet}
-    )
-
-    # consume
-    _ = ocean_assets.download_file(ddo.did, consumer_wallet)


### PR DESCRIPTION
Fixes part 1 of #1161

The problem was in download_file() not handling enterprise datatoken doing dispense. (All other methods of ocean.py can handle enterprise datatoken). However, to fix it turns the download_file() code from being about 30 lines, to about 250 lines. Even after being optimized, it'd probably be 50-60 lines. And, in that logic, there's a lot going on. Happy path it's fine, but what about when txs fail.

Here's another way. Since writing download_file() several weeks ago, I have realized that it's much cleaner to separate things into 2-3 clean functions. (And did this in predict-eth judging.) Those steps:
1. (if needed) get tokens, via exchange or dispenser or otherwise
2. pay for access service
3. download the asset

Also since writing download_file(), those steps have emerged to be clean! :) 

So, _this_ PR fixes the issue by:
- deprecating download_file
- revising consume-flow README, to use steps 2 + 3 directly (vs combined)
- revising publish-flow-restapi, to use steps 1 + 2 + 3 directly
