### PR TITLE
symmetric encryption fixed

### DIFF
--- a/ocean_lib/ocean/crypto.py
+++ b/ocean_lib/ocean/crypto.py
@@ -18,7 +18,7 @@ from eth_utils import decode_hex
 def calc_symkey(base_str: str) -> str:
     """Compute a symmetric private key that's a function of the base_str"""
     base_b = base_str.encode("utf-8")  # bytes
-    hash_b = sha256(base_b)
+    hash_b = sha256(base_b).hexdigest()
     symkey_b = b64encode(str(hash_b).encode("ascii"))[:43] + b"="  # bytes
     symkey = symkey_b.decode("ascii")
     return symkey

--- a/ocean_lib/ocean/crypto.py
+++ b/ocean_lib/ocean/crypto.py
@@ -19,7 +19,7 @@ def calc_symkey(base_str: str) -> str:
     """Compute a symmetric private key that's a function of the base_str"""
     base_b = base_str.encode("utf-8")  # bytes
     hash_b = sha256(base_b).hexdigest()
-    symkey_b = b64encode(str(hash_b).encode("ascii"))[:43] + b"="  # bytes
+    symkey_b = b64encode(hash_b.encode("ascii"))[:43] + b"="  # bytes
     symkey = symkey_b.decode("ascii")
     return symkey
 

--- a/ocean_lib/ocean/test/test_crypto.py
+++ b/ocean_lib/ocean/test/test_crypto.py
@@ -12,7 +12,7 @@ def test_symkey():
     base_str = "foo"
     symkey = crypto.calc_symkey(base_str)
     assert isinstance(symkey, str)
-    wrong_sym_key = calc_symkey("testwrong")
+    wrong_sym_key = crypto.calc_symkey("testwrong")
     assert wrong_sym_key != sym_key, "NOK : wrong_sym_key is the same as sym_key"
 
 

--- a/ocean_lib/ocean/test/test_crypto.py
+++ b/ocean_lib/ocean/test/test_crypto.py
@@ -13,7 +13,7 @@ def test_symkey():
     symkey = crypto.calc_symkey(base_str)
     assert isinstance(symkey, str)
     wrong_symkey = crypto.calc_symkey("testwrong")
-    assert wrong_sym_ey != symkey, "NOK : wrong_sym_key is the same as sym_key"
+    assert wrong_symkey != symkey, "NOK : wrong_sym_key is the same as sym_key"
 
 
 @enforce_types

--- a/ocean_lib/ocean/test/test_crypto.py
+++ b/ocean_lib/ocean/test/test_crypto.py
@@ -12,6 +12,8 @@ def test_symkey():
     base_str = "foo"
     symkey = crypto.calc_symkey(base_str)
     assert isinstance(symkey, str)
+    wrong_sym_key = calc_symkey("testwrong")
+    assert wrong_sym_key != sym_key, "NOK : wrong_sym_key is the same as sym_key"
 
 
 @enforce_types

--- a/ocean_lib/ocean/test/test_crypto.py
+++ b/ocean_lib/ocean/test/test_crypto.py
@@ -12,8 +12,8 @@ def test_symkey():
     base_str = "foo"
     symkey = crypto.calc_symkey(base_str)
     assert isinstance(symkey, str)
-    wrong_sym_key = crypto.calc_symkey("testwrong")
-    assert wrong_sym_key != sym_key, "NOK : wrong_sym_key is the same as sym_key"
+    wrong_symkey = crypto.calc_symkey("testwrong")
+    assert wrong_sym_ey != symkey, "NOK : wrong_sym_key is the same as sym_key"
 
 
 @enforce_types


### PR DESCRIPTION
security issue

Fixes # .

Changes proposed in this PR:
I was trying to test some function in the repo :
https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/crypto.py

I wanted to test symmetric encryption and test the result with wrong key...
And all keys works !

if you look at the code of calc_symkey at line 21 and 22 : 
`hash_b = sha256(base_b)`
`symkey_b = b64encode(str(hash_b).encode("ascii"))[:43] + b"="  # bytes`

Actually the result of  "str(hash_b)" is not a hash but the string representation of the hash object.
e.g. : `<sha256 _hashlib.HASH object @ 0x11d3aaa30>`

To have a hash, you need to just replace line 21 by : 
`hash_b = sha256(base_b).hexdigest()`

e.g. : `eadd5118ccd09b09649ff613c3cb457c10f686187d7c26103dadb64772f8b03b`

With the current code, I think that all symmetric key with `calc_symkey` give the same encryption !

I have tried, and I can decrypt with any symmetric key issued with `calc_symkey` something encrypted.
