### PR TITLE
Fix invalid timestamps

### DIFF
--- a/READMEs/c2d-flow.md
+++ b/READMEs/c2d-flow.md
@@ -152,7 +152,7 @@ datasets, algorithm = ocean.assets.pay_for_compute_service(
     consume_market_order_fee_address=bob.address,
     tx_dict={"from": bob},
     compute_environment=free_c2d_env["id"],
-    valid_until=int((datetime.utcnow() + timedelta(days=1)).timestamp()),
+    valid_until=int((datetime.now() + timedelta(days=1)).timestamp()),
     consumer_address=free_c2d_env["consumerAddress"],
 )
 assert datasets, "pay for dataset unsuccessful"

--- a/ocean_lib/data_provider/base.py
+++ b/ocean_lib/data_provider/base.py
@@ -4,7 +4,6 @@
 #
 
 """Provider module."""
-import json
 import logging
 import os
 import re
@@ -48,7 +47,7 @@ class DataServiceProviderBase:
     @staticmethod
     @enforce_types
     def sign_message(wallet, msg: str) -> Tuple[str, str]:
-        nonce = str(datetime.utcnow().timestamp())
+        nonce = str(datetime.now().timestamp() * 1000)
         print(f"signing message with nonce {nonce}: {msg}, account={wallet.address}")
         message_hash = Web3.solidityKeccak(
             ["bytes"],

--- a/ocean_lib/data_provider/test/test_data_service_provider.py
+++ b/ocean_lib/data_provider/test/test_data_service_provider.py
@@ -510,7 +510,7 @@ def test_initialize_compute_failure():
 
     http_client = HttpClientEvilMock()
     DataSP.set_http_client(http_client)
-    valid_until = int((datetime.utcnow() + timedelta(days=1)).timestamp())
+    valid_until = int((datetime.now() + timedelta(days=1)).timestamp())
 
     with pytest.raises(
         DataProviderException, match="request failed at the initializeComputeEndpoint"

--- a/tests/flows/test_reuse_order_fees.py
+++ b/tests/flows/test_reuse_order_fees.py
@@ -89,7 +89,7 @@ def test_reuse_order_fees(
 
     # Mock non-zero provider fees (simulate first time paying provider fees)
     provider_fee = int_units(provider_fee_in_unit, bt.decimals())
-    valid_until = int((datetime.utcnow() + timedelta(seconds=10)).timestamp())
+    valid_until = int((datetime.now() + timedelta(seconds=10)).timestamp())
     provider_fees = get_provider_fees(
         provider_wallet,
         bt.address,
@@ -220,7 +220,7 @@ def reuse_order_with_mock_provider_fees(
 
     # Mock provider fees
     provider_fee = int_units(provider_fee_in_unit, bt.decimals())
-    valid_until = int((datetime.utcnow() + timedelta(seconds=10)).timestamp())
+    valid_until = int((datetime.now() + timedelta(seconds=10)).timestamp())
     provider_fees = get_provider_fees(
         provider_wallet,
         bt.address,

--- a/tests/flows/test_start_order_fees.py
+++ b/tests/flows/test_start_order_fees.py
@@ -129,7 +129,7 @@ def test_start_order_fees(
 
     # Get provider fees
     provider_fee = int_units(provider_fee_in_unit, bt.decimals())
-    valid_for_two_hours = int((datetime.utcnow() + timedelta(hours=2)).timestamp())
+    valid_for_two_hours = int((datetime.now() + timedelta(hours=2)).timestamp())
     provider_fees = get_provider_fees(
         provider_wallet,
         bt.address,

--- a/tests/integration/ganache/test_compute_flow.py
+++ b/tests/integration/ganache/test_compute_flow.py
@@ -226,7 +226,7 @@ def run_compute_test(
     time_difference = (
         timedelta(hours=1) if "reuse_order" not in scenarios else timedelta(seconds=30)
     )
-    valid_until = int((datetime.utcnow() + time_difference).timestamp())
+    valid_until = int((datetime.now() + time_difference).timestamp())
 
     if "just_fees" in scenarios:
         fees_response = ocean_instance.retrieve_provider_fees_for_compute(
@@ -327,7 +327,7 @@ def run_compute_test(
         # ensure order expires
         time.sleep(time_difference.seconds + 1)
 
-        valid_until = int((datetime.utcnow() + time_difference).timestamp())
+        valid_until = int((datetime.now() + time_difference).timestamp())
         datasets, algorithm = ocean_instance.assets.pay_for_compute_service(
             datasets,
             algorithm if algorithm else algorithm_meta,

--- a/tests/resources/helper_functions.py
+++ b/tests/resources/helper_functions.py
@@ -9,13 +9,12 @@ import os
 import secrets
 from datetime import datetime
 from decimal import Decimal
-import time
 from typing import Any, Dict, Optional, Tuple, Union
 
 import coloredlogs
 import yaml
 from brownie import network
-from brownie.network import accounts, web3
+from brownie.network import accounts
 from enforce_typing import enforce_types
 from web3 import Web3
 
@@ -259,7 +258,7 @@ def get_provider_fees(
     provider_fee_address = provider_wallet.address
 
     provider_data = json.dumps(
-        {"environment": compute_env, "timestamp": datetime.utcnow().timestamp()},
+        {"environment": compute_env, "timestamp": datetime.now().timestamp()},
         separators=(",", ":"),
     )
     message_hash = Web3.solidityKeccak(


### PR DESCRIPTION
Hi Bret here from @FELT-Labs,

We run into issues with timestamps when being located in different time zones. The issue is that using `datetime.utcnow()` generates UTC time, but it doesn't set `tzinfo` which is the timezone information. But `.timestamp()` function actually takes timezone into consideration, so if `datetime` object doesn't have timezone info set, it will subtract the timezone difference during timestamp generation (you can read the source code here: https://github.com/python/cpython/blob/3.11/Lib/datetime.py#L1905). Easiest solution for that is just to use `datetime.now()` and let timestamp() handle the timezones. We could also use `datetime.now(timezone.utc)` which set's the timezone info to UTC, but that's more wordy.

There is also mistake in nonce generation for compute jobs which should be in milliseconds

Changes proposed in this PR:

- Fix timestamp creating
- Nonce for compute job must be in milliseconds