### PR TITLE
Use tx dicts in higher-level write functions

### DIFF
--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -158,7 +158,7 @@ datasets, algorithm = ocean.assets.pay_for_compute_service(
     datasets=[DATA_compute_input],
     algorithm_data=ALGO_compute_input,
     consume_market_order_fee_address=bob.address,
-    wallet=bob,
+    tx_dict={"from": bob},
     compute_environment=free_c2d_env["id"],
     valid_until=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
     consumer_address=free_c2d_env["consumerAddress"],

--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -86,7 +86,7 @@ DATA_compute_service = Service(
 
 # Add service and update asset
 DATA_ddo.add_service(DATA_compute_service)
-DATA_ddo = ocean.assets.update(DATA_ddo, alice)
+DATA_ddo = ocean.assets.update(DATA_ddo, {"from": alice})
 
 print(f"DATA_ddo did = '{DATA_ddo.did}'")
 ```
@@ -113,7 +113,7 @@ In the same Python console:
 ```python
 compute_service = DATA_ddo.services[1]
 compute_service.add_publisher_trusted_algorithm(ALGO_ddo)
-DATA_ddo = ocean.assets.update(DATA_ddo, alice)
+DATA_ddo = ocean.assets.update(DATA_ddo, {"from": alice})
 
 ```
 

--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -57,7 +57,7 @@ DATA_url_file = UrlFile(
 )
 
 name = "Branin dataset"
-(DATA_data_nft, DATA_datatoken, DATA_ddo) = ocean.assets.create_url_asset(name, DATA_url_file.url, alice, wait_for_aqua=True)
+(DATA_data_nft, DATA_datatoken, DATA_ddo) = ocean.assets.create_url_asset(name, DATA_url_file.url, {"from": alice}, wait_for_aqua=True)
 print(f"DATA_data_nft address = '{DATA_data_nft.address}'")
 print(f"DATA_datatoken address = '{DATA_datatoken.address}'")
 
@@ -100,7 +100,7 @@ In the same Python console:
 ALGO_url = "https://raw.githubusercontent.com/oceanprotocol/c2d-examples/main/branin_and_gpr/gpr.py"
 
 name = "grp"
-(ALGO_data_nft, ALGO_datatoken, ALGO_ddo) = ocean.assets.create_algo_asset(name, ALGO_url, alice, wait_for_aqua=True)
+(ALGO_data_nft, ALGO_datatoken, ALGO_ddo) = ocean.assets.create_algo_asset(name, ALGO_url, {"from": alice}, wait_for_aqua=True)
 
 print(f"ALGO_data_nft address = '{ALGO_data_nft.address}'")
 print(f"ALGO_datatoken address = '{ALGO_datatoken.address}'")

--- a/READMEs/df.md
+++ b/READMEs/df.md
@@ -110,7 +110,7 @@ assert DT_bal >= num_consumes, \
 # Alice sends datatokens to the service, to get access. This is the "consume".
 for i in range(num_consumes):
     print(f"Consume #{i+1}/{num_consumes}...")
-    ocean.assets.pay_for_access_service(ddo, alice)
+    ocean.assets.pay_for_access_service(ddo, {"from": alice})
     #don't need to call e.g. ocean.assets.download_asset() since wash-consuming
 ```
 

--- a/READMEs/df.md
+++ b/READMEs/df.md
@@ -1,3 +1,7 @@
+<!--
+Copyright 2022 Ocean Protocol Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
 # Quickstart: Data Farming Flow
 
 This README shows how to do steps in Ocean Data Farming (DF), where you curate data assets to earn rewards. It also helps to democratize "wash consume" until it becomes unprofitable.
@@ -24,7 +28,7 @@ Ensure that you've already (a) [installed Ocean](install.md), and (b) [set up lo
 First, let's set some key parameters for veOCEAN and DF. On Ganache, you can use these values as-is. But on Eth mainnet, you must choose your own. In the same Python console:
 ```python
 # On your asset, your DCV = DT_price * num_consumes
-# Your asset gets rewards pro-rata for its DCV compared to other assets' DCVs. 
+# Your asset gets rewards pro-rata for its DCV compared to other assets' DCVs.
 DT_price = 100.0 # number of OCEAN needed to buy one datatoken
 num_consumes = 3
 
@@ -42,7 +46,7 @@ WEEK = 7 * 86400 # seconds in a week
 t0 = chain.time()
 t1 = t0 // WEEK * WEEK + WEEK #this is a Thursday, because Jan 1 1970 was
 t2 = t1 + WEEK
-chain.sleep(t1 - t0) 
+chain.sleep(t1 - t0)
 chain.mine()
 
 #we're now at the beginning of the week. So, lock
@@ -62,7 +66,7 @@ name = "Branin dataset"
 url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
 
 #create data asset
-(data_NFT, DT, ddo) = ocean.assets.create_url_asset(name, url, alice, wait_for_aqua=False)
+(data_NFT, DT, ddo) = ocean.assets.create_url_asset(name, url, {"from": alice}, wait_for_aqua=False)
 print(f"Just published asset, with data_NFT.address={data_NFT.address}")
 
 #create exchange
@@ -120,14 +124,14 @@ WEEK = 7 * 86400 # seconds in a week
 t0 = chain.time()
 t1 = t0 // WEEK * WEEK + WEEK
 t2 = t1 + WEEK
-chain.sleep(t1 - t0) 
+chain.sleep(t1 - t0)
 chain.mine()
 
 #Rewards can be claimed via code or webapp, at your leisure. Let's do it now.
 OCEAN_before = from_wei(OCEAN.balanceOf(alice))
 ocean.ve_fee_distributor.claim({"from": alice})
 OCEAN_after = from_wei(OCEAN.balanceOf(alice))
-print(f"Just claimed {OCEAN_after - OCEAN_before} OCEAN rewards") 
+print(f"Just claimed {OCEAN_after - OCEAN_before} OCEAN rewards")
 ```
 
 ## 7. Repeat steps 1-6, for Eth mainnet

--- a/READMEs/key-value-flow.md
+++ b/READMEs/key-value-flow.md
@@ -25,7 +25,7 @@ Ensure that you've already (a) [installed Ocean](install.md), and (b) [set up lo
 In Python console:
 ```python
 from ocean_lib.models.data_nft import DataNFTArguments
-data_nft = ocean.data_nft_factory.create(DataNFTArguments('NFT1', 'NFT1'), alice)
+data_nft = ocean.data_nft_factory.create(DataNFTArguments('NFT1', 'NFT1'), {"from": alice})
 ```
 
 ## 3. Add key-value pair to data NFT

--- a/READMEs/main-flow.md
+++ b/READMEs/main-flow.md
@@ -90,7 +90,7 @@ Bob now has the datatoken for the dataset! Time to download the dataset and use 
 In the same Python console:
 ```python
 # Bob sends a datatoken to the service to get access
-order_tx_id = ocean.assets.pay_for_access_service(ddo, bob)
+order_tx_id = ocean.assets.pay_for_access_service(ddo, {"from": bob})
 
 # Bob downloads the file. If the connection breaks, Bob can try again
 asset_dir = ocean.assets.download_asset(ddo, bob, './', order_tx_id)

--- a/READMEs/main-flow.md
+++ b/READMEs/main-flow.md
@@ -25,7 +25,7 @@ name = "Branin dataset"
 url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
 
 #create data asset
-(data_nft, datatoken, ddo) = ocean.assets.create_url_asset(name, url, alice)
+(data_nft, datatoken, ddo) = ocean.assets.create_url_asset(name, url, {"from": alice})
 
 #print
 print("Just published asset:")
@@ -219,7 +219,7 @@ url_file = UrlFile(
 from ocean_lib.models.datatoken import DatatokenArguments
 _, _, ddo = ocean.assets.create(
     metadata,
-    alice,
+    {"from": alice},
     datatoken_args=[DatatokenArguments(files=[url_file])],
 )
 ```
@@ -240,7 +240,7 @@ You can control this during create():
 Calling `create()` like above generates a data NFT, a datatoken for that NFT, and a ddo. This is the most common case. However, sometimes you may want _just_ the data NFT, e.g. if using a data NFT as a simple key-value store. Here's how:
 ```python
 from ocean_lib.models.data_nft import DataNFTArguments
-data_nft = ocean.data_nft_factory.create(DataNFTArguments('NFT1', 'NFT1'), alice)
+data_nft = ocean.data_nft_factory.create(DataNFTArguments('NFT1', 'NFT1'), {"from": alice})
 ```
 
 If you call `create()` after this, you can pass in an argument `data_nft_address:string` and it will use that NFT rather than creating a new one.
@@ -251,7 +251,7 @@ Calling `create()` like above generates a data NFT, a datatoken for that NFT, an
 
 ```python
 from ocean_lib.models.datatoken import DatatokenArguments
-datatoken = data_nft.create_datatoken(DatatokenArguments("Datatoken 1", "DT1"), alice)
+datatoken = data_nft.create_datatoken(DatatokenArguments("Datatoken 1", "DT1"), {"from": alice})
 ```
 
 If you call `create()` after this, you can pass in an argument `deployed_datatokens:List[Datatoken]` and it will use those datatokens during creation.

--- a/READMEs/profile-nfts-flow.md
+++ b/READMEs/profile-nfts-flow.md
@@ -28,7 +28,7 @@ In the Python console:
 ```python
 # Publish an NFT token. Note "transferable=False"
 from ocean_lib.models.data_nft import DataNFTArguments
-data_nft = ocean.data_nft_factory.create(DataNFTArguments('NFT1', 'NFT1', transferable=False), alice)
+data_nft = ocean.data_nft_factory.create(DataNFTArguments('NFT1', 'NFT1', transferable=False), {"from": alice})
 ```
 
 ## 3. Alice adds key-value pair to data NFT. 'value' encrypted with a symmetric key 'symkey'

--- a/READMEs/publish-flow-graphql.md
+++ b/READMEs/publish-flow-graphql.md
@@ -36,7 +36,7 @@ query="""query{
 """
 
 #create asset
-(data_nft, datatoken, ddo) = ocean.assets.create_graphql_asset(name, url, query, alice)
+(data_nft, datatoken, ddo) = ocean.assets.create_graphql_asset(name, url, query, {"from": alice})
 print(f"Just published asset, with did={ddo.did}")
 ```
 

--- a/READMEs/publish-flow-onchain.md
+++ b/READMEs/publish-flow-onchain.md
@@ -37,7 +37,7 @@ contract_abi = {
 		}
 
 #create asset
-(data_nft, datatoken, ddo) = ocean.assets.create_onchain_asset(name, contract_address, contract_abi, alice)
+(data_nft, datatoken, ddo) = ocean.assets.create_onchain_asset(name, contract_address, contract_abi, {"from": alice})
 print(f"Just published asset, with did={ddo.did}")
 ```
 

--- a/READMEs/publish-flow-restapi.md
+++ b/READMEs/publish-flow-restapi.md
@@ -33,7 +33,7 @@ start_datetime = end_datetime - timedelta(days=7) #the previous week
 url = f"https://api.binance.com/api/v3/klines?symbol=ETHUSDT&interval=1d&startTime={int(start_datetime.timestamp())*1000}&endTime={int(end_datetime.timestamp())*1000}"
 
 #create asset
-(data_nft, datatoken, ddo) = ocean.assets.create_url_asset(name, url, alice)
+(data_nft, datatoken, ddo) = ocean.assets.create_url_asset(name, url, {"from": alice})
 print(f"Just published asset, with did={ddo.did}")
 ```
 

--- a/READMEs/publish-flow-restapi.md
+++ b/READMEs/publish-flow-restapi.md
@@ -55,7 +55,7 @@ ddo_did = ddo.did
 
 # Bob gets a free datatoken, sends it to the service, and downloads
 datatoken.dispense("1 ether", {"from": bob})
-order_tx_id = ocean.assets.pay_for_access_service(ddo, bob)
+order_tx_id = ocean.assets.pay_for_access_service(ddo, {"from": bob})
 asset_dir = ocean.assets.download_asset(ddo, bob, './', order_tx_id)
 
 import os

--- a/READMEs/search-and-filter-assets.md
+++ b/READMEs/search-and-filter-assets.md
@@ -15,7 +15,7 @@ Ensure that you've already (a) [installed Ocean](install.md), and (b) [set up lo
 
 ## 2. Alice publishes datasets
 
-Now, you're Alice. 
+Now, you're Alice.
 
 ```python
 #data info
@@ -30,9 +30,9 @@ tags = [
 ]
 # Publish few assets for testing
 for tag in tags:
-    (data_NFT, datatoken, ddo) = ocean.assets.create_url_asset(name, url, alice)
+    (data_NFT, datatoken, ddo) = ocean.assets.create_url_asset(name, url, {"from": alice})
     print(f"Just published asset, with did={ddo.did}")
-    
+
     # Update the metadata introducing `tags`
     ddo.metadata.update({"tags": tag})
     ddo = ocean.assets.update(ddo, alice, config["PROVIDER_URL"])

--- a/READMEs/search-and-filter-assets.md
+++ b/READMEs/search-and-filter-assets.md
@@ -35,7 +35,7 @@ for tag in tags:
 
     # Update the metadata introducing `tags`
     ddo.metadata.update({"tags": tag})
-    ddo = ocean.assets.update(ddo, alice, config["PROVIDER_URL"])
+    ddo = ocean.assets.update(ddo, {"from": alice}, config["PROVIDER_URL"])
     print(f"Just updated the metadata of the asset with did={ddo.did}.")
 
 ```

--- a/ocean_lib/aquarius/test/test_aquarius.py
+++ b/ocean_lib/aquarius/test/test_aquarius.py
@@ -22,7 +22,7 @@ def test_aqua_functions_for_single_ddo(publisher_ocean, publisher_wallet, file1)
     aquarius = publisher_ocean.assets._aquarius
 
     _, _, ddo1 = publisher_ocean.assets.create_url_asset(
-        "Sample asset", file1.url, publisher_wallet
+        "Sample asset", file1.url, {"from": publisher_wallet}
     )
 
     metadata1 = ddo1.metadata

--- a/ocean_lib/assets/test/test_asset_downloader.py
+++ b/ocean_lib/assets/test/test_asset_downloader.py
@@ -177,7 +177,7 @@ def test_ocean_assets_download_destination_file(
         service_index=ddo.get_index_of_service(access_service),
         provider_fees=provider_fees,
         consume_market_fees=consume_market_fees,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
     )
 
     orders = publisher_ocean.get_user_orders(

--- a/ocean_lib/models/data_nft.py
+++ b/ocean_lib/models/data_nft.py
@@ -44,8 +44,8 @@ class Flags(IntFlag):
 class DataNFT(ContractBase):
     CONTRACT_NAME = "ERC721Template"
 
-    def create_datatoken(self, datatoken_args, transaction_parameters) -> Datatoken:
-        return datatoken_args.create_datatoken(self, transaction_parameters)
+    def create_datatoken(self, datatoken_args, tx_dict) -> Datatoken:
+        return datatoken_args.create_datatoken(self, tx_dict)
 
     def calculate_did(self):
         check_network(self.network)
@@ -84,7 +84,7 @@ class DataNFTArguments:
         self.transferable = transferable or True
         self.owner = owner
 
-    def deploy_contract(self, config_dict, transaction_parameters) -> DataNFT:
+    def deploy_contract(self, config_dict, tx_dict) -> DataNFT:
         from ocean_lib.models.data_nft_factory import (  # isort:skip
             DataNFTFactoryContract,
         )
@@ -92,7 +92,7 @@ class DataNFTArguments:
         address = get_address_of_type(config_dict, DataNFTFactoryContract.CONTRACT_NAME)
         data_nft_factory = DataNFTFactoryContract(config_dict, address)
 
-        wallet_address = get_from_address(transaction_parameters)
+        wallet_address = get_from_address(tx_dict)
 
         receipt = data_nft_factory.deployERC721Contract(
             self.name,
@@ -103,7 +103,7 @@ class DataNFTArguments:
             self.uri,
             self.transferable,
             self.owner or wallet_address,
-            transaction_parameters,
+            tx_dict,
         )
 
         with warnings.catch_warnings():

--- a/ocean_lib/models/data_nft.py
+++ b/ocean_lib/models/data_nft.py
@@ -10,7 +10,7 @@ from brownie import network
 from enforce_typing import enforce_types
 
 from ocean_lib.models.datatoken import Datatoken
-from ocean_lib.ocean.util import create_checksum, get_address_of_type
+from ocean_lib.ocean.util import create_checksum, get_address_of_type, get_from_address
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
 from ocean_lib.web3_internal.contract_base import ContractBase
 from ocean_lib.web3_internal.utils import check_network
@@ -92,11 +92,7 @@ class DataNFTArguments:
         address = get_address_of_type(config_dict, DataNFTFactoryContract.CONTRACT_NAME)
         data_nft_factory = DataNFTFactoryContract(config_dict, address)
 
-        wallet_address = (
-            transaction_parameters["from"].address
-            if hasattr(transaction_parameters["from"], "address")
-            else transaction_parameters["from"]
-        )
+        wallet_address = get_from_address(transaction_parameters)
 
         receipt = data_nft_factory.deployERC721Contract(
             self.name,

--- a/ocean_lib/models/data_nft_factory.py
+++ b/ocean_lib/models/data_nft_factory.py
@@ -30,8 +30,8 @@ class DataNFTFactoryContract(ERC721TokenFactoryBase):
         except BadFunctionCallOutput:
             return False
 
-    def create(self, data_nft_args, wallet):
-        return data_nft_args.deploy_contract(self.config_dict, wallet)
+    def create(self, data_nft_args, transaction_parameters):
+        return data_nft_args.deploy_contract(self.config_dict, transaction_parameters)
 
     @enforce_types
     def start_multiple_token_order(

--- a/ocean_lib/models/data_nft_factory.py
+++ b/ocean_lib/models/data_nft_factory.py
@@ -30,13 +30,11 @@ class DataNFTFactoryContract(ERC721TokenFactoryBase):
         except BadFunctionCallOutput:
             return False
 
-    def create(self, data_nft_args, transaction_parameters):
-        return data_nft_args.deploy_contract(self.config_dict, transaction_parameters)
+    def create(self, data_nft_args, tx_dict):
+        return data_nft_args.deploy_contract(self.config_dict, tx_dict)
 
     @enforce_types
-    def start_multiple_token_order(
-        self, orders: List[OrderData], transaction_parameters: dict
-    ) -> str:
+    def start_multiple_token_order(self, orders: List[OrderData], tx_dict: dict) -> str:
         """An order contains the following keys:
 
         - tokenAddress, str
@@ -64,7 +62,7 @@ class DataNFTFactoryContract(ERC721TokenFactoryBase):
             consume_fees[1] = ContractBase.to_checksum_address(order.consume_fees[1])
             order._replace(consume_fees=tuple(consume_fees))
 
-        return self.contract.startMultipleTokenOrder(orders, transaction_parameters)
+        return self.contract.startMultipleTokenOrder(orders, tx_dict)
 
     @enforce_types
     def create_with_erc20(

--- a/ocean_lib/models/datatoken.py
+++ b/ocean_lib/models/datatoken.py
@@ -108,8 +108,8 @@ class DatatokenArguments:
             self.template_index,
             [self.name, self.symbol],
             [
-                ContractBase.to_checksum_address(self.minter) or wallet_address,
-                ContractBase.to_checksum_address(self.fee_manager) or wallet_address,
+                ContractBase.to_checksum_address(self.minter or wallet_address),
+                ContractBase.to_checksum_address(self.fee_manager or wallet_address),
                 self.publish_market_order_fees.address,
                 self.publish_market_order_fees.token,
             ],
@@ -277,17 +277,15 @@ class Datatoken(ContractBase):
         FRE_addr = get_address_of_type(self.config_dict, "FixedPrice")
         from_addr = get_from_address(tx_dict)
         BT = Datatoken(self.config_dict, base_token_addr)
-        owner_addr = checksum_addr(owner_addr) or from_addr
-        publish_market_fee_collector = (
-            checksum_addr(publish_market_fee_collector) or from_addr
-        )
+        owner_addr = owner_addr or from_addr
+        publish_market_fee_collector = publish_market_fee_collector or from_addr
 
         tx = self.contract.createFixedRate(
             checksum_addr(FRE_addr),
             [
                 checksum_addr(BT.address),
-                owner_addr,
-                publish_market_fee_collector,
+                checksum_addr(owner_addr),
+                checksum_addr(publish_market_fee_collector),
                 checksum_addr(allowed_swapper),
             ],
             [

--- a/ocean_lib/models/datatoken_enterprise.py
+++ b/ocean_lib/models/datatoken_enterprise.py
@@ -26,7 +26,7 @@ class DatatokenEnterprise(Datatoken):
         max_base_token_amount: int,
         consume_market_swap_fee_amount: int,
         consume_market_swap_fee_address: str,
-        transaction_parameters: dict,
+        tx_dict: dict,
         consume_market_fees=None,
     ) -> str:
         fre_address = get_address_of_type(self.config_dict, "FixedPrice")
@@ -63,7 +63,7 @@ class DatatokenEnterprise(Datatoken):
                 consume_market_swap_fee_amount,
                 ContractBase.to_checksum_address(consume_market_swap_fee_address),
             ),
-            transaction_parameters,
+            tx_dict,
         )
 
     @enforce_types
@@ -72,7 +72,7 @@ class DatatokenEnterprise(Datatoken):
         consumer: str,
         service_index: int,
         provider_fees: dict,
-        transaction_parameters: dict,
+        tx_dict: dict,
         consume_market_fees=None,
     ) -> str:
         if not consume_market_fees:
@@ -96,5 +96,5 @@ class DatatokenEnterprise(Datatoken):
                 consume_market_fees.to_tuple(),
             ),
             ContractBase.to_checksum_address(dispenser_address),
-            transaction_parameters,
+            tx_dict,
         )

--- a/ocean_lib/models/fixed_rate_exchange.py
+++ b/ocean_lib/models/fixed_rate_exchange.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 from enforce_typing import enforce_types
 
 from ocean_lib.models.factory_router import FactoryRouter
-from ocean_lib.ocean.util import str_with_wei
+from ocean_lib.ocean.util import get_from_address, str_with_wei
 from ocean_lib.web3_internal.constants import MAX_UINT256, ZERO_ADDRESS
 from ocean_lib.web3_internal.contract_base import ContractBase
 
@@ -210,11 +210,7 @@ class OneExchange:
 
         details = self.details
         BT = Datatoken(self._FRE.config_dict, details.base_token)
-        buyer_addr = (
-            tx_dict["from"].address
-            if hasattr(tx_dict["from"], "address")
-            else tx_dict["from"]
-        )
+        buyer_addr = get_from_address(tx_dict)
 
         BT_needed = self.BT_needed(datatoken_amt, consume_market_fee)
         assert BT.balanceOf(buyer_addr) >= BT_needed, "not enough funds"

--- a/ocean_lib/models/test/test_data_nft.py
+++ b/ocean_lib/models/test/test_data_nft.py
@@ -323,7 +323,7 @@ def test_create_datatoken(
             "DT1Symbol",
             fee_manager=consumer_wallet.address,
         ),
-        publisher_wallet,
+        {"from": publisher_wallet},
     )
     assert datatoken, "Could not create ERC20."
 
@@ -337,7 +337,7 @@ def test_create_datatoken(
             bytess=[b""],
             cap=Web3.toWei("0.1", "ether"),
         ),
-        publisher_wallet,
+        {"from": publisher_wallet},
     )
     assert dt_ent, "Could not create datatoken Enterprise with explicit parameters"
 
@@ -347,7 +347,7 @@ def test_create_datatoken(
             symbol="DatatokenEnterpriseDT1Symbol",
             cap=Web3.toWei("0.1", "ether"),
         ),
-        publisher_wallet,
+        {"from": publisher_wallet},
     )
     assert dt_ent, "Could not create datatoken Enterprise with implicit parameters."
 
@@ -368,7 +368,7 @@ def test_create_datatoken_with_usdc_order_fee(
                 amount=publish_market_order_fee_amount_in_wei,
             ),
         ),
-        publisher_wallet,
+        {"from": publisher_wallet},
     )
 
     # Check publish fee info
@@ -406,7 +406,7 @@ def test_create_datatoken_with_non_owner(
             minter=publisher_wallet.address,
             fee_manager=publisher_wallet.address,
         ),
-        consumer_wallet,
+        {"from": consumer_wallet},
     )
     assert dt, "Failed to create ERC20 token."
 
@@ -439,7 +439,7 @@ def test_fail_creating_erc20(
                 symbol="DT1Symbol",
                 minter=publisher_wallet.address,
             ),
-            consumer_wallet,
+            {"from": consumer_wallet},
         )
 
 
@@ -504,7 +504,7 @@ def test_erc721_datatoken_functions(
             symbol="DT1Symbol",
             minter=publisher_wallet.address,
         ),
-        consumer_wallet,
+        {"from": consumer_wallet},
     )
     with pytest.raises(Exception, match="NOT MINTER"):
         datatoken.mint(
@@ -565,7 +565,7 @@ def test_transfer_nft(
             "NFTtT",
             additional_datatoken_deployer=consumer_wallet.address,
         ),
-        publisher_wallet,
+        {"from": publisher_wallet},
     )
     assert data_nft.contract.name() == "NFT to TRANSFER"
     assert data_nft.symbol() == "NFTtT"
@@ -587,7 +587,7 @@ def test_transfer_nft(
 
     # Consumer is not the additional ERC20 deployer, but will be after the NFT transfer
     data_nft = data_nft_factory.create(
-        DataNFTArguments("NFT1", "NFT"), publisher_wallet
+        DataNFTArguments("NFT1", "NFT"), {"from": publisher_wallet}
     )
 
     receipt = data_nft.safeTransferFrom(
@@ -611,7 +611,7 @@ def test_transfer_nft(
                 address=publisher_wallet.address,
             ),
         ),
-        consumer_wallet,
+        {"from": consumer_wallet},
     )
     assert datatoken, "Failed to create ERC20 token."
 
@@ -701,7 +701,7 @@ def test_fail_create_datatoken(
 ):
     """Tests multiple failures for creating ERC20 token."""
     data_nft = data_nft_factory.create(
-        DataNFTArguments("DT1", "DTSYMBOL"), publisher_wallet
+        DataNFTArguments("DT1", "DTSYMBOL"), {"from": publisher_wallet}
     )
     data_nft.addToCreateERC20List(consumer_wallet.address, {"from": publisher_wallet})
 
@@ -713,7 +713,7 @@ def test_fail_create_datatoken(
                 name="DT1",
                 symbol="DT1Symbol",
             ),
-            consumer_wallet,
+            {"from": consumer_wallet},
         )
 
     # Should fail to create a specific ERC20 Template if the index doesn't exist
@@ -724,7 +724,7 @@ def test_fail_create_datatoken(
                 name="DT1",
                 symbol="DT1Symbol",
             ),
-            consumer_wallet,
+            {"from": consumer_wallet},
         )
 
     # Should fail to create a specific ERC20 Template if the user is not added on the ERC20 deployers list
@@ -736,7 +736,7 @@ def test_fail_create_datatoken(
                 name="DT1",
                 symbol="DT1Symbol",
             ),
-            another_consumer_wallet,
+            {"from": another_consumer_wallet},
         )
 
 
@@ -774,7 +774,7 @@ def test_nft_owner_transfer(config, publisher_wallet, consumer_wallet, data_NFT_
                 name="DT1",
                 symbol="DT1Symbol",
             ),
-            publisher_wallet,
+            {"from": publisher_wallet},
         )
 
     with pytest.raises(Exception, match="NOT MINTER"):
@@ -786,7 +786,7 @@ def test_nft_owner_transfer(config, publisher_wallet, consumer_wallet, data_NFT_
             name="DT1",
             symbol="DT1Symbol",
         ),
-        consumer_wallet,
+        {"from": consumer_wallet},
     )
     datatoken.addMinter(consumer_wallet.address, {"from": consumer_wallet})
 

--- a/ocean_lib/models/test/test_data_nft_factory.py
+++ b/ocean_lib/models/test/test_data_nft_factory.py
@@ -25,7 +25,7 @@ def test_nft_creation(
 ):
     """Tests the utils functions."""
     data_nft = data_nft_factory.create(
-        DataNFTArguments("DT1", "DTSYMBOL"), publisher_wallet
+        DataNFTArguments("DT1", "DTSYMBOL"), {"from": publisher_wallet}
     )
     assert data_nft.contract.name() == "DT1"
     assert data_nft.symbol() == "DTSYMBOL"
@@ -33,7 +33,7 @@ def test_nft_creation(
     # Tests current NFT count
     current_nft_count = data_nft_factory.getCurrentNFTCount()
     data_nft = data_nft_factory.create(
-        DataNFTArguments("DT2", "DTSYMBOL1"), publisher_wallet
+        DataNFTArguments("DT2", "DTSYMBOL1"), {"from": publisher_wallet}
     )
     assert data_nft_factory.getCurrentNFTCount() == current_nft_count + 1
 
@@ -51,7 +51,7 @@ def test_nft_creation(
             "DT1Symbol",
             fee_manager=consumer_wallet.address,
         ),
-        publisher_wallet,
+        {"from": publisher_wallet},
     )
     assert datatoken, "Failed to create ERC20 token."
 
@@ -108,7 +108,7 @@ def test_combo_functions(
                 amount=Web3.toWei("0.0005", "ether"),
             ),
         ),
-        publisher_wallet,
+        {"from": publisher_wallet},
     )
     assert datatoken, "Failed to create ERC20 token."
     fee_datatoken_address = datatoken.address
@@ -191,7 +191,7 @@ def test_start_multiple_order(
 ):
     """Tests the utils functions."""
     data_nft = data_nft_factory.create(
-        DataNFTArguments("DT1", "DTSYMBOL"), publisher_wallet
+        DataNFTArguments("DT1", "DTSYMBOL"), {"from": publisher_wallet}
     )
     assert data_nft.contract.name() == "DT1"
     assert data_nft.symbol() == "DTSYMBOL"
@@ -200,7 +200,7 @@ def test_start_multiple_order(
     # Tests current NFT count
     current_nft_count = data_nft_factory.getCurrentNFTCount()
     data_nft = data_nft_factory.create(
-        DataNFTArguments("DT2", "DTSYMBOL1"), publisher_wallet
+        DataNFTArguments("DT2", "DTSYMBOL1"), {"from": publisher_wallet}
     )
     assert data_nft_factory.getCurrentNFTCount() == current_nft_count + 1
 
@@ -218,7 +218,7 @@ def test_start_multiple_order(
             symbol="DT1Symbol",
             minter=publisher_wallet.address,
         ),
-        consumer_wallet,
+        {"from": consumer_wallet},
     )
     assert datatoken, "Failed to create ERC20 token."
 
@@ -335,5 +335,5 @@ def test_nonexistent_template_index(data_nft_factory, publisher_wallet):
             DataNFTArguments(
                 "DT1", "DTSYMBOL", template_index=non_existent_nft_template
             ),
-            publisher_wallet,
+            {"from": publisher_wallet},
         )

--- a/ocean_lib/models/test/test_datatoken.py
+++ b/ocean_lib/models/test/test_datatoken.py
@@ -99,7 +99,7 @@ def test_main(
                 name="DT1",
                 symbol="DT1Symbol",
             ),
-            another_consumer_wallet,
+            {"from": another_consumer_wallet},
         )
 
 

--- a/ocean_lib/models/test/test_datatoken.py
+++ b/ocean_lib/models/test/test_datatoken.py
@@ -130,7 +130,7 @@ def test_start_order(config, publisher_wallet, consumer_wallet, data_NFT_and_DT)
             address=publisher_wallet.address,
             token=datatoken.address,
         ),
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
     )
     # Check erc20 balances
     assert datatoken.balanceOf(publisher_wallet.address) == Web3.toWei("9", "ether")
@@ -199,7 +199,7 @@ def test_start_order(config, publisher_wallet, consumer_wallet, data_NFT_and_DT)
     receipt_interm = datatoken.reuse_order(
         receipt.txid,
         provider_fees=provider_fees,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
     )
     reused_event = receipt_interm.events["OrderReused"]
     assert reused_event, "Cannot find OrderReused event"

--- a/ocean_lib/models/test/test_datatoken_order_both_templates.py
+++ b/ocean_lib/models/test/test_datatoken_order_both_templates.py
@@ -98,7 +98,7 @@ def test_dispense_and_order_with_non_defaults(
             address=consume_fee_address,
             token=DAI.address,
         ),
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
     )
 
     assert tx
@@ -137,7 +137,7 @@ def test_dispense_and_order_with_defaults(
         consumer=consumer_wallet.address,
         service_index=1,
         provider_fees=provider_fees,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
     )
 
     assert tx
@@ -219,7 +219,6 @@ def test_buy_DT_and_order(
 
     consume_bal1 = DAI.balanceOf(consume_fee_address)
     publish_bal1 = USDC.balanceOf(consumer_wallet.address)
-    provider_fee_bal1 = USDC.balanceOf(another_consumer_wallet.address)
 
     args = {
         "consumer": another_consumer_wallet.address,
@@ -230,7 +229,7 @@ def test_buy_DT_and_order(
             token=DAI.address,
         ),
         "exchange": exchange,
-        "transaction_parameters": {"from": publisher_wallet},
+        "tx_dict": {"from": publisher_wallet},
     }
 
     if template_index == 2:
@@ -245,7 +244,6 @@ def test_buy_DT_and_order(
     if template_index == 2:
         assert DT.totalSupply() == to_wei(0)
 
-    provider_fee_bal2 = USDC.balanceOf(another_consumer_wallet.address)
     consume_bal2 = DAI.balanceOf(consume_fee_address)
     publish_bal2 = USDC.balanceOf(publish_market_fees.address)
 

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -186,12 +186,12 @@ class Ocean:
         base_token: Datatoken,
         amount: int,
         fixed_rate: int,
-        transaction_parameters: dict,
+        tx_dict: dict,
     ) -> bytes:
         fixed_price_address = self._addr("FixedPrice")
-        datatoken.approve(fixed_price_address, amount, transaction_parameters)
+        datatoken.approve(fixed_price_address, amount, tx_dict)
 
-        from_address = get_from_address(transaction_parameters)
+        from_address = get_from_address(tx_dict)
 
         receipt = datatoken.create_fixed_rate(
             fixed_price_address=fixed_price_address,
@@ -204,7 +204,7 @@ class Ocean:
             fixed_rate=fixed_rate,
             publish_market_swap_fee_amount=int(1e15),
             with_mint=0,
-            transaction_parameters=transaction_parameters,
+            tx_dict=tx_dict,
         )
 
         fixed_price_address == receipt.events["NewFixedRate"]["exchangeContract"]

--- a/ocean_lib/ocean/ocean.py
+++ b/ocean_lib/ocean/ocean.py
@@ -32,7 +32,11 @@ from ocean_lib.models.ve.ve_fee_estimate import VeFeeEstimate
 from ocean_lib.models.ve.ve_ocean import VeOcean
 from ocean_lib.ocean.ocean_assets import OceanAssets
 from ocean_lib.ocean.ocean_compute import OceanCompute
-from ocean_lib.ocean.util import get_address_of_type, get_ocean_token_address
+from ocean_lib.ocean.util import (
+    get_address_of_type,
+    get_from_address,
+    get_ocean_token_address,
+)
 from ocean_lib.services.service import Service
 from ocean_lib.structures.algorithm_metadata import AlgorithmMetadata
 from ocean_lib.web3_internal.constants import ZERO_ADDRESS
@@ -187,11 +191,7 @@ class Ocean:
         fixed_price_address = self._addr("FixedPrice")
         datatoken.approve(fixed_price_address, amount, transaction_parameters)
 
-        from_address = (
-            transaction_parameters["from"].address
-            if hasattr(transaction_parameters["from"], "address")
-            else transaction_parameters["from"]
-        )
+        from_address = get_from_address(transaction_parameters)
 
         receipt = datatoken.create_fixed_rate(
             fixed_price_address=fixed_price_address,

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -586,13 +586,14 @@ class OceanAssets:
         compute_environment: str,
         valid_until: int,
         consume_market_order_fee_address: str,
-        wallet,
+        tx_dict: dict,
         consumer_address: Optional[str] = None,
     ):
         data_provider = DataServiceProvider
+        wallet_address = get_from_address(tx_dict)
 
         if not consumer_address:
-            consumer_address = wallet.address
+            consumer_address = wallet_address
 
         initialize_response = data_provider.initialize_compute(
             [x.as_dictionary() for x in datasets],
@@ -613,7 +614,7 @@ class OceanAssets:
                     datasets[i].consume_market_order_fee_token,
                     datasets[i].consume_market_order_fee_amount,
                 ),
-                wallet,
+                tx_dict,
                 consumer_address,
             )
 
@@ -626,7 +627,7 @@ class OceanAssets:
                     token=algorithm_data.consume_market_order_fee_token,
                     amount=algorithm_data.consume_market_order_fee_amount,
                 ),
-                wallet,
+                tx_dict,
                 consumer_address,
             )
 
@@ -640,7 +641,7 @@ class OceanAssets:
         asset_compute_input: ComputeInput,
         item: dict,
         consume_market_fees: TokenFeeInfo,
-        wallet,
+        tx_dict: dict,
         consumer_address: Optional[str] = None,
     ):
         provider_fees = item.get("providerFee")
@@ -655,9 +656,7 @@ class OceanAssets:
 
         if valid_order and provider_fees:
             asset_compute_input.transfer_tx_id = dt.reuse_order(
-                valid_order,
-                provider_fees=provider_fees,
-                tx_dict={"from": wallet},
+                valid_order, provider_fees=provider_fees, tx_dict=tx_dict
             ).txid
             return
 
@@ -666,5 +665,5 @@ class OceanAssets:
             service_index=asset_compute_input.ddo.get_index_of_service(service),
             provider_fees=provider_fees,
             consume_market_fees=consume_market_fees,
-            tx_dict={"from": wallet},
+            tx_dict=tx_dict,
         ).txid

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -527,7 +527,7 @@ class OceanAssets:
     def pay_for_access_service(
         self,
         ddo: DDO,
-        wallet,
+        tx_dict: dict,
         service: Optional[Service] = None,
         consume_market_fees: Optional[TokenFeeInfo] = None,
         consumer_address: Optional[str] = None,
@@ -535,11 +535,12 @@ class OceanAssets:
     ):
         # fill in good defaults as needed
         service = service or ddo.services[0]
-        consumer_address = consumer_address or wallet.address
+        wallet_address = get_from_address(tx_dict)
+        consumer_address = consumer_address or wallet_address
 
         # main work...
         dt = Datatoken(self._config_dict, service.datatoken)
-        balance = dt.balanceOf(wallet.address)
+        balance = dt.balanceOf(wallet_address)
 
         if balance < Web3.toWei(1, "ether"):
             raise InsufficientBalance(
@@ -551,7 +552,7 @@ class OceanAssets:
         consumable_result = is_consumable(
             ddo,
             service,
-            {"type": "address", "value": wallet.address},
+            {"type": "address", "value": wallet_address},
             userdata=userdata,
         )
         if consumable_result != ConsumableCodes.OK:
@@ -573,7 +574,7 @@ class OceanAssets:
             service_index=ddo.get_index_of_service(service),
             provider_fees=provider_fees,
             consume_market_fees=consume_market_fees,
-            tx_dict={"from": wallet},
+            tx_dict=tx_dict,
         )
 
         return receipt.txid

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -26,7 +26,7 @@ from ocean_lib.exceptions import AquariusError, InsufficientBalance
 from ocean_lib.models.compute_input import ComputeInput
 from ocean_lib.models.data_nft import DataNFT, DataNFTArguments
 from ocean_lib.models.datatoken import Datatoken, DatatokenArguments, TokenFeeInfo
-from ocean_lib.ocean.util import create_checksum
+from ocean_lib.ocean.util import create_checksum, get_from_address
 from ocean_lib.services.service import Service
 from ocean_lib.structures.algorithm_metadata import AlgorithmMetadata
 from ocean_lib.structures.file_objects import (
@@ -235,11 +235,7 @@ class OceanAssets:
     def _default_metadata(
         self, name: str, transaction_parameters: dict, type="dataset"
     ) -> dict:
-        address = (
-            transaction_parameters["from"].address
-            if hasattr(transaction_parameters["from"], "address")
-            else transaction_parameters["from"]
-        )
+        address = get_from_address(transaction_parameters)
 
         date_created = datetime.now().isoformat()
         metadata = {
@@ -384,16 +380,12 @@ class OceanAssets:
             ddo, provider_uri, encrypt_flag, compress_flag
         )
 
-        wallet_address = (
-            transaction_parameters["from"].address
-            if hasattr(transaction_parameters["from"], "address")
-            else transaction_parameters["from"]
-        )
+        wallet_address = get_from_address(transaction_parameters)
 
         data_nft.setMetaData(
             0,
             provider_uri,
-            Web3.toChecksumAddress(wallet_address.lower()).encode("utf-8"),
+            wallet_address.encode("utf-8"),
             flags,
             document,
             ddo_hash,
@@ -456,16 +448,12 @@ class OceanAssets:
             errors_or_proof["s"][0],
         )
 
-        wallet_address = (
-            transaction_parameters["from"].address
-            if hasattr(transaction_parameters["from"], "address")
-            else transaction_parameters["from"]
-        )
+        wallet_address = get_from_address(transaction_parameters)
 
         tx_result = data_nft.setMetaData(
             0,
             provider_uri,
-            Web3.toChecksumAddress(wallet_address.lower()).encode("utf-8"),
+            wallet_address.encode("utf-8"),
             flags,
             document,
             ddo_hash,

--- a/ocean_lib/ocean/ocean_assets.py
+++ b/ocean_lib/ocean/ocean_assets.py
@@ -411,7 +411,7 @@ class OceanAssets:
     def update(
         self,
         ddo: DDO,
-        publisher_wallet,
+        transaction_parameters: dict,
         provider_uri: Optional[str] = None,
         encrypt_flag: Optional[bool] = True,
         compress_flag: Optional[bool] = True,
@@ -456,15 +456,21 @@ class OceanAssets:
             errors_or_proof["s"][0],
         )
 
+        wallet_address = (
+            transaction_parameters["from"].address
+            if hasattr(transaction_parameters["from"], "address")
+            else transaction_parameters["from"]
+        )
+
         tx_result = data_nft.setMetaData(
             0,
             provider_uri,
-            Web3.toChecksumAddress(publisher_wallet.address.lower()).encode("utf-8"),
+            Web3.toChecksumAddress(wallet_address.lower()).encode("utf-8"),
             flags,
             document,
             ddo_hash,
             [proof],
-            {"from": publisher_wallet},
+            transaction_parameters,
         )
 
         ddo = self._aquarius.wait_for_ddo_update(ddo, tx_result.txid)

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -385,7 +385,7 @@ def test_plain_asset_with_one_datatoken(publisher_ocean, publisher_wallet, confi
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         data_nft_address=data_nft.address,
         datatoken_args=[DatatokenArguments(files=files)],
     )
@@ -414,7 +414,7 @@ def test_plain_asset_multiple_datatokens(publisher_ocean, publisher_wallet, conf
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         data_nft_address=data_nft.address,
         datatoken_args=[
             DatatokenArguments("Datatoken 2", "DT2", files=files),
@@ -482,7 +482,7 @@ def test_plain_asset_multiple_services(publisher_ocean, publisher_wallet, config
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         services=[access_service, compute_service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -509,7 +509,7 @@ def test_encrypted_asset(publisher_ocean, publisher_wallet, config):
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
         services=services,
@@ -535,7 +535,7 @@ def test_compressed_asset(publisher_ocean, publisher_wallet, config):
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         services=services,
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -561,7 +561,7 @@ def test_compressed_and_encrypted_asset(publisher_ocean, publisher_wallet, confi
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         services=services,
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -588,7 +588,7 @@ def test_asset_creation_errors(publisher_ocean, publisher_wallet, config):
     with pytest.raises(brownie.exceptions.ContractNotFound):
         publisher_ocean.assets.create(
             metadata=metadata,
-            transaction_parameters={"from": publisher_wallet},
+            tx_dict={"from": publisher_wallet},
             services=[],
             data_nft_address=some_random_address,
             deployed_datatokens=[datatoken],
@@ -600,7 +600,7 @@ def test_asset_creation_errors(publisher_ocean, publisher_wallet, config):
         with pytest.raises(AquariusError):
             publisher_ocean.assets.create(
                 metadata=metadata,
-                transaction_parameters={"from": publisher_wallet},
+                tx_dict={"from": publisher_wallet},
                 services=[],
                 data_nft_address=data_nft.address,
                 deployed_datatokens=[datatoken],

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -362,7 +362,7 @@ def test_create_url_asset(publisher_ocean, publisher_wallet):
     name = "Branin dataset"
     url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
     (data_nft, datatoken, ddo) = ocean.assets.create_url_asset(
-        name, url, publisher_wallet
+        name, url, {"from": publisher_wallet}
     )
 
     assert ddo.nft["name"] == name  # thorough testing is below, on create() directly
@@ -380,12 +380,12 @@ def test_plain_asset_with_one_datatoken(publisher_ocean, publisher_wallet, confi
 
     # Publisher deploys NFT contract
     data_nft = data_nft_factory.create(
-        DataNFTArguments("NFT1", "NFTSYMBOL"), publisher_wallet
+        DataNFTArguments("NFT1", "NFTSYMBOL"), {"from": publisher_wallet}
     )
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         data_nft_address=data_nft.address,
         datatoken_args=[DatatokenArguments(files=files)],
     )
@@ -409,12 +409,12 @@ def test_plain_asset_multiple_datatokens(publisher_ocean, publisher_wallet, conf
     files = get_default_files()
 
     data_nft = data_nft_factory.create(
-        DataNFTArguments("NFT2", "NFT2SYMBOL"), publisher_wallet
+        DataNFTArguments("NFT2", "NFT2SYMBOL"), {"from": publisher_wallet}
     )
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         data_nft_address=data_nft.address,
         datatoken_args=[
             DatatokenArguments("Datatoken 2", "DT2", files=files),
@@ -482,7 +482,7 @@ def test_plain_asset_multiple_services(publisher_ocean, publisher_wallet, config
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         services=[access_service, compute_service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -509,7 +509,7 @@ def test_encrypted_asset(publisher_ocean, publisher_wallet, config):
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
         services=services,
@@ -535,7 +535,7 @@ def test_compressed_asset(publisher_ocean, publisher_wallet, config):
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         services=services,
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -561,7 +561,7 @@ def test_compressed_and_encrypted_asset(publisher_ocean, publisher_wallet, confi
 
     _, _, ddo = publisher_ocean.assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         services=services,
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -588,7 +588,7 @@ def test_asset_creation_errors(publisher_ocean, publisher_wallet, config):
     with pytest.raises(brownie.exceptions.ContractNotFound):
         publisher_ocean.assets.create(
             metadata=metadata,
-            publisher_wallet=publisher_wallet,
+            transaction_parameters={"from": publisher_wallet},
             services=[],
             data_nft_address=some_random_address,
             deployed_datatokens=[datatoken],
@@ -600,7 +600,7 @@ def test_asset_creation_errors(publisher_ocean, publisher_wallet, config):
         with pytest.raises(AquariusError):
             publisher_ocean.assets.create(
                 metadata=metadata,
-                publisher_wallet=publisher_wallet,
+                transaction_parameters={"from": publisher_wallet},
                 services=[],
                 data_nft_address=data_nft.address,
                 deployed_datatokens=[datatoken],
@@ -615,7 +615,7 @@ def test_create_algo_asset(publisher_ocean, publisher_wallet):
     name = "Branin dataset"
     url = "https://raw.githubusercontent.com/oceanprotocol/c2d-examples/main/branin_and_gpr/gpr.py"
     (data_nft, datatoken, ddo) = ocean.assets.create_algo_asset(
-        name, url, publisher_wallet
+        name, url, {"from": publisher_wallet}
     )
 
     assert ddo.nft["name"] == name  # thorough testing is below, on create() directly

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -349,7 +349,7 @@ def test_pay_for_access_service_insufficient_balance(
     with pytest.raises(InsufficientBalance):
         publisher_ocean.assets.pay_for_access_service(
             ddo,
-            empty_wallet,
+            {"from": empty_wallet},
             get_first_service_by_type(ddo, "access"),
             TokenFeeInfo(address=empty_wallet.address, token=datatoken.address),
         )

--- a/ocean_lib/ocean/test/test_ocean_assets.py
+++ b/ocean_lib/ocean/test/test_ocean_assets.py
@@ -55,7 +55,7 @@ def test_update_metadata(publisher_ocean, publisher_wallet):
     new_metadata["updated"] = datetime.utcnow().isoformat()
     ddo.metadata = new_metadata
 
-    ddo2 = publisher_ocean.assets.update(ddo, publisher_wallet)
+    ddo2 = publisher_ocean.assets.update(ddo, {"from": publisher_wallet})
 
     assert ddo2.datatokens == ddo.datatokens
     assert len(ddo2.services) == len(ddo.services)
@@ -79,7 +79,7 @@ def test_update_credentials(publisher_ocean, publisher_wallet):
 
     ddo.credentials = _new_credentials
 
-    ddo2 = publisher_ocean.assets.update(ddo, publisher_wallet)
+    ddo2 = publisher_ocean.assets.update(ddo, {"from": publisher_wallet})
 
     assert ddo2.credentials == _new_credentials, "Credentials were not updated."
 
@@ -115,7 +115,7 @@ def test_update_datatokens(publisher_ocean, publisher_wallet, config, file2):
 
     ddo.services.append(access_service)
 
-    ddo2 = publisher_ocean.assets.update(ddo, publisher_wallet)
+    ddo2 = publisher_ocean.assets.update(ddo, {"from": publisher_wallet})
 
     assert len(ddo2.datatokens) == len(ddo_orig.datatokens) + 1
     assert len(ddo2.services) == len(ddo_orig.services) + 1
@@ -141,7 +141,7 @@ def test_update_datatokens(publisher_ocean, publisher_wallet, config, file2):
 
     ddo2_prev_datatokens = ddo2.datatokens
 
-    ddo4 = publisher_ocean.assets.update(ddo3, publisher_wallet)
+    ddo4 = publisher_ocean.assets.update(ddo3, {"from": publisher_wallet})
 
     assert ddo4, "Can't read ddo after update."
     assert len(ddo4.datatokens) == 1
@@ -169,7 +169,7 @@ def test_update_flags(publisher_ocean, publisher_wallet):
 
     ddo2 = publisher_ocean.assets.update(
         ddo,
-        publisher_wallet,
+        {"from": publisher_wallet},
         compress_flag=True,
         encrypt_flag=True,
     )

--- a/ocean_lib/ocean/util.py
+++ b/ocean_lib/ocean/util.py
@@ -59,3 +59,14 @@ def to_wei(amt_eth) -> int:
 @enforce_types
 def str_with_wei(amt_wei: int) -> str:
     return f"{from_wei(amt_wei)} ({amt_wei} wei)"
+
+
+@enforce_types
+def get_from_address(tx_dict: dict) -> str:
+    address = (
+        tx_dict["from"].address
+        if hasattr(tx_dict["from"], "address")
+        else tx_dict["from"]
+    )
+
+    return Web3.toChecksumAddress(address.lower())

--- a/tests/flows/test_reuse_order_fees.py
+++ b/tests/flows/test_reuse_order_fees.py
@@ -118,7 +118,7 @@ def test_reuse_order_fees(
             token=bt.address,
             amount=int_units("10", bt.decimals()),
         ),
-        transaction_parameters={"from": consumer_wallet},
+        tx_dict={"from": consumer_wallet},
     )
 
     # Reuse order where:
@@ -233,7 +233,7 @@ def reuse_order_with_mock_provider_fees(
     dt.reuse_order(
         order_tx_id=start_order_tx_id,
         provider_fees=provider_fees,
-        transaction_parameters={"from": consumer_wallet},
+        tx_dict={"from": consumer_wallet},
     )
 
     # Get balances after reuse_order

--- a/tests/flows/test_start_order_fees.py
+++ b/tests/flows/test_start_order_fees.py
@@ -226,7 +226,7 @@ def create_asset_with_order_fee_and_timeout(
             symbol="DT1",
             publish_market_order_fees=publish_market_order_fees,
         ),
-        publisher_wallet,
+        {"from": publisher_wallet},
     )
 
     data_provider = DataServiceProvider
@@ -256,7 +256,7 @@ def create_asset_with_order_fee_and_timeout(
     # Publish asset
     data_nft, datatokens, ddo = ocean_assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         services=[service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],

--- a/tests/flows/test_start_order_fees.py
+++ b/tests/flows/test_start_order_fees.py
@@ -154,7 +154,7 @@ def test_start_order_fees(
             token=bt.address,
             amount=consume_market_order_fee,
         ),
-        transaction_parameters={"from": consumer_wallet},
+        tx_dict={"from": consumer_wallet},
     )
 
     # Get balances
@@ -256,7 +256,7 @@ def create_asset_with_order_fee_and_timeout(
     # Publish asset
     data_nft, datatokens, ddo = ocean_assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         services=[service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],

--- a/tests/integration/ganache/test_compute_flow.py
+++ b/tests/integration/ganache/test_compute_flow.py
@@ -249,7 +249,7 @@ def run_compute_test(
         compute_environment=free_c2d_env["id"],
         valid_until=valid_until,
         consume_market_order_fee_address=consumer_wallet.address,
-        wallet=consumer_wallet,
+        tx_dict={"from": consumer_wallet},
     )
 
     # Start compute job
@@ -314,7 +314,7 @@ def run_compute_test(
             compute_environment=free_c2d_env["id"],
             valid_until=valid_until,
             consume_market_order_fee_address=consumer_wallet.address,
-            wallet=consumer_wallet,
+            tx_dict={"from": consumer_wallet},
         )
 
         # transferTxId was not updated
@@ -335,7 +335,7 @@ def run_compute_test(
             compute_environment=free_c2d_env["id"],
             valid_until=valid_until,
             consume_market_order_fee_address=consumer_wallet.address,
-            wallet=consumer_wallet,
+            tx_dict={"from": consumer_wallet},
         )
 
         assert datasets[0].transfer_tx_id != prev_dt_tx_id

--- a/tests/integration/ganache/test_compute_flow.py
+++ b/tests/integration/ganache/test_compute_flow.py
@@ -503,7 +503,7 @@ def test_compute_update_trusted_algorithm(
     )
 
     updated_dataset = publisher_ocean.assets.update(
-        dataset_with_compute_service_generator, publisher_wallet
+        dataset_with_compute_service_generator, {"from": publisher_wallet}
     )
 
     # Expect to pass when trusted algorithm is used

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -26,11 +26,11 @@ def test_consume_asset(config: dict, publisher_wallet, consumer_wallet, asset_ty
     if asset_type == "simple":
         url = "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff"
         data_nft, dt, ddo = ocean_assets.create_url_asset(
-            "Data NFTs in Ocean", url, publisher_wallet
+            "Data NFTs in Ocean", url, {"from": publisher_wallet}
         )
     elif asset_type == "arweave":
         data_nft, dt, ddo = ocean_assets.create_arweave_asset(
-            "Data NFTs in Ocean", ARWEAVE_TRANSACTION_ID, publisher_wallet
+            "Data NFTs in Ocean", ARWEAVE_TRANSACTION_ID, {"from": publisher_wallet}
         )
     elif asset_type == "onchain":
         abi = {
@@ -43,7 +43,7 @@ def test_consume_asset(config: dict, publisher_wallet, consumer_wallet, asset_ty
         router_address = get_address_of_type(config, "Router")
 
         data_nft, dt, ddo = ocean_assets.create_onchain_asset(
-            "Data NFTs in Ocean", router_address, abi, publisher_wallet
+            "Data NFTs in Ocean", router_address, abi, {"from": publisher_wallet}
         )
     else:
         url = "http://172.15.0.15:8000/subgraphs/name/oceanprotocol/ocean-subgraph"
@@ -58,7 +58,7 @@ def test_consume_asset(config: dict, publisher_wallet, consumer_wallet, asset_ty
             """
 
         data_nft, dt, ddo = ocean_assets.create_graphql_asset(
-            "Data NFTs in Ocean", url, query, publisher_wallet
+            "Data NFTs in Ocean", url, query, {"from": publisher_wallet}
         )
 
     assert ddo, "The ddo is not created."

--- a/tests/integration/ganache/test_consume_flow.py
+++ b/tests/integration/ganache/test_consume_flow.py
@@ -89,7 +89,7 @@ def test_consume_asset(config: dict, publisher_wallet, consumer_wallet, asset_ty
         consumer=consumer_wallet.address,
         service_index=ddo.get_index_of_service(service),
         provider_fees=provider_fees,
-        transaction_parameters={"from": consumer_wallet},
+        tx_dict={"from": consumer_wallet},
     )
 
     # Download file

--- a/tests/integration/ganache/test_disconnecting_components.py
+++ b/tests/integration/ganache/test_disconnecting_components.py
@@ -53,7 +53,9 @@ def _create_ddo(ocean, publisher):
     global exception_flag
     time.sleep(5)
     try:
-        ocean.assets.create_url_asset("Sample asset", "https://foo.txt", publisher)
+        ocean.assets.create_url_asset(
+            "Sample asset", "https://foo.txt", {"from": publisher}
+        )
     except requests.exceptions.InvalidURL as err:
         exception_flag = 1
         assert err.args[0] == "InvalidURL http://foourl.com."

--- a/tests/integration/ganache/test_graphql.py
+++ b/tests/integration/ganache/test_graphql.py
@@ -68,7 +68,7 @@ def test_consume_simple_graphql_query(
         consumer=consumer_wallet.address,
         service_index=ddo.get_index_of_service(service),
         provider_fees=provider_fees,
-        transaction_parameters={"from": consumer_wallet},
+        tx_dict={"from": consumer_wallet},
     )
 
     # Download file
@@ -153,7 +153,7 @@ def test_consume_parametrized_graphql_query(
     )
     data_nft, datatoken, ddo = ocean_assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         datatoken_args=[dt_arg],
     )
 
@@ -188,7 +188,7 @@ def test_consume_parametrized_graphql_query(
         consumer=consumer_wallet.address,
         service_index=ddo.get_index_of_service(service),
         provider_fees=provider_fees,
-        transaction_parameters={"from": consumer_wallet},
+        tx_dict={"from": consumer_wallet},
     )
 
     # Download file

--- a/tests/integration/ganache/test_graphql.py
+++ b/tests/integration/ganache/test_graphql.py
@@ -37,7 +37,7 @@ def test_consume_simple_graphql_query(
         """
 
     data_nft, dt, ddo = ocean.assets.create_graphql_asset(
-        "Data NFTs in Ocean", url, query, publisher_wallet
+        "Data NFTs in Ocean", url, query, {"from": publisher_wallet}
     )
 
     assert ddo, "The ddo is not created."
@@ -153,7 +153,7 @@ def test_consume_parametrized_graphql_query(
     )
     data_nft, datatoken, ddo = ocean_assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         datatoken_args=[dt_arg],
     )
 

--- a/tests/integration/ganache/test_market_flow.py
+++ b/tests/integration/ganache/test_market_flow.py
@@ -57,7 +57,7 @@ def test_market_flow(
         )
         asset_folder = consumer_ocean.assets.download_asset(
             ddo,
-            {"from": consumer_wallet},
+            consumer_wallet,
             consumer_ocean.config_dict["DOWNLOADS_PATH"],
             order_tx_id,
             service,

--- a/tests/integration/ganache/test_market_flow.py
+++ b/tests/integration/ganache/test_market_flow.py
@@ -51,13 +51,13 @@ def test_market_flow(
     if consumer_type == "publisher":
         order_tx_id = consumer_ocean.assets.pay_for_access_service(
             ddo,
-            consumer_wallet,
+            {"from": consumer_wallet},
             service=service,
             consume_market_fees=TokenFeeInfo(token=datatoken.address),
         )
         asset_folder = consumer_ocean.assets.download_asset(
             ddo,
-            consumer_wallet,
+            {"from": consumer_wallet},
             consumer_ocean.config_dict["DOWNLOADS_PATH"],
             order_tx_id,
             service,
@@ -65,7 +65,7 @@ def test_market_flow(
     else:
         order_tx_id = consumer_ocean.assets.pay_for_access_service(
             ddo,
-            consumer_wallet,
+            {"from": consumer_wallet},
             service=service,
             consume_market_fees=TokenFeeInfo(
                 address=another_consumer_wallet.address,
@@ -116,7 +116,9 @@ def test_pay_for_access_service_good_default(
 
     # Place order for the download service
     # - Here, use good defaults for service, and fee-related args
-    order_tx_id = consumer_ocean.assets.pay_for_access_service(ddo, consumer_wallet)
+    order_tx_id = consumer_ocean.assets.pay_for_access_service(
+        ddo, {"from": consumer_wallet}
+    )
 
     asset_folder = consumer_ocean.assets.download_asset(
         ddo,

--- a/tests/integration/ganache/test_onchain.py
+++ b/tests/integration/ganache/test_onchain.py
@@ -65,7 +65,7 @@ def test_consume_parametrized_onchain_data(
     dt_arg = DatatokenArguments(files=files, consumer_parameters=consumer_parameters)
     data_nft, _, ddo = ocean_assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         datatoken_args=[dt_arg],
     )
 
@@ -101,7 +101,7 @@ def test_consume_parametrized_onchain_data(
         consumer=consumer_wallet.address,
         service_index=ddo.get_index_of_service(service),
         provider_fees=provider_fees,
-        transaction_parameters={"from": consumer_wallet},
+        tx_dict={"from": consumer_wallet},
     )
 
     # Download file

--- a/tests/integration/ganache/test_onchain.py
+++ b/tests/integration/ganache/test_onchain.py
@@ -65,7 +65,7 @@ def test_consume_parametrized_onchain_data(
     dt_arg = DatatokenArguments(files=files, consumer_parameters=consumer_parameters)
     data_nft, _, ddo = ocean_assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         datatoken_args=[dt_arg],
     )
 

--- a/tests/integration/remote/util.py
+++ b/tests/integration/remote/util.py
@@ -106,7 +106,7 @@ def do_ocean_tx_and_handle_gotchas(ocean, alice_wallet):
     print("Call create() from data NFT, and wait for it to complete...")
     try:
         data_nft = ocean.data_nft_factory.create(
-            DataNFTArguments(symbol, symbol), alice_wallet
+            DataNFTArguments(symbol, symbol), {"from": alice_wallet}
         )
         data_nft_symbol = data_nft.symbol()
     except ERRORS_TO_CATCH as e:

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -120,7 +120,7 @@ def get_registered_asset_with_access_service(
 
     data_nft, dts, ddo = ocean_instance.assets.create(
         metadata,
-        publisher_wallet,
+        {"from": publisher_wallet},
         datatoken_args=[DatatokenArguments("Branin: DT1", "DT1", files=files)],
     )
 
@@ -175,7 +175,7 @@ def get_registered_asset_with_compute_service(
 
     return ocean_instance.assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         services=[compute_service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -215,7 +215,7 @@ def get_registered_algorithm_with_access_service(
 
     return ocean_instance.assets.create(
         metadata=metadata,
-        publisher_wallet=publisher_wallet,
+        transaction_parameters={"from": publisher_wallet},
         datatoken_args=[DatatokenArguments("Algo DT1", "DT1", files=[algorithm_file])],
     )
 

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -175,7 +175,7 @@ def get_registered_asset_with_compute_service(
 
     return ocean_instance.assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         services=[compute_service],
         data_nft_address=data_nft.address,
         deployed_datatokens=[datatoken],
@@ -215,7 +215,7 @@ def get_registered_algorithm_with_access_service(
 
     return ocean_instance.assets.create(
         metadata=metadata,
-        transaction_parameters={"from": publisher_wallet},
+        tx_dict={"from": publisher_wallet},
         datatoken_args=[DatatokenArguments("Algo DT1", "DT1", files=[algorithm_file])],
     )
 

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -164,7 +164,7 @@ def deploy_erc721_erc20(
         config_dict, get_address_of_type(config_dict, "ERC721Factory")
     )
     data_nft = data_nft_factory.create(
-        DataNFTArguments("NFT", "NFTSYMBOL"), data_nft_publisher
+        DataNFTArguments("NFT", "NFTSYMBOL"), {"from": data_nft_publisher}
     )
 
     if not datatoken_minter:
@@ -180,7 +180,7 @@ def deploy_erc721_erc20(
             symbol="DT1Symbol",
             minter=datatoken_minter.address,
         ),
-        data_nft_publisher,
+        {"from": data_nft_publisher},
     )
 
     return data_nft, datatoken


### PR DESCRIPTION
Closes #1253

Besides what was asked, I saw that in some places we send name the transaction dict parameter `tx_dict` (Trent way) and in others `transaction_parameters` (Călina way). I decided to make them all uniform and keep only `tx_dict` everywhere