### PR TITLE
Helps #1358: clarify mac/win instructions wrt barge/local

### DIFF
--- a/READMEs/install.md
+++ b/READMEs/install.md
@@ -60,7 +60,6 @@ Thanks to Brownie, ocean.py treats each Ocean smart contract as a Python class, 
 
 You've now installed Ocean, great!
 
-As a MacOS or Windows user, your next step is to [setup remotely](setup-remote.md).
-
 As a Linux user, your next step is to [setup locally](setup-local.md).
 
+As a MacOS or Windows user, your next step is to [setup remotely](setup-remote.md). Note: this is a temporary workaround because Ocean's Barge tool does not support MacOS nor Windows yet for local setup.

--- a/READMEs/install.md
+++ b/READMEs/install.md
@@ -60,4 +60,7 @@ Thanks to Brownie, ocean.py treats each Ocean smart contract as a Python class, 
 
 You've now installed Ocean, great!
 
-Your next step is to [setup locally](setup-local.md).
+As a MacOS or Windows user, your next step is to [setup remotely](setup-remote.md).
+
+As a Linux user, your next step is to [setup locally](setup-local.md).
+

--- a/READMEs/setup-local.md
+++ b/READMEs/setup-local.md
@@ -52,9 +52,8 @@ cd my_project
 source venv/bin/activate
 ```
 
-Then, set keys in readmes. If you're a Linux or MacOS user, you'll use "`export`"; if Windows, you'll use "`set`". Let's make it explicit. In the same console:
+Then, set keys in readmes. As a Linux user, you'll use "`export`". In the same console:
 
-#### Linux & MacOS users:
 ```console
 # keys for alice and bob in readmes
 export TEST_PRIVATE_KEY1=0x8467415bb2ba7c91084d932276214b11a3dd9bdb2930fefa194b666dd8020b99
@@ -62,16 +61,6 @@ export TEST_PRIVATE_KEY2=0x1d751ded5a32226054cd2e71261039b65afb9ee1c746d055dd699
 
 # key for minting fake OCEAN
 export FACTORY_DEPLOYER_PRIVATE_KEY=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58
-```
-
-#### Windows users:
-```console
-# keys for alice and bob in readmes
-set TEST_PRIVATE_KEY1=0x8467415bb2ba7c91084d932276214b11a3dd9bdb2930fefa194b666dd8020b99
-set TEST_PRIVATE_KEY2=0x1d751ded5a32226054cd2e71261039b65afb9ee1c746d055dd699b1150a5befc
-
-# key for minting fake OCEAN
-set FACTORY_DEPLOYER_PRIVATE_KEY=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58
 ```
 
 ## 4. Setup in Python


### PR DESCRIPTION
Further improves on #1358 "Stopgap: Since barge doesn't currently work on MacOS or Win, say so in local-setup README"

Changes proposed in this PR:

- Removed some Windows/MacOS mentions from Setup-local.md
- Added setup-remote.md link to the bottom of the install.md next steps section