### PR TITLE
More test optimisations

### DIFF
--- a/ocean_lib/data_provider/base.py
+++ b/ocean_lib/data_provider/base.py
@@ -248,12 +248,17 @@ class DataServiceProviderBase:
 
     @staticmethod
     @enforce_types
-    def get(*args, **kwargs) -> Optional[Union[Mock, Response]]:
+    def get(*args, **kwargs) -> dict:
         return DataServiceProviderBase._http_method("get", *args, **kwargs).json()
 
     @staticmethod
     @enforce_types
-    def post(*args, **kwargs) -> Optional[Union[Mock, Response]]:
+    def get_raw(*args, **kwargs) -> Optional[Union[Mock, Response]]:
+        return DataServiceProviderBase._http_method("get", *args, **kwargs)
+
+    @staticmethod
+    @enforce_types
+    def post(*args, **kwargs) -> dict:
         return DataServiceProviderBase._http_method("post", *args, **kwargs).json()
 
     @staticmethod

--- a/ocean_lib/data_provider/base.py
+++ b/ocean_lib/data_provider/base.py
@@ -237,7 +237,7 @@ class DataServiceProviderBase:
     @enforce_types
     def _http_method(method: str, *args, **kwargs) -> Optional[Union[Mock, Response]]:
         try:
-            return getattr(DataServiceProviderBase._http_client, method)(
+            return getattr(DataServiceProviderBase._http_client, method.lower())(
                 *args, **kwargs
             )
         except Exception:

--- a/ocean_lib/data_provider/data_encryptor.py
+++ b/ocean_lib/data_provider/data_encryptor.py
@@ -39,8 +39,7 @@ class DataEncryptor(DataServiceProviderBase):
             "encrypt", provider_uri, {"chainId": chain_id}
         )
 
