### PR TITLE
Fixes to the test runs

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,8 +10,7 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Black Code Formatter
-        uses: lgeiger/black-action@master
+      - uses: psf/black@stable
         with:
-          args: ". --check"
+          options: "--check --verbose"
+          version: "22.10.0"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,8 +10,8 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
           version: "22.10.0"
-          src: "."

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: psf/black@stable
+        working-directory: ${{ github.workspace }}
         with:
           options: "--check --verbose"
           version: "22.10.0"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: psf/black@stable
-        working-directory: ${{ github.workspace }}
         with:
           options: "--check --verbose"
           version: "22.10.0"
+          src: "./src"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           options: "--check --verbose"
           version: "22.10.0"
-          src: "./src"
+          src: "."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,4 +50,5 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           python -m pip install --upgrade pip
+          pip install vyper==0.3.7 --ignore-requires-python
           pip install -r requirements_dev.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,6 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
-      - name: Install pip
-        working-directory: ${{ github.workspace }}
-        run: |
-          python -m pip install --upgrade pip
       - name: Install Mac OS specific dependencies
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
@@ -53,5 +49,5 @@ jobs:
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
         run: |
-          python -m pip install --upgrade pip==22.3.1
+          python -m pip install --upgrade pip
           pip install -r requirements_dev.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,5 +53,5 @@ jobs:
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==22.3.1
           pip install -r requirements_dev.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           brew install autoconf automake libtool
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
+        # vyper is grounded here until it declares explicit support for Python 3.11
         run: |
           python -m pip install --upgrade pip
           pip install vyper==0.3.7 --ignore-requires-python

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,9 +37,12 @@ jobs:
             done
           ls -la "$HOME/.ocean/ocean-contracts/artifacts/"
       - name: "Read address.json contents"
+        working-directory: ${{ github.workspace }}
         uses: andstor/file-reader-action@v1
         with:
           path: "$HOME/.ocean/ocean-contracts/artifacts/address.json"
+      - name: File contents
+        run: echo "${ steps.read_file.outputs.contents }"
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,6 +36,10 @@ jobs:
             [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
             done
           ls -la "$HOME/.ocean/ocean-contracts/artifacts/"
+      - name: "Read address.json contents"
+        uses: andstor/file-reader-action@v1
+        with:
+          path: "$HOME/.ocean/ocean-contracts/artifacts/address.json"
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,11 +38,7 @@ jobs:
           ls -la "$HOME/.ocean/ocean-contracts/artifacts/"
       - name: "Read address.json contents"
         working-directory: ${{ github.workspace }}
-        uses: andstor/file-reader-action@v1
-        with:
-          path: "$HOME/.ocean/ocean-contracts/artifacts/address.json"
-      - name: File contents
-        run: echo "${ steps.read_file.outputs.contents }"
+        run: cat "$HOME/.ocean/ocean-contracts/artifacts/address.json"
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
         run: |

--- a/READMEs/install.md
+++ b/READMEs/install.md
@@ -38,9 +38,12 @@ Issue: M1 * `coincurve` or `cryptography`
 - Workaround: ensure you have `autoconf`, `automake` and `libtool` installed, e.g. using Homebrew or MacPorts.
 
 
-Issue: MacOS "Unsupported Architecture" 
+Issue: MacOS "Unsupported Architecture"
 - If you run MacOS, you may encounter an "Unsupported Architecture" issue.
 - Workaround: install including ARCHFLAGS: `ARCHFLAGS="-arch x86_64" pip install ocean-lib`. [Details](https://github.com/oceanprotocol/ocean.py/issues/486).
+
+To install ocean-lib using Python 3.11, run `pip install vyper==0.3.7 --ignore-requires-python` before installing ocean-lib.
+This is a temporary fix until Vyper has a release declaring dependencies for Python 3.11. We do not directly use Vyper in ocean-lib.
 
 ## ocean.py uses Brownie
 

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,11 @@ install_requirements = [
     "eciespy",
     "eth-brownie==1.19.3",
     "yarl==1.8.1",
-    "bitarray>=2.6.0,<3",
+    "bitarray>=2.6.0,<3"
     # web3 requires eth-abi, requests, and more,
     # so those will be installed too.
     # See https://github.com/ethereum/web3.py/blob/master/setup.py
 ]
-
 # Required to run setup.py:
 setup_requirements = ["pytest-runner"]
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requirements = [
     "eciespy",
     "eth-brownie==1.19.3",
     "yarl==1.8.1",
-    "bitarray>=2.6.0,<3"
+    "bitarray>=2.6.0,<3",
     # web3 requires eth-abi, requests, and more,
     # so those will be installed too.
     # See https://github.com/ethereum/web3.py/blob/master/setup.py

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requirements = [
     "enforce-typing==1.0.0.post1",
     "json-sempai==0.4.0",
     "eciespy",
-    "eth-brownie",
+    "eth-brownie==1.19.3",
     "yarl==1.8.1",
     "bitarray>=2.6.0,<3",
     # web3 requires eth-abi, requests, and more,


### PR DESCRIPTION
Helps with #1174. Includes:

- using psf/action-black, which is the official black action and allows version grounding. Previously, we were using a specific version in pre-commits and an auto-resolvable version in the Github Action check. If those are different, black fails.
- Display the address file in barge to help debugging for the "addresses not found" issue.
- Dependency grounding of eth-brownie, a fix for Python 3.11 dependencies and details in the installation readme. This was because pip was downgrading eth-brownie to a very old version just to satisfy its vyper dependency. This meant brownie was actually incompatible with the current code and broke imports. I also created https://github.com/oceanprotocol/ocean.py/issues/1302 as a follow-up to prevent similar issues in the future.