### PR TITLE
MacOs user: Brownie network not connected

### DIFF
--- a/READMEs/setup-remote.md
+++ b/READMEs/setup-remote.md
@@ -68,6 +68,14 @@ A simpler option is to bypass the need for an account! Just change to RPCs that 
 sed -i 's#https://polygon-mainnet.infura.io/v3/$WEB3_INFURA_PROJECT_ID#https://polygon-rpc.com/#g; s#https://polygon-mumbai.infura.io/v3/$WEB3_INFURA_PROJECT_ID#https://rpc-mumbai.maticvigil.com#g' ~/.brownie/network-config.yaml
 `
 
+#### MacOS users:
+
+`console
+brew install gnu-sed
+gsed -i 's#https://polygon-mainnet.infura.io/v3/$WEB3_INFURA_PROJECT_ID#https://polygon-rpc.com/#g; s#https://polygon-mumbai.infura.io/v3/$WEB3_INFURA_PROJECT_ID#https://rpc-mumbai.maticvigil.com#g' ~/.brownie/network-config.yaml
+`
+
+
 #### RPCs wrapup
 
 Congrats, you've now configured your Brownie network file! You rarely need to worry about it from now on.


### PR DESCRIPTION
 Avoid "Exception: Brownie network is not connected. Please call network.connect ("{network name}")" on MacOS

Fixes # .

Changes proposed in this PR:

- 
- 
- 