-        response = DataServiceProviderBase._http_method(
-            "post",
+        response = DataServiceProviderBase.post_raw(
             encrypt_endpoint,
             data=payload,
             headers={"Content-type": "application/octet-stream"},

--- a/ocean_lib/data_provider/data_encryptor.py
+++ b/ocean_lib/data_provider/data_encryptor.py
@@ -35,8 +35,8 @@ class DataEncryptor(DataServiceProviderBase):
         else:
             payload = objects_to_encrypt
 
-        _, encrypt_endpoint = DataServiceProviderBase.build_encrypt_endpoint(
-            provider_uri, chain_id
+        _, encrypt_endpoint = DataServiceProviderBase.build_endpoint(
+            "encrypt", provider_uri, {"chainId": chain_id}
         )
 
         response = DataServiceProviderBase._http_method(

--- a/ocean_lib/data_provider/data_service_provider.py
+++ b/ocean_lib/data_provider/data_service_provider.py
@@ -10,14 +10,12 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-import requests
 from enforce_typing import enforce_types
 from requests.models import PreparedRequest, Response
 
 from ocean_lib.agreements.service_types import ServiceTypes
 from ocean_lib.data_provider.base import DataServiceProviderBase
 from ocean_lib.data_provider.fileinfo_provider import FileInfoProvider
-from ocean_lib.exceptions import DataProviderException
 from ocean_lib.http_requests.requests_session import get_requests_session
 from ocean_lib.models.compute_input import ComputeInput
 from ocean_lib.structures.algorithm_metadata import AlgorithmMetadata
@@ -45,7 +43,7 @@ class DataServiceProvider(DataServiceProviderBase):
         userdata: Optional[Dict] = None,
     ) -> Response:
 
-        _, initialize_endpoint = DataServiceProvider.build_endpoint(
+        method, initialize_endpoint = DataServiceProvider.build_endpoint(
             "initialize", service.service_endpoint
         )
 
@@ -60,20 +58,12 @@ class DataServiceProvider(DataServiceProviderBase):
             payload["userdata"] = userdata
 
         response = DataServiceProvider._http_method(
-            "get", url=initialize_endpoint, params=payload
+            method, url=initialize_endpoint, params=payload
         )
-        if not response or not hasattr(response, "status_code"):
-            raise DataProviderException(
-                f"Failed to get a response for request: initializeEndpoint={initialize_endpoint}, payload={payload}, response is {response}"
-            )
 
-        if response.status_code != 200:
-            msg = (
-                f"Initialize service failed at the initializeEndpoint "
-                f"{initialize_endpoint}, reason {response.text}, status {response.status_code}"
-            )
-            logger.error(msg)
-            raise DataProviderException(msg)
+        DataServiceProviderBase.check_response(
+            response, "initializeEndpoint", initialize_endpoint, payload
+        )
 
         logger.info(
             f"Service initialized successfully"
@@ -98,7 +88,7 @@ class DataServiceProvider(DataServiceProviderBase):
         The first dataset is also required to have a compute service.
         """
         (
-            _,
+            method,
             initialize_compute_endpoint,
         ) = DataServiceProvider.build_endpoint("initializeCompute", service_endpoint)
 
@@ -113,7 +103,7 @@ class DataServiceProvider(DataServiceProviderBase):
         }
 
         response = DataServiceProvider._http_method(
-            "post",
+            method,
             initialize_compute_endpoint,
             data=json.dumps(payload),
             headers={"content-type": "application/json"},
@@ -154,7 +144,7 @@ class DataServiceProvider(DataServiceProviderBase):
             )
             indexes = [index]
 
-        _, download_endpoint = DataServiceProvider.build_endpoint(
+        method, download_endpoint = DataServiceProvider.build_endpoint(
             "download", service_endpoint
         )
 
@@ -175,7 +165,7 @@ class DataServiceProvider(DataServiceProviderBase):
                 consumer_wallet, did
             )
             response = DataServiceProvider._http_method(
-                "get", url=download_endpoint, params=payload, stream=True, timeout=3
+                method, url=download_endpoint, params=payload, stream=True, timeout=3
             )
 
             DataServiceProviderBase.check_response(
@@ -237,8 +227,7 @@ class DataServiceProvider(DataServiceProviderBase):
         _, compute_endpoint = DataServiceProvider.build_endpoint(
             "computeStart", dataset_compute_service.service_endpoint
         )
-        response = DataServiceProvider._http_method(
-            "post",
+        response = DataServiceProvider.post_raw(
             compute_endpoint,
             data=json.dumps(payload),
             headers={"content-type": "application/json"},
@@ -363,7 +352,7 @@ class DataServiceProvider(DataServiceProviderBase):
             "consumerAddress": consumer.address,
         }
 
-        (_, compute_job_result_endpoint,) = DataServiceProvider.build_endpoint(
+        (_, compute_job_result_endpoint) = DataServiceProvider.build_endpoint(
             "computeResult", dataset_compute_service.service_endpoint
         )
         req.prepare_url(compute_job_result_endpoint, params)
@@ -444,8 +433,10 @@ class DataServiceProvider(DataServiceProviderBase):
         )
 
         resp_content = json.loads(response.content.decode("utf-8"))
+
         if isinstance(resp_content, list):
             return resp_content[0]
+
         return resp_content
 
     @staticmethod
@@ -469,18 +460,13 @@ class DataServiceProvider(DataServiceProviderBase):
                 f"for `algorithm_meta`, got {type(algorithm_meta)}"
             )
 
+        input_datasets = input_datasets if input_datasets else []
         _input_datasets = []
-        if input_datasets:
-            for _input in input_datasets:
-                assert _input.did, "The received dataset does not have a did."
-                assert (
-                    _input.transfer_tx_id
-                ), "The received dataset does not have a transaction id."
-                assert (
-                    _input.service_id
-                ), "The received dataset does not have a specified service id."
-                if _input.did != dataset.did:
-                    _input_datasets.append(_input.as_dictionary())
+        for _input in input_datasets:
+            for req_key in ["did", "transfer_tx_id", "service_id"]:
+                assert getattr(
+                    _input, req_key
+                ), f"The received dataset does not have a {req_key}."
 
         nonce, signature = DataServiceProvider.sign_message(
             consumer, f"{consumer.address}{dataset.did}"
@@ -547,13 +533,9 @@ class DataServiceProvider(DataServiceProviderBase):
         if userdata is not None:
             data["userdata"] = userdata
 
-        response = requests.post(endpoint, json=data)
+        response = DataServiceProvider.post_raw(endpoint, json=data)
 
         if not response or response.status_code != 200:
             return False
 
-        response = response.json()
-        for ddo_info in response:
-            return ddo_info["valid"]
-
-        return False
+        return any([file_info["valid"] for file_info in response.json()])

--- a/ocean_lib/data_provider/data_service_provider.py
+++ b/ocean_lib/data_provider/data_service_provider.py
@@ -43,7 +43,7 @@ class DataServiceProvider(DataServiceProviderBase):
         userdata: Optional[Dict] = None,
     ) -> Response:
 
-        method, initialize_endpoint = DataServiceProvider.build_endpoint(
+        _, initialize_endpoint = DataServiceProvider.build_endpoint(
             "initialize", service.service_endpoint
         )
 
@@ -57,9 +57,7 @@ class DataServiceProvider(DataServiceProviderBase):
             userdata = json.dumps(userdata)
             payload["userdata"] = userdata
 
-        response = DataServiceProvider._http_method(
-            method, url=initialize_endpoint, params=payload
-        )
+        response = DataServiceProvider.get_raw(url=initialize_endpoint, params=payload)
 
         DataServiceProviderBase.check_response(
             response, "initializeEndpoint", initialize_endpoint, payload
@@ -88,7 +86,7 @@ class DataServiceProvider(DataServiceProviderBase):
         The first dataset is also required to have a compute service.
         """
         (
-            method,
+            _,
             initialize_compute_endpoint,
         ) = DataServiceProvider.build_endpoint("initializeCompute", service_endpoint)
 
@@ -102,8 +100,7 @@ class DataServiceProvider(DataServiceProviderBase):
             "consumerAddress": consumer_address,
         }
 
-        response = DataServiceProvider._http_method(
-            method,
+        response = DataServiceProvider.post_raw(
             initialize_compute_endpoint,
             data=json.dumps(payload),
             headers={"content-type": "application/json"},
@@ -144,7 +141,7 @@ class DataServiceProvider(DataServiceProviderBase):
             )
             indexes = [index]
 
-        method, download_endpoint = DataServiceProvider.build_endpoint(
+        _, download_endpoint = DataServiceProvider.build_endpoint(
             "download", service_endpoint
         )
 
@@ -164,8 +161,8 @@ class DataServiceProvider(DataServiceProviderBase):
             payload["nonce"], payload["signature"] = DataServiceProvider.sign_message(
                 consumer_wallet, did
             )
-            response = DataServiceProvider._http_method(
-                method, url=download_endpoint, params=payload, stream=True, timeout=3
+            response = DataServiceProvider.get_raw(
+                url=download_endpoint, params=payload, stream=True, timeout=3
             )
 
             DataServiceProviderBase.check_response(

--- a/ocean_lib/data_provider/fileinfo_provider.py
+++ b/ocean_lib/data_provider/fileinfo_provider.py
@@ -35,19 +35,19 @@ class FileInfoProvider(DataServiceProviderBase):
         with_checksum: bool = False,
         userdata: Optional[dict] = None,
     ) -> Response:  # Can not add Service typing due to enforce_type errors.
-        _, fileinfo_endpoint = DataServiceProviderBase.build_fileinfo(
-            service.service_endpoint
+        _, fileinfo_endpoint = DataServiceProviderBase.build_endpoint(
+            "fileinfo", service.service_endpoint
         )
+
         payload = {"did": did, "serviceId": service.id}
+
         if userdata is not None:
             payload["userdata"] = userdata
 
         if with_checksum:
             payload["checksum"] = 1
 
-        response = DataServiceProviderBase._http_method(
-            "post", fileinfo_endpoint, json=payload
-        )
+        response = DataServiceProviderBase.post_raw(fileinfo_endpoint, json=payload)
 
         DataServiceProviderBase.check_response(
             response, "fileInfoEndpoint", fileinfo_endpoint, payload

--- a/ocean_lib/data_provider/test/test_data_service_provider.py
+++ b/ocean_lib/data_provider/test/test_data_service_provider.py
@@ -87,22 +87,16 @@ def test_initialize_fails():
         )
 
     mock_service.service_endpoint = DEFAULT_PROVIDER_URL
-    match_message = DataSP.build_endpoint("initialize", mock_service.service_endpoint)[
-        1
-    ]
     with pytest.raises(
         DataProviderException,
-        match=f"Failed to get a response for request: initializeEndpoint={match_message}",
-    ) as err:
+        match="initializeEndpoint failed",
+    ):
         DataSP.initialize(
             "some_did",
             mock_service,
             "some_consumer_address",
             userdata={"test_dict_key": "test_dict_value"},
         )
-    assert err.value.args[0].startswith(
-        "Failed to get a response for request: initializeEndpoint"
-    )
 
 
 @pytest.mark.unit

--- a/ocean_lib/data_provider/test/test_data_service_provider.py
+++ b/ocean_lib/data_provider/test/test_data_service_provider.py
@@ -87,9 +87,12 @@ def test_initialize_fails():
         )
 
     mock_service.service_endpoint = DEFAULT_PROVIDER_URL
+    match_message = DataSP.build_endpoint("initialize", mock_service.service_endpoint)[
+        1
+    ]
     with pytest.raises(
         DataProviderException,
-        match=f"Failed to get a response for request: initializeEndpoint={DataSP.build_initialize_endpoint(mock_service.service_endpoint)[1]}",
+        match=f"Failed to get a response for request: initializeEndpoint={match_message}",
     ) as err:
         DataSP.initialize(
             "some_did",
@@ -382,34 +385,25 @@ def test_build_specific_endpoints():
 
     provider_uri = DEFAULT_PROVIDER_URL
     base_uri = DataSP.get_root_uri(DEFAULT_PROVIDER_URL)
-    assert DataSP.build_download_endpoint(provider_uri)[1] == urljoin(
-        base_uri, endpoints["download"][1]
-    )
-    assert DataSP.build_initialize_endpoint(provider_uri)[1] == urljoin(
-        base_uri, endpoints["initialize"][1]
-    )
-    assert DataSP.build_initialize_compute_endpoint(provider_uri)[1] == urljoin(
-        base_uri, endpoints["initializeCompute"][1]
-    )
+
     assert (
-        DataSP.build_encrypt_endpoint(provider_uri, 8996)[1]
+        DataSP.build_endpoint("encrypt", provider_uri, {"chainId": 8996})[1]
         == urljoin(base_uri, endpoints["encrypt"][1]) + "?chainId=8996"
     )
-    assert DataSP.build_fileinfo(provider_uri)[1] == urljoin(
-        base_uri, endpoints["fileinfo"][1]
-    )
-    assert DataSP.build_compute_endpoint(provider_uri)[1] == urljoin(
-        base_uri, endpoints["computeStatus"][1]
-    )
-    assert DataSP.build_compute_endpoint(provider_uri)[1] == urljoin(
-        base_uri, endpoints["computeStart"][1]
-    )
-    assert DataSP.build_compute_endpoint(provider_uri)[1] == urljoin(
-        base_uri, endpoints["computeStop"][1]
-    )
-    assert DataSP.build_compute_endpoint(provider_uri)[1] == urljoin(
-        base_uri, endpoints["computeDelete"][1]
-    )
+
+    for key in [
+        "fileinfo",
+        "download",
+        "initialize",
+        "initializeCompute",
+        "computeStatus",
+        "computeStart",
+        "computeStop",
+        "computeDelete",
+    ]:
+        assert DataSP.build_endpoint(key, provider_uri)[1] == urljoin(
+            base_uri, endpoints[key][1]
+        )
 
     DataSP.get_service_endpoints = original_func
 

--- a/ocean_lib/web3_internal/utils.py
+++ b/ocean_lib/web3_internal/utils.py
@@ -4,7 +4,7 @@
 #
 import logging
 from collections import namedtuple
-from typing import Any
+from typing import Any, Union
 
 import requests
 from brownie import network
@@ -32,7 +32,13 @@ def to_32byte_hex(val: int) -> str:
 
 
 @enforce_types
-def sign_with_key(message_hash: HexBytes, key: str) -> str:
+def sign_with_key(message_hash: Union[HexBytes, str], key: str) -> str:
+    if isinstance(message_hash, str):
+        message_hash = Web3.solidityKeccak(
+            ["bytes"],
+            [Web3.toBytes(text=message_hash)],
+        )
+
     pk = keys.PrivateKey(Web3.toBytes(hexstr=key))
     prefix = "\x19Ethereum Signed Message:\n32"
     signable_hash = Web3.solidityKeccak(

--- a/tests/resources/ddo_helpers.py
+++ b/tests/resources/ddo_helpers.py
@@ -122,6 +122,7 @@ def get_registered_asset_with_compute_service(
         "https://raw.githubusercontent.com/oceanprotocol/c2d-examples/main/branin_and_gpr/branin.arff",
         tx_dict={"from": publisher_wallet},
         compute_values=compute_values,
+        wait_for_aqua=False,
     )
 
 


### PR DESCRIPTION
More work on #929. I also did some cleanup of the provider functions.
Initially, I wanted to use the methods from build_service_endpoint (first item of the tuple returned). However, it seems it's not entirely accurate and so I kept the hardcoding. I would suggest removing the method part entirely, but we can discuss that later.

In regards to tests, here are the only tests that now take > 10s:
```
93.92s call     tests/integration/ganache/test_compute_flow.py::TestComputeFlow::test_compute_update_trusted_algorithm
54.45s call     tests/readmes/test_readmes.py::TestReadmes::test_script_execution[test_c2d-flow.py]
35.07s call     tests/integration/ganache/test_compute_flow.py::TestComputeFlow::test_compute_reuse_order
26.85s call     tests/readmes/test_readmes.py::TestReadmes::test_script_execution[test_main-flow.py]
24.74s call     ocean_lib/ocean/test/test_ocean_assets.py::test_create_pricing_schemas
21.90s call     ocean_lib/ocean/test/test_ocean_assets.py::test_update_datatokens
19.99s call     tests/readmes/test_readmes.py::TestReadmes::test_script_execution[test_search-and-filter-assets.py]
17.20s call     tests/readmes/test_readmes.py::TestReadmes::test_script_execution[test_custody-light-flow.py]
15.02s call     ocean_lib/ocean/test/test_ocean_assets.py::test_update
11.00s call     ocean_lib/models/ve/test/test_ve_ocean.py::test_ve_ocean1
10.27s call     tests/integration/ganache/test_graphql.py::test_consume_parametrized_graphql_query
```

Mostly, large tests are large because they handle updates and sequential work that needs to wait for Aquarius. There is no way of restructuring those tests without losing meaning. For readme tests, there is no way I can do async publishing because it would complicate the readmes. 

For compute tests, the improvement is 186.21s to 105.35s.